### PR TITLE
Fixed the logo overflow on Not Found Page(404( Page

### DIFF
--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -276,7 +276,7 @@ const NotFoundPage: React.FC = () => {
             <img 
               src="KubeSteller.png" 
               alt="KubeStellar Logo" 
-              className="h-16 md:h-24 relative z-10 transition-transform hover:scale-105 duration-300"
+              className="h-16 md:h-24 relative  transition-transform hover:scale-105 duration-300"
             />
           </div>
         </div>

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -276,7 +276,7 @@ const NotFoundPage: React.FC = () => {
             <img 
               src="KubeSteller.png" 
               alt="KubeStellar Logo" 
-              className="h-16 md:h-24 relative  transition-transform hover:scale-105 duration-300"
+              className="h-16 md:h-24 relative z-1 transition-transform hover:scale-105 duration-300"
             />
           </div>
         </div>


### PR DESCRIPTION
### Description
The logo on the 404 page was overflowing the content due to an incorrect z-index value, causing it to extend beyond its intended boundary and overlap with other elements.

### Related Issue
Fixes #106 

### Changes Made
<!-- Provide a detailed list of changes made in this PR. -->
- Updated the tailwind class for the logo component to set a corrected z-index value.

### Checklist
Please ensure the following before submitting your PR:
- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

