### PR TITLE
fix: added logic to check for undefined length in Cluster.txt

### DIFF
--- a/src/components/Clusters.tsx
+++ b/src/components/Clusters.tsx
@@ -35,18 +35,18 @@ const K8sInfo = () => {
     <div className="w-full max-w-full p-4">
       <div className="grid grid-cols-3">
       <div>
-        <h2 className="text-2xl font-bold mb-6">Kubernetes Clusters ({clusters.length})</h2>
+        <h2 className="text-2xl font-bold mb-6">Kubernetes Clusters ({clusters?.length})</h2>
         <ul>
-          {clusters.map(cluster => (
+          {clusters && clusters.map(cluster => (
             <li key={cluster}>{cluster}</li>
           ))}
         </ul>
       </div>
 
       <div>
-        <h2 className="text-2xl font-bold mb-6">Kubernetes Contexts ({contexts.length})</h2>
+        <h2 className="text-2xl font-bold mb-6">Kubernetes Contexts ({contexts?.length})</h2>
         <ul>
-          {contexts.map(ctx => (
+          {contexts && contexts.map(ctx => (
             <li key={ctx.name}>
               {ctx.name} {ctx.name === currentContext && '(Current)'} 
               <span style={{color: '#666'}}> → cluster: {ctx.cluster}</span>


### PR DESCRIPTION
In React, it's a good practice to explicitly check for **null** or **undefined** before trying to access properties like length or calling .map() on arrays.

fixes #12


<img width="1582" alt="Screenshot 2025-01-20 at 11 40 35 PM" src="https://github.com/user-attachments/assets/149ae33b-3933-4173-a510-8c9e61fbacb4" />
