### PR TITLE
Refactored and moved the BP component into small components

### DIFF
--- a/src/components/BindingPolicy/BPPagination.tsx
+++ b/src/components/BindingPolicy/BPPagination.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Box, Typography, Button } from "@mui/material";
+
+interface BPPaginationProps {
+  filteredCount: number;
+  totalCount: number;
+}
+
+const BPPagination: React.FC<BPPaginationProps> = ({
+  filteredCount,
+  totalCount,
+}) => {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        mt: 2,
+      }}
+    >
+      <Typography variant="body2" color="text.secondary">
+        Showing {filteredCount} of {totalCount} entries
+      </Typography>
+      <Box sx={{ display: "flex", gap: 1 }}>
+        {[1, 2, 3, "...", 40].map((page, index) => (
+          <Button
+            key={index}
+            variant="outlined"
+            size="small"
+            sx={{ minWidth: 40 }}
+          >
+            {page}
+          </Button>
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export default BPPagination;

--- a/src/components/BindingPolicy/BPTable.tsx
+++ b/src/components/BindingPolicy/BPTable.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import {
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  Button,
+  Chip,
+  IconButton,
+  Tooltip,
+  Box,
+} from "@mui/material";
+import { Info, Trash2 } from "lucide-react";
+import { BindingPolicyInfo } from "../../types/bindingPolicy";
+
+interface BPTableProps {
+  policies: BindingPolicyInfo[];
+  onPreviewMatches: () => void;
+  onDeletePolicy: (policy: BindingPolicyInfo) => void;
+  activeFilters: { status?: "Active" | "Inactive" };
+}
+
+const BPTable: React.FC<BPTableProps> = ({
+  policies,
+  onPreviewMatches,
+  onDeletePolicy,
+  activeFilters,
+}) => {
+  const filteredPolicies = policies.filter((policy) => {
+    if (!policy) return false;
+    if (activeFilters.status && policy.status !== activeFilters.status) {
+      return false;
+    }
+    return true;
+  });
+
+  return (
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell>Binding Policy Name</TableCell>
+          <TableCell>Clusters</TableCell>
+          <TableCell>Workload</TableCell>
+          <TableCell>Creation Date</TableCell>
+          <TableCell>Status</TableCell>
+          <TableCell align="right">
+            <Tooltip title="Preview matches">
+              <IconButton size="small" onClick={onPreviewMatches}>
+                <Info />
+              </IconButton>
+            </Tooltip>
+          </TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {filteredPolicies.map((policy) => (
+          <TableRow key={policy.name}>
+            <TableCell>
+              <Button color="primary" sx={{ textTransform: "none" }}>
+                {policy.name}
+              </Button>
+            </TableCell>
+            <TableCell>
+              <Chip label={policy.clusters} size="small" color="success" />
+            </TableCell>
+            <TableCell>
+              <Chip label={policy.workload} size="small" color="success" />
+            </TableCell>
+            <TableCell>{policy.creationDate}</TableCell>
+            <TableCell>
+              <Chip
+                label={policy.status}
+                size="small"
+                color={policy.status === "Active" ? "success" : "error"}
+                sx={{
+                  "& .MuiChip-label": {
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 0.5,
+                  },
+                }}
+                icon={
+                  policy.status === "Active" ? <span>✓</span> : <span>✗</span>
+                }
+              />
+            </TableCell>
+            <TableCell align="right">
+              <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}>
+                <IconButton size="small">
+                  <Info />
+                </IconButton>
+                <IconButton
+                  size="small"
+                  color="error"
+                  onClick={() => onDeletePolicy(policy)}
+                >
+                  <Trash2 />
+                </IconButton>
+              </Box>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+};
+
+export default BPTable;

--- a/src/components/BindingPolicy/Dialogs/BPHeader.tsx
+++ b/src/components/BindingPolicy/Dialogs/BPHeader.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from "react";
+import {
+  Button,
+  TextField,
+  InputAdornment,
+  Box,
+  Menu,
+  MenuItem,
+  Chip,
+} from "@mui/material";
+import { Search, Filter, Plus,  X } from "lucide-react";
+import CreateBindingPolicyDialog from "../../CreateBindingPolicyDialog";
+import { BindingPolicyInfo } from "../../../types/bindingPolicy";
+
+interface BPHeaderProps {
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+  createDialogOpen: boolean;
+  setCreateDialogOpen: (open: boolean) => void;
+  onCreatePolicy: (
+    policyData: Omit<BindingPolicyInfo, "creationDate" | "clusters" | "status">
+  ) => void;
+  activeFilters: { status?: "Active" | "Inactive" };
+  setActiveFilters: (filters: { status?: "Active" | "Inactive" }) => void;
+}
+
+const BPHeader: React.FC<BPHeaderProps> = ({
+  searchQuery,
+  setSearchQuery,
+  createDialogOpen,
+  setCreateDialogOpen,
+  onCreatePolicy,
+  activeFilters,
+  setActiveFilters,
+}) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+  const handleFilterClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleFilterClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleStatusFilter = (status: "Active" | "Inactive" | undefined) => {
+    setActiveFilters({ ...activeFilters, status });
+    handleFilterClose();
+  };
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        mb: 3,
+      }}
+    >
+      <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
+        <TextField
+          size="small"
+          placeholder="Search"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <Search size={20} />
+              </InputAdornment>
+            ),
+          }}
+        />
+        <Button
+          startIcon={<Filter size={20} />}
+          variant="outlined"
+          onClick={handleFilterClick}
+          color={Object.keys(activeFilters).length > 0 ? "primary" : "inherit"}
+        >
+          Filter
+        </Button>
+        {activeFilters.status && (
+          <Chip
+            label={`Status: ${activeFilters.status}`}
+            onDelete={() => handleStatusFilter(undefined)}
+            deleteIcon={<X size={16} />}
+          />
+        )}
+        <Menu
+          anchorEl={anchorEl}
+          open={Boolean(anchorEl)}
+          onClose={handleFilterClose}
+        >
+          <MenuItem onClick={() => handleStatusFilter("Active")}>
+            Status: Active
+          </MenuItem>
+          <MenuItem onClick={() => handleStatusFilter("Inactive")}>
+            Status: Inactive
+          </MenuItem>
+          {activeFilters.status && (
+            <MenuItem onClick={() => handleStatusFilter(undefined)}>
+              Clear Status Filter
+            </MenuItem>
+          )}
+        </Menu>
+      </Box>
+
+      <CreateBindingPolicyDialog
+        open={createDialogOpen}
+        onClose={() => setCreateDialogOpen(false)}
+        onCreatePolicy={onCreatePolicy}
+      />
+
+      <Box sx={{ display: "flex", gap: 1 }}>
+        <Button
+          variant="outlined"
+          startIcon={<Plus size={20} />}
+          onClick={() => setCreateDialogOpen(true)}
+        >
+          Create Binding Policy
+        </Button>
+      </Box>
+    </Box>
+  );
+};
+
+export default BPHeader;

--- a/src/components/BindingPolicy/Dialogs/DeleteDialog.tsx
+++ b/src/components/BindingPolicy/Dialogs/DeleteDialog.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+} from "@mui/material";
+
+interface DeleteDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  policyName?: string;
+}
+
+const DeleteDialog: React.FC<DeleteDialogProps> = ({
+  open,
+  onClose,
+  onConfirm,
+  policyName,
+}) => {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>Delete Binding Policy</DialogTitle>
+      <DialogContent>
+        <Typography>
+          Are you sure you want to delete the binding policy "{policyName}"?
+          This action cannot be undone.
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button variant="contained" color="error" onClick={onConfirm}>
+          Delete
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default DeleteDialog;

--- a/src/components/BindingPolicy/PreviewDialog.tsx
+++ b/src/components/BindingPolicy/PreviewDialog.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Box,
+  Typography,
+  Paper,
+  Chip,
+} from "@mui/material";
+import { ManagedCluster, Workload } from "../../types/bindingPolicy";
+
+interface PreviewDialogProps {
+  open: boolean;
+  onClose: () => void;
+  matchedClusters: ManagedCluster[];
+  matchedWorkloads: Workload[];
+}
+
+const PreviewDialog: React.FC<PreviewDialogProps> = ({
+  open,
+  onClose,
+  matchedClusters,
+  matchedWorkloads,
+}) => {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>Preview Matches</DialogTitle>
+      <DialogContent>
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: 2,
+            mt: 2,
+          }}
+        >
+          <Box>
+            <Typography variant="h6" gutterBottom>
+              Matched Clusters
+            </Typography>
+            {matchedClusters.map((cluster) => (
+              <Paper key={cluster.name} sx={{ p: 2, mb: 1 }}>
+                <Typography variant="subtitle1">{cluster.name}</Typography>
+                <Box
+                  sx={{ display: "flex", gap: 0.5, flexWrap: "wrap", mt: 1 }}
+                >
+                  {Object.entries(cluster.labels).map(([key, value]) => (
+                    <Chip
+                      key={key}
+                      label={`${key}=${value}`}
+                      size="small"
+                      sx={{ backgroundColor: "#e3f2fd" }}
+                    />
+                  ))}
+                </Box>
+              </Paper>
+            ))}
+          </Box>
+          <Box>
+            <Typography variant="h6" gutterBottom>
+              Matched Workloads
+            </Typography>
+            {matchedWorkloads.map((workload) => (
+              <Paper key={workload.name} sx={{ p: 2, mb: 1 }}>
+                <Typography variant="subtitle1">{workload.name}</Typography>
+                <Box
+                  sx={{ display: "flex", gap: 0.5, flexWrap: "wrap", mt: 1 }}
+                >
+                  {Object.entries(workload.labels).map(([key, value]) => (
+                    <Chip
+                      key={key}
+                      label={`${key}=${value}`}
+                      size="small"
+                      sx={{ backgroundColor: "#e3f2fd" }}
+                    />
+                  ))}
+                </Box>
+              </Paper>
+            ))}
+          </Box>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default PreviewDialog;

--- a/src/pages/BP.tsx
+++ b/src/pages/BP.tsx
@@ -1,46 +1,15 @@
 import { useEffect, useState } from "react";
+import { Paper, Box } from "@mui/material";
+import BPHeader from "../components/BindingPolicy/Dialogs/BPHeader";
+import BPTable from "../components/BindingPolicy/BPTable";
+import BPPagination from "../components/BindingPolicy/BPPagination";
+import PreviewDialog from "../components/BindingPolicy/PreviewDialog";
+import DeleteDialog from "../components/BindingPolicy/Dialogs/DeleteDialog";
 import {
-  Button,
-  TextField,
-  InputAdornment,
-  Table,
-  TableHead,
-  TableBody,
-  TableRow,
-  TableCell,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Chip,
-  IconButton,
-  Tooltip,
-  Paper,
-  Box,
-  Typography,
-} from "@mui/material";
-import { Search, Filter, Plus,  Info, Trash2 } from "lucide-react";
-import CreateBindingPolicyDialog from "../components/CreateBindingPolicyDialog";
-
-interface BindingPolicyInfo {
-  name: string;
-  clusters: number;
-  workload: string;
-  creationDate: string;
-  status: "Active" | "Inactive";
-}
-
-interface ManagedCluster {
-  name: string;
-  labels: Record<string, string>;
-  status: string;
-}
-
-interface Workload {
-  name: string;
-  namespace: string;
-  labels: Record<string, string>;
-}
+  BindingPolicyInfo,
+  ManagedCluster,
+  Workload,
+} from "../types/bindingPolicy";
 
 const BP = () => {
   const [bindingPolicies, setBindingPolicies] = useState<BindingPolicyInfo[]>(
@@ -48,7 +17,6 @@ const BP = () => {
   );
   const [loading, setLoading] = useState<boolean>(true);
   const [searchQuery, setSearchQuery] = useState<string>("");
-  // const [showPreview, setShowPreview] = useState(false);
   const [selectedLabels] = useState<Record<string, string>>({});
   const [availableClusters, setAvailableClusters] = useState<ManagedCluster[]>(
     []
@@ -56,9 +24,12 @@ const BP = () => {
   const [availableWorkloads, setAvailableWorkloads] = useState<Workload[]>([]);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
-
+  const [previewDialogOpen, setPreviewDialogOpen] = useState(false);
   const [selectedPolicy, setSelectedPolicy] =
     useState<BindingPolicyInfo | null>(null);
+  const [activeFilters, setActiveFilters] = useState<{
+    status?: "Active" | "Inactive";
+  }>({});
 
   useEffect(() => {
     // Simulate loading initial data
@@ -139,9 +110,6 @@ const BP = () => {
     }, 1000);
   }, []);
 
-  const [previewDialogOpen, setPreviewDialogOpen] = useState(false);
-
-  // Calculate matches based on selected labels
   const getMatches = () => {
     const matchedClusters = availableClusters.filter((cluster) => {
       return Object.entries(selectedLabels).every(
@@ -188,11 +156,6 @@ const BP = () => {
     setCreateDialogOpen(false);
   };
 
-  const handlePreviewMatches = () => {
-    setPreviewDialogOpen(true);
-  };
-
-  // Add function to filter binding policies
   const filteredPolicies = bindingPolicies.filter((policy) => {
     const searchLower = searchQuery.toLowerCase();
     return (
@@ -210,237 +173,45 @@ const BP = () => {
     );
   }
 
+  const { matchedClusters, matchedWorkloads } = getMatches();
+
   return (
     <Paper sx={{ maxWidth: "100%", margin: "auto", p: 3 }}>
-      {/* Header Section */}
-      <Box
-        sx={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-          mb: 3,
-        }}
-      >
-        <Box sx={{ display: "flex", gap: 2 }}>
-          <TextField
-            size="small"
-            placeholder="Search"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  <Search size={20} />
-                </InputAdornment>
-              ),
-            }}
-          />
-          <Button startIcon={<Filter size={20} />} variant="outlined">
-            Filter
-          </Button>
-        </Box>
-        <CreateBindingPolicyDialog
-          open={createDialogOpen}
-          onClose={() => setCreateDialogOpen(false)}
-          onCreatePolicy={handleCreatePolicySubmit}
-        />
+      <BPHeader
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+        createDialogOpen={createDialogOpen}
+        setCreateDialogOpen={setCreateDialogOpen}
+        onCreatePolicy={handleCreatePolicySubmit}
+        activeFilters={activeFilters}
+        setActiveFilters={setActiveFilters}
+      />
 
-        <Box sx={{ display: "flex", gap: 1 }}>
-          <Button
-            variant="outlined"
-            startIcon={<Plus size={20} />}
-            onClick={() => setCreateDialogOpen(true)}
-          >
-            Create Binding Policy
-          </Button>
-       
-        </Box>
-      </Box>
+      <BPTable
+        policies={filteredPolicies}
+        onPreviewMatches={() => setPreviewDialogOpen(true)}
+        onDeletePolicy={handleDeletePolicy}
+        activeFilters={activeFilters}
+      />
 
-      {/* Table Section */}
-      <Table>
-        <TableHead>
-          <TableRow>
-            <TableCell>Binding Policy Name</TableCell>
-            <TableCell>Clusters</TableCell>
-            <TableCell>Workload</TableCell>
-            <TableCell>Creation Date</TableCell>
-            <TableCell>Status</TableCell>
-            <TableCell align="right">
-              <Tooltip title="Preview matches">
-                <IconButton size="small" onClick={handlePreviewMatches}>
-                  <Info />
-                </IconButton>
-              </Tooltip>
-            </TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {filteredPolicies.map((policy) => (
-            <TableRow key={policy.name}>
-              <TableCell>
-                <Button color="primary" sx={{ textTransform: "none" }}>
-                  {policy.name}
-                </Button>
-              </TableCell>
-              <TableCell>
-                <Chip label={policy.clusters} size="small" color="success" />
-              </TableCell>
-              <TableCell>
-                <Chip label={policy.workload} size="small" color="success" />
-              </TableCell>
-              <TableCell>{policy.creationDate}</TableCell>
-              <TableCell>
-                <Chip
-                  label={policy.status}
-                  size="small"
-                  color={policy.status === "Active" ? "success" : "error"}
-                  sx={{
-                    "& .MuiChip-label": {
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 0.5,
-                    },
-                  }}
-                  icon={
-                    policy.status === "Active" ? <span>✓</span> : <span>✗</span>
-                  }
-                />
-              </TableCell>
-              <TableCell align="right">
-                <Box
-                  sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}
-                >
-                  <IconButton size="small">
-                    <Info />
-                  </IconButton>
-                  <IconButton
-                    size="small"
-                    color="error"
-                    onClick={() => handleDeletePolicy(policy)}
-                  >
-                    <Trash2 />
-                  </IconButton>
-                </Box>
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+      <BPPagination
+        filteredCount={filteredPolicies.length}
+        totalCount={bindingPolicies.length}
+      />
 
-      {/* Pagination */}
-      <Box
-        sx={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-          mt: 2,
-        }}
-      >
-        <Typography variant="body2" color="text.secondary">
-          Showing {filteredPolicies.length} of {bindingPolicies.length} entries
-        </Typography>
-        <Box sx={{ display: "flex", gap: 1 }}>
-          {[1, 2, 3, "...", 40].map((page, index) => (
-            <Button
-              key={index}
-              variant="outlined"
-              size="small"
-              sx={{ minWidth: 40 }}
-            >
-              {page}
-            </Button>
-          ))}
-        </Box>
-      </Box>
-
-      {/* Preview Dialog */}
-      <Dialog
+      <PreviewDialog
         open={previewDialogOpen}
         onClose={() => setPreviewDialogOpen(false)}
-        maxWidth="md"
-        fullWidth
-      >
-        <DialogTitle>Preview Matches</DialogTitle>
-        <DialogContent>
-          <Box
-            sx={{
-              display: "grid",
-              gridTemplateColumns: "1fr 1fr",
-              gap: 2,
-              mt: 2,
-            }}
-          >
-            <Box>
-              <Typography variant="h6" gutterBottom>
-                Matched Clusters
-              </Typography>
-              {getMatches().matchedClusters.map((cluster) => (
-                <Paper key={cluster.name} sx={{ p: 2, mb: 1 }}>
-                  <Typography variant="subtitle1">{cluster.name}</Typography>
-                  <Box
-                    sx={{ display: "flex", gap: 0.5, flexWrap: "wrap", mt: 1 }}
-                  >
-                    {Object.entries(cluster.labels).map(([key, value]) => (
-                      <Chip
-                        key={key}
-                        label={`${key}=${value}`}
-                        size="small"
-                        sx={{ backgroundColor: "#e3f2fd" }}
-                      />
-                    ))}
-                  </Box>
-                </Paper>
-              ))}
-            </Box>
-            <Box>
-              <Typography variant="h6" gutterBottom>
-                Matched Workloads
-              </Typography>
-              {getMatches().matchedWorkloads.map((workload) => (
-                <Paper key={workload.name} sx={{ p: 2, mb: 1 }}>
-                  <Typography variant="subtitle1">{workload.name}</Typography>
-                  <Box
-                    sx={{ display: "flex", gap: 0.5, flexWrap: "wrap", mt: 1 }}
-                  >
-                    {Object.entries(workload.labels).map(([key, value]) => (
-                      <Chip
-                        key={key}
-                        label={`${key}=${value}`}
-                        size="small"
-                        sx={{ backgroundColor: "#e3f2fd" }}
-                      />
-                    ))}
-                  </Box>
-                </Paper>
-              ))}
-            </Box>
-          </Box>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setPreviewDialogOpen(false)}>Close</Button>
-        </DialogActions>
-      </Dialog>
+        matchedClusters={matchedClusters}
+        matchedWorkloads={matchedWorkloads}
+      />
 
-      {/* Delete Dialog */}
-      <Dialog
+      <DeleteDialog
         open={deleteDialogOpen}
         onClose={() => setDeleteDialogOpen(false)}
-      >
-        <DialogTitle>Delete Binding Policy</DialogTitle>
-        <DialogContent>
-          <Typography>
-            Are you sure you want to delete the binding policy "
-            {selectedPolicy?.name}"? This action cannot be undone.
-          </Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setDeleteDialogOpen(false)}>Cancel</Button>
-          <Button variant="contained" color="error" onClick={confirmDelete}>
-            Delete
-          </Button>
-        </DialogActions>
-      </Dialog>
+        onConfirm={confirmDelete}
+        policyName={selectedPolicy?.name}
+      />
     </Paper>
   );
 };

--- a/src/types/bindingPolicy.ts
+++ b/src/types/bindingPolicy.ts
@@ -1,0 +1,19 @@
+export interface BindingPolicyInfo {
+    name: string;
+    clusters: number;
+    workload: string;
+    creationDate: string;
+    status: "Active" | "Inactive";
+}
+
+export interface ManagedCluster {
+    name: string;
+    labels: Record<string, string>;
+    status: string;
+}
+
+export interface Workload {
+    name: string;
+    namespace: string;
+    labels: Record<string, string>;
+} 


### PR DESCRIPTION
### Description
This PR restructures the codebase by separating concerns into individual components (BPHeader, BPTable, BPPagination, DeleteDialog), improving maintainability,  and reusability. Centralized types enhance type consistency, while reducing complexity and making the overall structure easier to understand.

### Related Issue
Partially addresses: #54 

### Changes Made
- Simplifies the overall structure and reduces complexity of the main BP component.
- Assigns specific responsibilities to components:
       1.     - BPHeader: Manages search and action buttons.
       2.     - BPTable: Displays binding policies data.
       3.     - BPPagination: Handles pagination UI.
       4.     - DeleteDialog: Manages policy deletion confirmation.
- Centralizes types in a separate file for consistent type management.
- Adds status filtering (Active/Inactive) with visual feedback via Chips.
- Adds a CancelConfirmationDialog component for unsaved changes.
- Displays confirmation dialog only when unsaved changes exist (YAML edits, file uploads, or policy name entry).
- Maintains existing functionality inplace.


### Checklist
Please ensure the following before submitting your PR:
- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

