### PR TITLE
Fix logo image styling for better responsiveness in Header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -57,12 +57,12 @@ const Header = () => {
                 className="flex items-center gap-1 xl:gap-2 mt-1 mb-5"
               >
                 <span className="text-[16px] leading-[1.2] sm:text-lg xl:text-xl 2xl:text-2xl font-semibold text-base-content dark:text-neutral-200">
-                  <img
-                    src="/KubeSteller.png"
-                    alt="logo"
-                    className="w-44 h-10"
-                  />
-                </span>
+                <img
+                  src="/KubeSteller.png"
+                  alt="logo"
+                  className="w-44 h-auto object-contain"
+                />
+              </span>
               </Link>
               {menu.map((item, index) => (
                 <MenuItem
@@ -77,9 +77,13 @@ const Header = () => {
         </div>
 
         <Link to={"/"} className="flex items-center gap-1 xl:gap-2">
-          <span className="text-[16px] leading-[1.2] sm:text-lg xl:text-xl 2xl:text-2xl font-semibold text-base-content dark:text-neutral-200">
-            <img src="/KubeSteller.png" alt="logo" className="w-44 h-10" />
-          </span>
+        <span className="text-[16px] leading-[1.2] sm:text-lg xl:text-xl 2xl:text-2xl font-semibold text-base-content dark:text-neutral-200">
+          <img 
+            src="/KubeSteller.png" 
+            alt="logo" 
+            className="w-44 h-auto object-contain"
+          />
+        </span>
         </Link>
       </div>
 


### PR DESCRIPTION
Adjust the logo image styling to ensure better responsiveness by changing the height to auto and using the object-contain property.

Fixes #70