### PR TITLE
[FEATURE] Add build number in the bottom right of the UI - gray text …

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const GITHUB_REPO_URL = 'https://github.com/kubestellar/ui';
+
+interface FooterProps {
+  commitHash: string;
+}
+
+const Footer: React.FC<FooterProps> = ({ commitHash }) => {
+  return (
+    <div 
+      className="fixed bottom-2.5 right-2.5 z-50"
+    >
+      <a 
+        href={`${GITHUB_REPO_URL}/commit/${commitHash}`} 
+        target="_blank" 
+        rel="noopener noreferrer"
+        className="text-gray-400"
+      >
+        Commit: {commitHash}
+      </a>
+    </div>
+  );
+};
+
+export default Footer;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,11 +1,11 @@
 import {
   Outlet,
+  ScrollRestoration, 
 } from "react-router-dom";
 import Header from "./Header";
 import Menu from "./menu/Menu";
 
 const GITHUB_REPO_URL = 'https://github.com/kubestellar/ui';
-
 
 export function Layout() {
   // Log the commit hash to console for debugging
@@ -15,6 +15,7 @@ export function Layout() {
 
   return (
     <div className="w-full min-h-screen flex flex-col justify-between relative">
+      <ScrollRestoration /> 
       <div>
         <Header />
         <div className="w-full flex gap-0 pt-20 xl:pt-[96px] 2xl:pt-[112px] mb-auto">
@@ -29,31 +30,30 @@ export function Layout() {
       
       {/* Commit Hash Footer */}
       <div 
+        style={{
+          position: 'fixed',
+          bottom: '10px', 
+          right: '10px', 
+          color: 'grey',      
+          fontSize: '20px',    
+          opacity: 0.8,        
+          zIndex: 9999,
+          fontWeight: 300,     
+          letterSpacing: '0.5px' 
+        }}
+      >
+        <a 
+          href={`${GITHUB_REPO_URL}/commit/${commitHash}`} 
+          target="_blank" 
+          rel="noopener noreferrer"
           style={{
-            position: 'fixed',
-            bottom: '10px', 
-            right: '10px', 
-            color: 'grey',      
-            fontSize: '18px',    
-            opacity: 0.8,        
-            zIndex: 9999,
-            fontWeight: 300,     
-            letterSpacing: '0.5px' 
+            color: 'black',
+            textDecoration: 'none'
           }}
         >
-          <a 
-            href={`https://github.com/kubestellar/ui/commit/${commitHash}`} 
-            target="_blank" 
-            rel="noopener noreferrer"
-            style={{
-              color: 'black',
-              textDecoration: 'none'
-            }}
-          >
-            Commit: {commitHash}
-          </a>
-        </div>
-
+          Commit: {commitHash}
+        </a>
+      </div>
     </div>
   );
 }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -4,8 +4,7 @@ import {
 } from "react-router-dom";
 import Header from "./Header";
 import Menu from "./menu/Menu";
-
-const GITHUB_REPO_URL = 'https://github.com/kubestellar/ui';
+import Footer from "./Footer";
 
 export function Layout() {
   // Log the commit hash to console for debugging
@@ -28,32 +27,7 @@ export function Layout() {
         </div>
       </div>
       
-      {/* Commit Hash Footer */}
-      <div 
-        style={{
-          position: 'fixed',
-          bottom: '10px', 
-          right: '10px', 
-          color: 'grey',      
-          fontSize: '20px',    
-          opacity: 0.8,        
-          zIndex: 9999,
-          fontWeight: 300,     
-          letterSpacing: '0.5px' 
-        }}
-      >
-        <a 
-          href={`${GITHUB_REPO_URL}/commit/${commitHash}`} 
-          target="_blank" 
-          rel="noopener noreferrer"
-          style={{
-            color: 'black',
-            textDecoration: 'none'
-          }}
-        >
-          Commit: {commitHash}
-        </a>
-      </div>
+      <Footer commitHash={commitHash} />
     </div>
   );
 }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,27 +1,59 @@
 import {
-
-    Outlet,
-    ScrollRestoration,
-  } from "react-router-dom";
+  Outlet,
+} from "react-router-dom";
 import Header from "./Header";
 import Menu from "./menu/Menu";
- 
- 
+
+const GITHUB_REPO_URL = 'https://github.com/kubestellar/ui';
+
+
 export function Layout() {
-    return (
-      <div className="w-full min-h-screen flex flex-col justify-between">
-        <ScrollRestoration />
-        <div>
-          <Header />
-          <div className="w-full flex gap-0 pt-20 xl:pt-[96px] 2xl:pt-[112px] mb-auto">
-            <div className="hidden xl:block xl:w-[250px] 2xl:w-[280px] 3xl:w-[350px] border-r-2 border-base-300 dark:border-slate-700 px-3 xl:px-4 xl:py-1">
-              <Menu />
-            </div>
-            <div className="w-full px-4 xl:px-4 2xl:px-5 xl:py-2 overflow-clip">
-              <Outlet />
-            </div>
+  // Log the commit hash to console for debugging
+  console.log('Git Commit Hash:', import.meta.env.VITE_GIT_COMMIT_HASH);
+
+  const commitHash = import.meta.env.VITE_GIT_COMMIT_HASH || 'unknown';
+
+  return (
+    <div className="w-full min-h-screen flex flex-col justify-between relative">
+      <div>
+        <Header />
+        <div className="w-full flex gap-0 pt-20 xl:pt-[96px] 2xl:pt-[112px] mb-auto">
+          <div className="hidden xl:block xl:w-[250px] 2xl:w-[280px] 3xl:w-[350px] border-r-2 border-base-300 dark:border-slate-700 px-3 xl:px-4 xl:py-1">
+            <Menu />
+          </div>
+          <div className="w-full px-4 xl:px-4 2xl:px-5 xl:py-2 overflow-clip">
+            <Outlet />
           </div>
         </div>
       </div>
-    );
-  }
+      
+      {/* Commit Hash Footer */}
+      <div 
+          style={{
+            position: 'fixed',
+            bottom: '10px', 
+            right: '10px', 
+            color: 'grey',      
+            fontSize: '18px',    
+            opacity: 0.8,        
+            zIndex: 9999,
+            fontWeight: 300,     
+            letterSpacing: '0.5px' 
+          }}
+        >
+          <a 
+            href={`https://github.com/kubestellar/ui/commit/${commitHash}`} 
+            target="_blank" 
+            rel="noopener noreferrer"
+            style={{
+              color: 'black',
+              textDecoration: 'none'
+            }}
+          >
+            Commit: {commitHash}
+          </a>
+        </div>
+
+    </div>
+  );
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,21 +2,37 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { visualizer } from "rollup-plugin-visualizer";
 import EnvironmentPlugin from 'vite-plugin-environment'
+import { execSync } from 'child_process';
 
-// DOCS: https://www.npmjs.com/package/rollup-plugin-visualizer
-// https://vitejs.dev/config/
+// Function to get git commit hash
+const getGitCommitHash = () => {
+  try {
+    // Use more robust git command
+    return execSync('git rev-parse HEAD').toString().trim().slice(0, 7);
+  } catch (error) {
+    console.error('Failed to get git commit hash:', error);
+    return 'unknown';
+  }
+};
+
 export default defineConfig({
   plugins: [
     react(),
+    EnvironmentPlugin('all', { 
+      // Prefix for environment variables
+      prefix: 'VITE_' 
+    }),
     EnvironmentPlugin({
-      VITE_BASE_URL: process.env.VITE_BASE_URL,
+      VITE_GIT_COMMIT_HASH: getGitCommitHash(),
     }),
     visualizer({
-      filename: "bundle-stats.html", // Output file for the analysis
-      open: true, // Automatically open the file in the browser if true
-      gzipSize: true, // Show gzip sizes
-      brotliSize: true, // Show brotli sizes
-      // template: 'network', // sunburst, treemap, network, raw-data, list, flamegraph
+      filename: "bundle-stats.html",
+      open: true,
+      gzipSize: true,
+      brotliSize: true,
     }),
   ],
+  define: {
+    'import.meta.env.VITE_GIT_COMMIT_HASH': JSON.stringify(getGitCommitHash())
+  }
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,35 +4,44 @@ import { visualizer } from "rollup-plugin-visualizer";
 import EnvironmentPlugin from 'vite-plugin-environment'
 import { execSync } from 'child_process';
 
-// Function to get git commit hash
+// Utility function to extract the current git commit hash
+// Provides a short 7-character version of the full commit hash
 const getGitCommitHash = () => {
   try {
-    // Use more robust git command
     return execSync('git rev-parse HEAD').toString().trim().slice(0, 7);
   } catch (error) {
-    console.error('Failed to get git commit hash:', error);
+    console.error('Failed to retrieve git commit hash:', error);
     return 'unknown';
   }
 };
 
+// Vite configuration for KubeStellar UI project
+// Includes React plugin, environment variable management, and bundle visualization
 export default defineConfig({
   plugins: [
+    // React framework integration
     react(),
-    EnvironmentPlugin('all', { 
-      // Prefix for environment variables
-      prefix: 'VITE_' 
-    }),
+
+    // Environment variable management
+    // Enables access to base URL and git commit hash across the application
     EnvironmentPlugin({
+      VITE_BASE_URL: process.env.VITE_BASE_URL,
       VITE_GIT_COMMIT_HASH: getGitCommitHash(),
     }),
+
+    // Bundle size and composition visualization
+    // Helps in understanding application's build characteristics
     visualizer({
-      filename: "bundle-stats.html",
-      open: true,
-      gzipSize: true,
-      brotliSize: true,
+      filename: "bundle-stats.html", 
+      open: true,           // Automatically open analysis in browser
+      gzipSize: true,       // Include gzip compressed size
+      brotliSize: true,     // Include brotli compressed size
     }),
   ],
+
+  // Global compile-time constants and environment variable definitions
+  // Ensures commit hash is available during build and runtime
   define: {
-    'import.meta.env.VITE_GIT_COMMIT_HASH': JSON.stringify(getGitCommitHash())
+    'import.meta.env.VITE_GIT_COMMIT_HASH': JSON.stringify(getGitCommitHash()),
   }
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,9 @@ import { visualizer } from "rollup-plugin-visualizer";
 import EnvironmentPlugin from 'vite-plugin-environment'
 import { execSync } from 'child_process';
 
+// DOCS: https://www.npmjs.com/package/rollup-plugin-visualizer
+// https://vitejs.dev/config/
+
 // Utility function to extract the current git commit hash
 // Provides a short 7-character version of the full commit hash
 const getGitCommitHash = () => {
@@ -32,10 +35,12 @@ export default defineConfig({
     // Bundle size and composition visualization
     // Helps in understanding application's build characteristics
     visualizer({
-      filename: "bundle-stats.html", 
-      open: true,           // Automatically open analysis in browser
-      gzipSize: true,       // Include gzip compressed size
-      brotliSize: true,     // Include brotli compressed size
+      filename: "bundle-stats.html", // Output file for the analysis
+      open: true, // Automatically open the file in the browser if true
+      gzipSize: true, // Show gzip sizes
+      brotliSize: true, // Show brotli sizes
+      // template: 'network', // sunburst, treemap, network, raw-data, list, flamegraph
+
     }),
   ],
 


### PR DESCRIPTION
### Description  
This PR adds a **build number display** in the bottom-right corner of the UI, making it easier to identify the version of the application from a screenshot.  

### Related Issue  
Fixes #118  

### Changes Made  
- [x] Added a **gray-colored build number** in the bottom-right corner of the UI.  
- [x] Implemented logic to retrieve the **latest commit hash** and display it.  
- [x] Ensured that the build number updates dynamically based on the latest commit.  

### Checklist  
- [x] I have reviewed the project's contribution guidelines.  
- [x] I have tested the changes locally and ensured they work as expected.  
- [x] My code follows the project's coding standards.  

### Screenshots or Logs 
![image](https://github.com/user-attachments/assets/518bad22-b83f-460b-810e-962747e1e17b)


### Additional Notes  
This feature allows developers and testers to quickly verify which version of the UI is being used, making debugging and issue tracking more efficient.  
The **build number is clickable**, and clicking on it redirects to the respective commit on GitHub for easy reference.  
