### PR TITLE
Fix#116 cluster selection

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -155,7 +155,64 @@ func getKubeInfo() ([]ContextInfo, []string, string, error, []ManagedClusterInfo
 	var contexts []ContextInfo
 	clusterSet := make(map[string]bool)
 
-	// Filter contexts to only include kubeflex contexts
+	// First, get the its1 context to fetch managed clusters
+	var its1Context string
+	for contextName := range config.Contexts {
+		if strings.Contains(contextName, "its1") {
+			its1Context = contextName
+			break
+		}
+	}
+
+	// Get managed clusters from its1
+	var managedClusters []ManagedClusterInfo
+	if its1Context != "" {
+		// Use its1Context to get the managed clusters
+		config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			return nil, nil, "", err, nil
+		}
+
+		clientset, err := kubernetes.NewForConfig(config)
+		if err != nil {
+			return nil, nil, "", err, nil
+		}
+
+		// Get managed clusters from its1
+		clustersBytes, err := clientset.RESTClient().Get().
+			AbsPath("/apis/cluster.open-cluster-management.io/v1").
+			Resource("managedclusters").
+			DoRaw(context.TODO())
+		if err != nil {
+			fmt.Printf("Error getting managed clusters: %v\n", err)
+			// Continue with empty managed clusters list
+		} else {
+			var clusterList struct {
+				Items []struct {
+					Metadata struct {
+						Name              string            `json:"name"`
+						Labels            map[string]string `json:"labels"`
+						CreationTimestamp string            `json:"creationTimestamp"`
+					} `json:"metadata"`
+				} `json:"items"`
+			}
+
+			if err := json.Unmarshal(clustersBytes, &clusterList); err != nil {
+				fmt.Printf("Error unmarshaling clusters: %v\n", err)
+			} else {
+				for _, item := range clusterList.Items {
+					creationTime, _ := time.Parse(time.RFC3339, item.Metadata.CreationTimestamp)
+					managedClusters = append(managedClusters, ManagedClusterInfo{
+						Name:         item.Metadata.Name,
+						Labels:       item.Metadata.Labels,
+						CreationTime: creationTime,
+					})
+				}
+			}
+		}
+	}
+
+	// Now get the kubeflex contexts
 	for contextName, context := range config.Contexts {
 		if strings.HasSuffix(contextName, "-kubeflex") {
 			contexts = append(contexts, ContextInfo{
@@ -172,13 +229,7 @@ func getKubeInfo() ([]ContextInfo, []string, string, error, []ManagedClusterInfo
 		clusters = append(clusters, clusterName)
 	}
 
-	itsData, err := getITSInfo()
-	if err != nil {
-		fmt.Printf("ITS error: %v\n", err) // Debug print
-		// Don't return error, continue with other data
-	}
-
-	return contexts, clusters, config.CurrentContext, nil, itsData
+	return contexts, clusters, config.CurrentContext, nil, managedClusters
 }
 
 func getITSInfo() ([]ManagedClusterInfo, error) {

--- a/backend/main.go
+++ b/backend/main.go
@@ -153,15 +153,17 @@ func getKubeInfo() ([]ContextInfo, []string, string, error, []ManagedClusterInfo
 	}
 
 	var contexts []ContextInfo
-	clusterSet := make(map[string]bool) // Use map to track unique clusters
+	clusterSet := make(map[string]bool)
 
-	// Get contexts and their associated clusters
+	// Filter contexts to only include kubeflex contexts
 	for contextName, context := range config.Contexts {
-		contexts = append(contexts, ContextInfo{
-			Name:    contextName,
-			Cluster: context.Cluster,
-		})
-		clusterSet[context.Cluster] = true
+		if strings.HasSuffix(contextName, "-kubeflex") {
+			contexts = append(contexts, ContextInfo{
+				Name:    contextName,
+				Cluster: context.Cluster,
+			})
+			clusterSet[context.Cluster] = true
+		}
 	}
 
 	// Convert unique clusters to slice

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -34,8 +34,17 @@ const Header = () => {
         );
         setContexts(kubeflexContexts);
         setHasAvailableClusters(kubeflexContexts.length > 0);
-        setCurrentContext(data.currentContext);
-        setSelectedCluster(data.currentContext || null);
+
+        const currentKubeflexContext = data.currentContext?.endsWith(
+          "-kubeflex"
+        )
+          ? data.currentContext
+          : kubeflexContexts.length > 0
+          ? kubeflexContexts[0].name
+          : "";
+
+        setCurrentContext(currentKubeflexContext);
+        setSelectedCluster(currentKubeflexContext);
       })
       .catch((error) => {
         console.error("Error fetching contexts:", error);
@@ -55,7 +64,7 @@ const Header = () => {
   const handleClusterChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newCluster = e.target.value;
     setCurrentContext(newCluster);
-    setSelectedCluster(newCluster);
+    setSelectedCluster(newCluster || null);
   };
 
   return (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,6 +6,7 @@ import ChangeThemes from "./ChangeThemes";
 import { menu } from "./menu/data";
 import MenuItem from "./menu/MenuItem";
 import { useCluster } from "../context/ClusterContext";
+import { api } from "../lib/api";
 
 interface Context {
   name: string;
@@ -25,24 +26,30 @@ const Header = () => {
   const toggleFullScreen = () => {
     setIsFullScreen((prev) => !prev);
   };
+
   React.useEffect(() => {
-    fetch("http://localhost:4000/api/clusters")
-      .then((response) => response.json())
-      .then((data) => {
-        const kubeflexContexts = data.contexts.filter((ctx: Context) =>
-          ctx.name.endsWith("-kubeflex")
+    api
+      .get("/api/clusters")
+      .then((response) => {
+        const data = response.data;
+        const kubeflexContexts = data.contexts.filter(
+          (ctx: Context) =>
+            ctx.name.endsWith("-kubeflex") || ctx.cluster.endsWith("-kubeflex")
         );
+
+        console.log("Kubeflex contexts:", kubeflexContexts);
+
         setContexts(kubeflexContexts);
         setHasAvailableClusters(kubeflexContexts.length > 0);
 
-        const currentKubeflexContext = data.currentContext?.endsWith(
-          "-kubeflex"
-        )
-          ? data.currentContext
-          : kubeflexContexts.length > 0
-          ? kubeflexContexts[0].name
-          : "";
+        let currentKubeflexContext = "";
+        if (data.currentContext?.endsWith("-kubeflex")) {
+          currentKubeflexContext = data.currentContext;
+        } else if (kubeflexContexts.length > 0) {
+          currentKubeflexContext = kubeflexContexts[0].name;
+        }
 
+        console.log("Selected context:", currentKubeflexContext);
         setCurrentContext(currentKubeflexContext);
         setSelectedCluster(currentKubeflexContext);
       })

--- a/src/components/menu/MenuItem.tsx
+++ b/src/components/menu/MenuItem.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { NavLink } from 'react-router-dom';
-import { IconType } from 'react-icons';
-import { useCluster } from '../../context/ClusterContext';
-
+import React from "react";
+import { NavLink } from "react-router-dom";
+import { IconType } from "react-icons";
+import { useCluster } from "../../context/ClusterContext";
 
 interface MenuItemProps {
   onClick?: () => void;
@@ -16,20 +15,15 @@ interface MenuItemProps {
   }>;
 }
 
-const MenuItem: React.FC<MenuItemProps> = ({
-  onClick,
-  catalog,
-  listItems,
-}) => {
-  const {selectedCluster, hasAvailableClusters} = useCluster();
+const MenuItem: React.FC<MenuItemProps> = ({ onClick, catalog, listItems }) => {
+  const { selectedCluster, hasAvailableClusters } = useCluster();
   const isDisabled = !hasAvailableClusters || !selectedCluster;
-  // Determine if menu item should be disabled
-   const shouldDisableItem = (label: string) => {
-    // Don't disable these menu items
+
+  const shouldDisableItem = (label: string) => {
     const alwaysEnabledItems = ["Home", "User", "Onboard"];
-    if (alwaysEnabledItems.includes(label)) return false;
-    return isDisabled;
+    return !alwaysEnabledItems.includes(label) && isDisabled;
   };
+
   return (
     <div className="w-full flex flex-col items-stretch gap-2">
       <span className="hidden xl:block px-2 xl:text-sm 2xl:text-base 3xl:text-lg uppercase">
@@ -53,7 +47,6 @@ const MenuItem: React.FC<MenuItemProps> = ({
                     : ""
                 }`
               }
-             
             >
               <listItem.icon
                 className={`xl:text-2xl 2xl:text-3xl 3xl:text-4xl ${


### PR DESCRIPTION
### Description
This pull request addresses the issue of cluster selection in the header dropdown of the application. The changes ensure that only valid kubeflex contexts are displayed and selected correctly. Additionally, the menu items are now properly disabled based on the availability of clusters.

### Related Issue

Fixes #116 

### Changes Made
- Use the its1 context to fetch the managed clusters list
- Return both the kubeflex contexts and the managed clusters from its1


### Checklist
Please ensure the following before submitting your PR:
- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.


