### PR TITLE
Optimize Dockerfile and add .dockerignore files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+# Ignore node_modules and build files
+node_modules/
+dist/
+coverage/
+
+# Ignore package manager lock files (if you are using npm, remove yarn.lock and vice versa)
+yarn.lock
+pnpm-lock.yaml
+
+# Ignore Git files
+.git
+.gitignore
+
+# Ignore environment files (avoid exposing secrets)
+.env
+.env.local
+.env.production
+.env.development
+
+# Ignore logs and temp files
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.vscode/
+.idea/
+
+# Ignore Docker-related files
+.dockerignore
+Dockerfile
+
+# Ignore temporary files
+tmp/
+*.tmp
+*.bak

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,35 @@
+# Ignore Go build artifacts
+/bin/
+*.exe
+*.out
+*.o
+*.a
+
+# Ignore Go modules cache
+/pkg/
+vendor/
+
+# Ignore dependency files (if using Go modules, only go.mod & go.sum are needed)
+**/node_modules
+**/dist
+**/coverage
+
+# Ignore Git files
+.git
+.gitignore
+
+# Ignore Docker-related files
+.dockerignore
+Dockerfile
+
+# Ignore IDE and editor settings
+*.swp
+*.swo
+*.idea/
+.vscode/
+*.log
+
+# Ignore temporary files
+tmp/
+*.tmp
+*.bak

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.22.3 AS builder
 # Set the working directory inside the container
 WORKDIR /app
 
-# Copy go.mod and go.sum files to the working directory
+# Copy go.mod and go.sum first to leverage Docker layer caching
 COPY go.mod go.sum ./
 
 # Download dependencies
@@ -13,8 +13,8 @@ RUN go mod download
 # Copy the rest of the source code
 COPY . ./
 
-# Build the Go application with static linking
-RUN CGO_ENABLED=0 GOOS=linux go build -o backend-app main.go
+# Build the Go application with optimizations for small binary size
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o backend-app main.go
 
 # Stage 2: Create a minimal image to run the application
 FROM alpine:3.18

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,17 +11,21 @@ services:
     networks:
       - kubestellar-network
 
+
   backend:
     build:
-      context: ./backend
+      context: ./backend 
       dockerfile: Dockerfile
     container_name: kubestellar-backend
+    restart: unless-stopped
     ports:
       - "4000:4000"
     volumes:
       - $HOME/.kube:/root/.kube:ro
     networks:
       - kubestellar-network
+    environment:
+      - GO_ENV=production 
 
 networks:
   kubestellar-network:


### PR DESCRIPTION
Reduce binary size of the Go application by optimizing the Dockerfile and include .dockerignore files to prevent unnecessary files from being included in the Docker context.

![Screenshot from 2025-01-31 01-10-10](https://github.com/user-attachments/assets/0a2f3224-2724-4c78-86d5-d9327d00844b)
@clubanderson review my PR
