### PR TITLE
chore(ci): update branch filter to allow all branches for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: Build, Check Formatting, and Run Tests
 on:
   push:
-    branches: [main]
+    branches: ["*"]
   pull_request:
-    branches: [main]
+    branches: ["*"] 
 
 jobs:
 


### PR DESCRIPTION
Modify the CI workflow to trigger on all branches instead of just the main branch.