### PR TITLE
Fixed ITS UI Bug

### DIFF
--- a/src/pages/ITS.tsx
+++ b/src/pages/ITS.tsx
@@ -60,7 +60,7 @@ const ITS = () => {
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <h3 className="font-semibold mb-2">Labels</h3>
-                  {Object.keys(cluster.labels).length > 0 ? (
+                  {cluster.labels && Object.keys(cluster.labels).length > 0 ? (
                     <div className="flex flex-wrap gap-2">
                       {Object.entries(cluster.labels).map(([key, value]) => (
                         <span


### PR DESCRIPTION
We kept getting a previous error that there was nothing to verify the `Object.keys(cluster.label)` . And without it cluster.labels is undefined or null.

Changed line 63 in ITS.tsx to add in `clusters.labels &&` .

You can view the ITS UI page now, but there's no labels displayed. Plus the backend CLI has ongoing GETs. That's the next thing to work on.