### PR TITLE
Fix cluster selection logic in Header component and update MenuItem b…

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -153,15 +153,17 @@ func getKubeInfo() ([]ContextInfo, []string, string, error, []ManagedClusterInfo
 	}
 
 	var contexts []ContextInfo
-	clusterSet := make(map[string]bool) // Use map to track unique clusters
+	clusterSet := make(map[string]bool)
 
-	// Get contexts and their associated clusters
+	// Filter contexts to only include kubeflex contexts
 	for contextName, context := range config.Contexts {
-		contexts = append(contexts, ContextInfo{
-			Name:    contextName,
-			Cluster: context.Cluster,
-		})
-		clusterSet[context.Cluster] = true
+		if strings.HasSuffix(contextName, "-kubeflex") {
+			contexts = append(contexts, ContextInfo{
+				Name:    contextName,
+				Cluster: context.Cluster,
+			})
+			clusterSet[context.Cluster] = true
+		}
 	}
 
 	// Convert unique clusters to slice

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -34,8 +34,17 @@ const Header = () => {
         );
         setContexts(kubeflexContexts);
         setHasAvailableClusters(kubeflexContexts.length > 0);
-        setCurrentContext(data.currentContext);
-        setSelectedCluster(data.currentContext || null);
+
+        const currentKubeflexContext = data.currentContext?.endsWith(
+          "-kubeflex"
+        )
+          ? data.currentContext
+          : kubeflexContexts.length > 0
+          ? kubeflexContexts[0].name
+          : "";
+
+        setCurrentContext(currentKubeflexContext);
+        setSelectedCluster(currentKubeflexContext);
       })
       .catch((error) => {
         console.error("Error fetching contexts:", error);
@@ -55,7 +64,7 @@ const Header = () => {
   const handleClusterChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newCluster = e.target.value;
     setCurrentContext(newCluster);
-    setSelectedCluster(newCluster);
+    setSelectedCluster(newCluster || null);
   };
 
   return (

--- a/src/components/menu/MenuItem.tsx
+++ b/src/components/menu/MenuItem.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { NavLink } from 'react-router-dom';
-import { IconType } from 'react-icons';
-import { useCluster } from '../../context/ClusterContext';
-
+import React from "react";
+import { NavLink } from "react-router-dom";
+import { IconType } from "react-icons";
+import { useCluster } from "../../context/ClusterContext";
 
 interface MenuItemProps {
   onClick?: () => void;
@@ -16,20 +15,15 @@ interface MenuItemProps {
   }>;
 }
 
-const MenuItem: React.FC<MenuItemProps> = ({
-  onClick,
-  catalog,
-  listItems,
-}) => {
-  const {selectedCluster, hasAvailableClusters} = useCluster();
+const MenuItem: React.FC<MenuItemProps> = ({ onClick, catalog, listItems }) => {
+  const { selectedCluster, hasAvailableClusters } = useCluster();
   const isDisabled = !hasAvailableClusters || !selectedCluster;
-  // Determine if menu item should be disabled
-   const shouldDisableItem = (label: string) => {
-    // Don't disable these menu items
+
+  const shouldDisableItem = (label: string) => {
     const alwaysEnabledItems = ["Home", "User", "Onboard"];
-    if (alwaysEnabledItems.includes(label)) return false;
-    return isDisabled;
+    return !alwaysEnabledItems.includes(label) && isDisabled;
   };
+
   return (
     <div className="w-full flex flex-col items-stretch gap-2">
       <span className="hidden xl:block px-2 xl:text-sm 2xl:text-base 3xl:text-lg uppercase">
@@ -53,7 +47,6 @@ const MenuItem: React.FC<MenuItemProps> = ({
                     : ""
                 }`
               }
-             
             >
               <listItem.icon
                 className={`xl:text-2xl 2xl:text-3xl 3xl:text-4xl ${


### PR DESCRIPTION
…
### Description
This pull request addresses the issue of cluster selection in the header dropdown of the application. The changes ensure that only valid kubeflex contexts are displayed and selected correctly. Additionally, the menu items are now properly disabled based on the availability of clusters.


### Related Issue
Fixes #116 

### Changes Made

- Filter kubeflex contexts in the backend to ensure only relevant clusters are returned.
- Update Header component to set the current context based on available kubeflex contexts.
- Ensure the selected cluster is set to null when no cluster is selected.
- Modify MenuItem component to disable items correctly based on cluster availability.

### Checklist
Please ensure the following before submitting your PR:
- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

