### PR TITLE
Add CRUD operations for namespaces and API endpoints

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/katamyra/kubestellarUI/api"
+	nsresources "github.com/katamyra/kubestellarUI/namespace/resources"
 	"github.com/katamyra/kubestellarUI/wds/deployment"
 	"github.com/katamyra/kubestellarUI/wds/resources"
 )
@@ -145,6 +146,13 @@ func main() {
 	router.GET("/api/services/:namespace/:name", resources.GetServiceByServiceName)
 	router.POST("/api/services/create", resources.CreateService)
 	router.DELETE("/api/services/delete", resources.DeleteService)
+
+	// NAMESPACES
+	router.GET("/api/namespaces", nsresources.GetAllNamespaces)
+	router.GET("/api/namespaces/:name", nsresources.GetNamespaceDetails)
+	router.POST("/api/namespaces/create", nsresources.CreateNamespace)
+	router.PUT("/api/namespaces/update/:name", nsresources.UpdateNamespace)
+	router.DELETE("/api/namespaces/delete/:name", nsresources.DeleteNamespace)
 
 	router.Run(":4000")
 }

--- a/backend/models/namespace.go
+++ b/backend/models/namespace.go
@@ -1,0 +1,10 @@
+package models
+
+type Namespace struct {
+	Name       string            `json:"name"`
+	Status     string            `json:"status,omitempty"`
+	Labels     map[string]string `json:"labels,omitempty"`
+	Pods       []string          `json:"pods,omitempty"`
+	Deployments []string         `json:"deployments,omitempty"`
+	Services   []string          `json:"services,omitempty"`
+}

--- a/backend/namespace/namespace.go
+++ b/backend/namespace/namespace.go
@@ -1,0 +1,137 @@
+package ns
+
+import (
+	"context"
+	"fmt"
+	"time"
+	"github.com/katamyra/kubestellarUI/models"
+	"github.com/katamyra/kubestellarUI/wds"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// timeout duration for Kubernetes API requests
+const requestTimeout = 5 * time.Second
+
+// CreateNamespace creates a new namespace
+func CreateNamespace(namespace models.Namespace) error {
+	clientset, err := wds.GetClientSetKubeConfig()
+	if err != nil {
+		return fmt.Errorf("failed to initialize Kubernetes client: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+
+	// Create namespace with optional labels
+	_, err = clientset.CoreV1().Namespaces().Create(ctx, &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   namespace.Name,
+			Labels: namespace.Labels,
+		},
+	}, metav1.CreateOptions{})
+
+	if err != nil {
+		return fmt.Errorf("failed to create namespace: %v", err)
+	}
+	return nil
+}
+
+// GetAllNamespaces fetches all namespaces along with their pods
+func GetAllNamespaces() ([]models.Namespace, error) {
+	clientset, err := wds.GetClientSetKubeConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize Kubernetes client: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+
+	namespaces, err := clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list namespaces: %v", err)
+	}
+
+	var namespaceDetails []models.Namespace
+	for _, ns := range namespaces.Items {
+		pods, _ := clientset.CoreV1().Pods(ns.Name).List(ctx, metav1.ListOptions{})
+
+		var podNames []string
+		for _, pod := range pods.Items {
+			podNames = append(podNames, pod.Name)
+		}
+
+		namespaceDetails = append(namespaceDetails, models.Namespace{
+			Name:   ns.Name,
+			Status: string(ns.Status.Phase),
+			Pods:   podNames,
+		})
+	}
+
+	return namespaceDetails, nil
+}
+
+// GetNamespaceDetails fetches details of a specific namespace
+func GetNamespaceDetails(namespace string) (*models.Namespace, error) {
+	clientset, err := wds.GetClientSetKubeConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize Kubernetes client: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+
+	ns, err := clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("namespace '%s' not found: %v", namespace, err)
+	}
+
+	details := &models.Namespace{
+		Name:   ns.Name,
+		Status: string(ns.Status.Phase),
+		Labels: ns.Labels,
+	}
+
+	return details, nil
+}
+
+// UpdateNamespace updates namespace labels
+func UpdateNamespace(namespaceName string, labels map[string]string) error {
+	clientset, err := wds.GetClientSetKubeConfig()
+	if err != nil {
+		return fmt.Errorf("failed to initialize Kubernetes client: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+
+	ns, err := clientset.CoreV1().Namespaces().Get(ctx, namespaceName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("namespace '%s' not found", namespaceName)
+	}
+
+	ns.Labels = labels
+	_, err = clientset.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to update namespace: %v", err)
+	}
+
+	return nil
+}
+
+// DeleteNamespace removes a namespace
+func DeleteNamespace(name string) error {
+	clientset, err := wds.GetClientSetKubeConfig()
+	if err != nil {
+		return fmt.Errorf("failed to initialize Kubernetes client: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+
+	err = clientset.CoreV1().Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to delete namespace '%s': %v", name, err)
+	}
+	return nil
+}

--- a/backend/namespace/resources/service.go
+++ b/backend/namespace/resources/service.go
@@ -1,0 +1,97 @@
+package nsresources
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/katamyra/kubestellarUI/models"
+	ns "github.com/katamyra/kubestellarUI/namespace"
+)
+
+
+
+// createNamespace handles creating a new namespace
+func CreateNamespace(c *gin.Context) {
+	var namespace models.Namespace
+	if err := c.ShouldBindJSON(&namespace); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body", "details": err.Error()})
+		return
+	}
+
+	err := ns.CreateNamespace(namespace)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create namespace", "details": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"message":   "Namespace created successfully",
+		"namespace": namespace.Name,
+	})
+}
+
+// getAllNamespaces retrieves all namespaces with their pods
+func GetAllNamespaces(c *gin.Context) {
+	namespaces, err := ns.GetAllNamespaces()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve namespaces", "details": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"namespaces": namespaces})
+}
+
+// getNamespaceDetails retrieves detailed information about a specific namespace
+func GetNamespaceDetails(c *gin.Context) {
+	namespaceName := c.Param("name")
+
+	details, err := ns.GetNamespaceDetails(namespaceName)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Namespace not found", "details": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, details)
+}
+
+// updateNamespace handles updating labels of an existing namespace
+func UpdateNamespace(c *gin.Context) {
+	namespaceName := c.Param("name")
+
+	var labelUpdate struct {
+		Labels map[string]string `json:"labels"`
+	}
+
+	if err := c.ShouldBindJSON(&labelUpdate); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body", "details": err.Error()})
+		return
+	}
+
+	err := ns.UpdateNamespace(namespaceName, labelUpdate.Labels)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update namespace", "details": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message":   "Namespace updated successfully",
+		"namespace": namespaceName,
+		"labels":    labelUpdate.Labels,
+	})
+}
+
+// deleteNamespace handles deleting a namespace
+func DeleteNamespace(c *gin.Context) {
+	namespaceName := c.Param("name")
+
+	err := ns.DeleteNamespace(namespaceName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete namespace", "details": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message":   "Namespace deleted successfully",
+		"namespace": namespaceName,
+	})
+}


### PR DESCRIPTION
Implement CRUD operations for managing namespaces, including creating, retrieving, updating, and deleting namespaces through new API endpoints.