### PR TITLE
feat: added new route to handle user raw deployment configuration data to create deployment workload 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,8 @@ lib-cov
 # Coverage directory used by tools like istanbul
 coverage
 *.lcov
-
+../.idea/
+*.idea
 # nyc test coverage
 .nyc_output
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -131,6 +131,7 @@ func main() {
 
 	// Route to CRUD deployment
 	router.POST("/api/wds/create", deployment.CreateDeployment)
+	router.POST("/api/wds/create/json", deployment.HandleCreateDeploymentJson)
 	router.PUT("/api/wds/update", deployment.UpdateDeployment)
 	router.DELETE("/api/wds/delete", deployment.DeleteDeployment)
 	router.GET("/api/wds/:name", deployment.GetDeploymentByName)


### PR DESCRIPTION
### Description
<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->

### Related Issue
<!-- Link the issue(s) this PR addresses. -->
Fixes #127


https://github.com/user-attachments/assets/07e73099-c785-44de-8486-954be3329376


## New Route - `http://localhost:4000/api/wds/create/json`

Sample Data - 

```json
{
    "name": "user-demo-nginx",
    "namespace": "default",
    "replicas": 2,
    "labels": {
        "app": "nginx"
    },
    "container": {
        "name":"nginx",
        "image":"nnginx:latest",
        "ports": [{
            "ContainerPort":80
        }]
    }
}
```

Note: 
- Creating the deployment from local file or github URL and path - Use this route - `http://localhost:4000/api/wds/create`
- Creating the deployment from user configuration data - use this route - `http://localhost:4000/api/wds/create/json`

