### PR TITLE
feat: WDS backend Implementation for Kubernetes Service Resources

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/katamyra/kubestellarUI/api"
 	"github.com/katamyra/kubestellarUI/wds/deployment"
+	"github.com/katamyra/kubestellarUI/wds/resources"
 )
 
 type ContextInfo struct {
@@ -137,6 +138,10 @@ func main() {
 	router.GET("/ws", func(ctx *gin.Context) {
 		deployment.HandleDeploymentLogs(ctx.Writer, ctx.Request)
 	})
+	// SERVICES
+	router.GET("/api/services/:namespace", resources.GetServiceList)
+	router.GET("/api/services/:namespace/:name", resources.GetServiceByServiceName)
+
 	router.Run(":4000")
 }
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -141,6 +141,8 @@ func main() {
 	// SERVICES
 	router.GET("/api/services/:namespace", resources.GetServiceList)
 	router.GET("/api/services/:namespace/:name", resources.GetServiceByServiceName)
+	router.POST("/api/services/create", resources.CreateService)
+	router.DELETE("/api/services/delete", resources.DeleteService)
 
 	router.Run(":4000")
 }

--- a/backend/wds/common.go
+++ b/backend/wds/common.go
@@ -1,0 +1,60 @@
+package wds
+
+import (
+	"fmt"
+	"os"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+/*
+Load the KubeConfig file and return the kubernetes clientset which gives you access to play with the k8s api
+*/
+func homeDir() string {
+	if h := os.Getenv("HOME"); h != "" {
+		return h
+	}
+	return os.Getenv("USERPROFILE") // windows
+}
+func GetClientSetKubeConfig() (*kubernetes.Clientset, error) {
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		if home := homeDir(); home != "" {
+			kubeconfig = fmt.Sprintf("%s/.kube/config", home)
+		}
+	}
+
+	// Load the kubeconfig file
+	config, err := clientcmd.LoadFromFile(kubeconfig)
+	if err != nil {
+		// c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to load kubeconfig"})
+		return nil, fmt.Errorf("failed to load kubeconfig")
+	}
+
+	// Use WDS1 context specifically
+	ctxContext := config.Contexts["wds1"]
+	if ctxContext == nil {
+		// c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create ctxConfig"})
+		return nil, fmt.Errorf("failed to create ctxConfig")
+	}
+
+	// Create config for WDS cluster
+	clientConfig := clientcmd.NewDefaultClientConfig(
+		*config,
+		&clientcmd.ConfigOverrides{
+			CurrentContext: "wds1",
+		},
+	)
+
+	restConfig, err := clientConfig.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create restconfig")
+	}
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Kubernetes client")
+	}
+	return clientset, nil
+}

--- a/backend/wds/deployment/details.go
+++ b/backend/wds/deployment/details.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/katamyra/kubestellarUI/wds"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -33,7 +34,7 @@ func GetDeploymentByName(c *gin.Context) {
 		namespace = "default" // Use "default" namespace if not provided
 	}
 
-	clientset, err := getClientSetKubeConfig()
+	clientset, err := wds.GetClientSetKubeConfig()
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"message": "failed to create Kubernetes clientset",

--- a/backend/wds/deployment/logs.go
+++ b/backend/wds/deployment/logs.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/katamyra/kubestellarUI/wds"
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -28,7 +29,7 @@ func HandleDeploymentLogs(w http.ResponseWriter, r *http.Request) {
 	namespace := r.URL.Query().Get("namespace")
 	deploymentName := r.URL.Query().Get("deployment")
 
-	clientset, err := getClientSetKubeConfig()
+	clientset, err := wds.GetClientSetKubeConfig()
 	if err != nil {
 		conn.WriteMessage(websocket.TextMessage, []byte("Error: "+err.Error()))
 		return

--- a/backend/wds/deployment/status.go
+++ b/backend/wds/deployment/status.go
@@ -6,12 +6,13 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/katamyra/kubestellarUI/wds"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Get deployment status by name
 func GetDeploymentStatus(c *gin.Context) {
-	clientset, err := getClientSetKubeConfig()
+	clientset, err := wds.GetClientSetKubeConfig()
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create Kubernetes client"})
 		return

--- a/backend/wds/resources/services.go
+++ b/backend/wds/resources/services.go
@@ -1,0 +1,66 @@
+package resources
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/katamyra/kubestellarUI/wds"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func GetServiceList(ctx *gin.Context) {
+	namespace := ctx.Param("namespace")
+
+	clientset, err := wds.GetClientSetKubeConfig()
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{
+			"message": "failed to create Kubernetes clientset",
+			"err":     err,
+		})
+		return
+	}
+	var ListEverything = metav1.ListOptions{
+		LabelSelector: labels.Everything().String(),
+		FieldSelector: fields.Everything().String(),
+	}
+	services, err := clientset.CoreV1().Services(namespace).List(ctx, ListEverything)
+	if err != nil {
+		ctx.JSON(http.StatusNotFound, gin.H{"error": "Services not found", "err": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusAccepted, gin.H{
+		"services": services,
+	})
+
+}
+
+func GetServiceByServiceName(ctx *gin.Context) {
+	name := ctx.Param("name")
+	namespace := ctx.Param("namespace")
+	clientset, err := wds.GetClientSetKubeConfig()
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{
+			"message": "failed to create Kubernetes clientset",
+			"err":     err,
+		})
+		return
+	}
+	services, err := clientset.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		ctx.JSON(http.StatusNotFound, gin.H{"error": "Services not found", "err": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusAccepted, gin.H{
+		"name":              services.Name,
+		"namespace":         services.Namespace,
+		"uid":               services.UID,
+		"creationTimestamp": services.CreationTimestamp.Time,
+		"services":          services,
+		"status":            services.Status,
+	})
+
+}

--- a/backend/wds/resources/services.go
+++ b/backend/wds/resources/services.go
@@ -1,7 +1,9 @@
 package resources
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/katamyra/kubestellarUI/wds"
@@ -9,6 +11,80 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 )
+
+type Label struct {
+	Component string `json:"component"`
+	Provider  string `json:"provider"`
+}
+type MetaDataDetail struct {
+	Name              string    `json:"name"`
+	Namespace         string    `json:"namespace"`
+	Uid               string    `json:"uid"`
+	ResourceVersion   string    `json:"resourceVersion"`
+	CreationTimestamp time.Time `json:"creationTimestamp"`
+	Labels            Label     `json:"labels,omitempty"`
+	ManagedFields     []struct {
+		Manager    string    `json:"manager"`
+		Operation  string    `json:"operation"`
+		ApiVersion string    `json:"apiVersion"`
+		Time       time.Time `json:"time"`
+		FieldsType string    `json:"fieldsType"`
+	} `json:"managedFields"`
+}
+
+type Status struct {
+	LoadBalancer corev1.LoadBalancerStatus `json:"loadBalancer,omitempty"`
+}
+type ServiceDetail struct {
+	Metadata MetaDataDetail `json:"metadata"`
+	Status   Status         `json:"status"`
+}
+
+func helperServiceDetails(service corev1.Service) ServiceDetail {
+	serviceDetail := ServiceDetail{
+		Metadata: MetaDataDetail{
+			Name:              service.Name,
+			Namespace:         service.Namespace,
+			Uid:               string(service.UID),
+			ResourceVersion:   service.ResourceVersion,
+			CreationTimestamp: service.CreationTimestamp.Time,
+			ManagedFields: make([]struct {
+				Manager    string    `json:"manager"`
+				Operation  string    `json:"operation"`
+				ApiVersion string    `json:"apiVersion"`
+				Time       time.Time `json:"time"`
+				FieldsType string    `json:"fieldsType"`
+			}, len(service.ManagedFields)),
+		},
+		Status: struct {
+			LoadBalancer corev1.LoadBalancerStatus `json:"loadBalancer,omitempty"`
+		}{
+			LoadBalancer: service.Status.LoadBalancer,
+		},
+	}
+	if service.Labels != nil {
+		serviceDetail.Metadata.Labels.Component = service.Labels["component"]
+		serviceDetail.Metadata.Labels.Provider = service.Labels["provider"]
+	}
+
+	// Copy managed fields
+	for i, field := range service.ManagedFields {
+		serviceDetail.Metadata.ManagedFields[i] = struct {
+			Manager    string    `json:"manager"`
+			Operation  string    `json:"operation"`
+			ApiVersion string    `json:"apiVersion"`
+			Time       time.Time `json:"time"`
+			FieldsType string    `json:"fieldsType"`
+		}{
+			Manager:    field.Manager,
+			Operation:  string(field.Operation),
+			ApiVersion: field.APIVersion,
+			Time:       field.Time.Time,
+			FieldsType: field.FieldsType,
+		}
+	}
+	return serviceDetail
+}
 
 func GetServiceList(ctx *gin.Context) {
 	namespace := ctx.Param("namespace")
@@ -31,10 +107,15 @@ func GetServiceList(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusAccepted, gin.H{
-		"services": services,
-	})
+	var servicesList []ServiceDetail
+	for _, service := range services.Items {
+		serviceDetail := helperServiceDetails(service)
+		servicesList = append(servicesList, serviceDetail)
+	}
 
+	ctx.JSON(http.StatusOK, gin.H{
+		"services": servicesList,
+	})
 }
 
 func GetServiceByServiceName(ctx *gin.Context) {
@@ -53,14 +134,10 @@ func GetServiceByServiceName(ctx *gin.Context) {
 		ctx.JSON(http.StatusNotFound, gin.H{"error": "Services not found", "err": err.Error()})
 		return
 	}
+	serviceDetail := helperServiceDetails(*services)
 
 	ctx.JSON(http.StatusAccepted, gin.H{
-		"name":              services.Name,
-		"namespace":         services.Namespace,
-		"uid":               services.UID,
-		"creationTimestamp": services.CreationTimestamp.Time,
-		"services":          services,
-		"status":            services.Status,
+		"service": serviceDetail,
 	})
 
 }


### PR DESCRIPTION
Fixes #100 

- GetServiceList :  /api/services/:namespace
- GetServiceByServiceName: /api/services/:namespace/:name
- added create resource service route : /api/services/create
- Delete service - /api/services/delete

And also moved the GetClientSetKubeConfig from /wds/deployment/common.go to /wds/common.go 

### For test - Create Service resource  - POST: `http://localhost:4000/api/services/create`

```bash
{
  "name": "my-service",
  "namespace": "default",
  "labels": {
    "app": "my-app",
    "env": "production"
  },
  "ports": [
    {
      "name": "http",
      "port": 80,
      "targetPort": 8080,
      "protocol": "TCP"
    },
    {
      "name": "https",
      "port": 443,
      "targetPort": 8443,
      "protocol": "TCP"
    },
    {
      "name": "custom-port",
      "port": 9090,
      "targetPort": 9091,
      "protocol": "UDP"
    }
  ]
}
```