### PR TITLE
Disable menu items when no cluster is selected & add visual feedback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,16 @@
 import React from "react";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import { routesConfig } from "./routes/routes-config";
+import { ClusterProvider } from "./context/ClusterContext";
 
 const router = createBrowserRouter(routesConfig);
 
 const App: React.FC = () => {
-  return <RouterProvider router={router} />;
+  return (
+    <ClusterProvider>
+      <RouterProvider router={router} />
+    </ClusterProvider>
+  );
 };
 
 export default App;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,7 @@ import { RxEnterFullScreen, RxExitFullScreen } from "react-icons/rx";
 import ChangeThemes from "./ChangeThemes";
 import { menu } from "./menu/data";
 import MenuItem from "./menu/MenuItem";
+import { useCluster } from "../context/ClusterContext";
 
 interface Context {
   name: string;
@@ -16,6 +17,7 @@ const Header = () => {
   const element = document.getElementById("root");
   const [contexts, setContexts] = React.useState<Context[]>([]);
   const [currentContext, setCurrentContext] = React.useState("");
+  const { setSelectedCluster, setHasAvailableClusters } = useCluster();
 
   const [isDrawerOpen, setDrawerOpen] = React.useState(false);
   const toggleDrawer = () => setDrawerOpen(!isDrawerOpen);
@@ -31,10 +33,16 @@ const Header = () => {
           ctx.name.endsWith("-kubeflex")
         );
         setContexts(kubeflexContexts);
+        setHasAvailableClusters(kubeflexContexts.length > 0);
         setCurrentContext(data.currentContext);
+        setSelectedCluster(data.currentContext || null);
       })
-      .catch((error) => console.error("Error fetching contexts:", error));
-  }, []);
+      .catch((error) => {
+        console.error("Error fetching contexts:", error);
+        setHasAvailableClusters(false);
+        setSelectedCluster(null);
+      });
+  }, [setSelectedCluster, setHasAvailableClusters]);
 
   React.useEffect(() => {
     if (isFullScreen) {
@@ -43,6 +51,12 @@ const Header = () => {
       element?.requestFullscreen({ navigationUI: "auto" });
     }
   }, [element, isFullScreen]);
+
+  const handleClusterChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newCluster = e.target.value;
+    setCurrentContext(newCluster);
+    setSelectedCluster(newCluster);
+  };
 
   return (
     <div className="fixed z-[3] top-0 left-0 right-0 bg-base-100 w-full flex justify-between px-3 xl:px-4 py-3 xl:py-5 gap-4 xl:gap-0">
@@ -75,12 +89,12 @@ const Header = () => {
                 className="flex items-center gap-1 xl:gap-2 mt-1 mb-5"
               >
                 <span className="text-[16px] leading-[1.2] sm:text-lg xl:text-xl 2xl:text-2xl font-semibold text-base-content dark:text-neutral-200">
-                <img
-                  src="/KubeSteller.png"
-                  alt="logo"
-                  className="w-44 h-auto object-contain"
-                />
-              </span>
+                  <img
+                    src="/KubeSteller.png"
+                    alt="logo"
+                    className="w-44 h-auto object-contain"
+                  />
+                </span>
               </Link>
               {menu.map((item, index) => (
                 <MenuItem
@@ -95,21 +109,21 @@ const Header = () => {
         </div>
 
         <Link to={"/"} className="flex items-center gap-1 xl:gap-2">
-        <span className="text-[16px] leading-[1.2] sm:text-lg xl:text-xl 2xl:text-2xl font-semibold text-base-content dark:text-neutral-200">
-          <img 
-            src="/KubeSteller.png" 
-            alt="logo" 
-            className="w-44 h-auto object-contain"
-          />
-        </span>
+          <span className="text-[16px] leading-[1.2] sm:text-lg xl:text-xl 2xl:text-2xl font-semibold text-base-content dark:text-neutral-200">
+            <img
+              src="/KubeSteller.png"
+              alt="logo"
+              className="w-44 h-auto object-contain"
+            />
+          </span>
         </Link>
       </div>
 
       <div className="flex items-center gap-0 xl:gap-1 2xl:gap-2 3xl:gap-5">
-          <select
+        <select
           className="select select-bordered w-[200px] mr-4"
           value={currentContext}
-          onChange={(e) => setCurrentContext(e.target.value)}
+          onChange={handleClusterChange}
         >
           <option value="" disabled>
             Select cluster

--- a/src/components/menu/MenuItem.tsx
+++ b/src/components/menu/MenuItem.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
 import { IconType } from 'react-icons';
+import { useCluster } from '../../context/ClusterContext';
+
 
 interface MenuItemProps {
   onClick?: () => void;
@@ -19,26 +21,50 @@ const MenuItem: React.FC<MenuItemProps> = ({
   catalog,
   listItems,
 }) => {
+  const {selectedCluster, hasAvailableClusters} = useCluster();
+  const isDisabled = !hasAvailableClusters || !selectedCluster;
+  // Determine if menu item should be disabled
+   const shouldDisableItem = (label: string) => {
+    // Don't disable these menu items
+    const alwaysEnabledItems = ["Home", "User", "Onboard"];
+    if (alwaysEnabledItems.includes(label)) return false;
+    return isDisabled;
+  };
   return (
     <div className="w-full flex flex-col items-stretch gap-2">
       <span className="hidden xl:block px-2 xl:text-sm 2xl:text-base 3xl:text-lg uppercase">
         {catalog}
       </span>
       {listItems.map((listItem, index) => {
+        const isItemDisabled = shouldDisableItem(listItem.label);
+
         if (listItem.isLink) {
           return (
             <NavLink
               key={index}
-              onClick={onClick}
-              to={listItem.url || ''}
+              onClick={isItemDisabled ? (e) => e.preventDefault() : onClick}
+              to={listItem.url || ""}
               className={({ isActive }) =>
-                isActive
-                  ? 'btn 2xl:min-h-[52px] 3xl:min-h-[64px] btn-active btn-ghost btn-block justify-start'
-                  : 'btn 2xl:min-h-[52px] 3xl:min-h-[64px] btn-ghost btn-block justify-start'
+                `btn 2xl:min-h-[52px] 3xl:min-h-[64px] ${
+                  isActive ? "btn-active " : ""
+                }btn-ghost btn-block justify-start ${
+                  isItemDisabled
+                    ? "opacity-50 cursor-not-allowed pointer-events-none"
+                    : ""
+                }`
               }
+             
             >
-              <listItem.icon className="xl:text-2xl 2xl:text-3xl 3xl:text-4xl" />
-              <span className="xl:text-sm 2xl:text-base 3xl:text-lg capitalize">
+              <listItem.icon
+                className={`xl:text-2xl 2xl:text-3xl 3xl:text-4xl ${
+                  isItemDisabled ? "text-gray-400" : ""
+                }`}
+              />
+              <span
+                className={`xl:text-sm 2xl:text-base 3xl:text-lg capitalize ${
+                  isItemDisabled ? "text-gray-400" : ""
+                }`}
+              >
                 {listItem.label}
               </span>
             </NavLink>

--- a/src/context/ClusterContext.tsx
+++ b/src/context/ClusterContext.tsx
@@ -1,0 +1,36 @@
+import { createContext, useContext, useState, ReactNode } from "react";
+
+interface ClusterContextType {
+  selectedCluster: string | null;
+  setSelectedCluster: (cluster: string | null) => void;
+  hasAvailableClusters: boolean;
+  setHasAvailableClusters: (hasAvailable: boolean) => void;
+}
+
+const ClusterContext = createContext<ClusterContextType | undefined>(undefined);
+
+export function ClusterProvider({ children }: { children: ReactNode }) {
+  const [selectedCluster, setSelectedCluster] = useState<string | null>(null);
+  const [hasAvailableClusters, setHasAvailableClusters] = useState(false);
+
+  return (
+    <ClusterContext.Provider
+      value={{
+        selectedCluster,
+        setSelectedCluster,
+        hasAvailableClusters,
+        setHasAvailableClusters,
+      }}
+    >
+      {children}
+    </ClusterContext.Provider>
+  );
+}
+
+export function useCluster() {
+  const context = useContext(ClusterContext);
+  if (context === undefined) {
+    throw new Error("useCluster must be used within a ClusterProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
### Description
This PR introduces a global cluster selection state and updates the application to disable menu items when no cluster is selected. This ensures a better user experience by preventing navigation to other menu Items.

### Related Issue
Fixes #96 

### Changes Made
- Created a Cluster Context: Manages cluster selection state across the app.
- Updated the Header Component:
- Disables menu items when no cluster is selected. Keeps "Home," "User," and "Onboard" always enabled.
- Disabled menu items are grayed out with reduced opacity.
- Included the ClusterProvider to manage global state.

### Checklist
Please ensure the following before submitting your PR:
- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

