### PR TITLE
fix: replace katamyra with your-github-username

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Before you begin, ensure that your system meets the following requirements:
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/katamyra/kubestellarUI.git
+git clone https://github.com/your-github-username/ui.git
 
-cd kubestellarUI
+cd ui
 ```
 
 ### 2. Create `.env` File for Frontend Configuration


### PR DESCRIPTION
It's better to keep it like that because I simply copied the command from the README.md file. Then, when I was about to raise a new PR, I found that I had the wrong remote origin, and later discovered this note in the README.md file: