### PR TITLE
fix: alignment of Kebeconfig onboard in Cluster category for frontend

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -18,7 +18,7 @@ export function Layout() {
       <div>
         <Header />
         <div className="w-full flex gap-0 pt-20 xl:pt-[96px] 2xl:pt-[112px] mb-auto">
-          <div className="hidden xl:block xl:w-[250px] 2xl:w-[280px] 3xl:w-[350px] border-r-2 border-base-300 dark:border-slate-700 px-3 xl:px-4 xl:py-1">
+        <div className="hidden xl:block xl:w-[285px] 2xl:w-[310px] 3xl:w-[350px] border-r-2 border-base-300 dark:border-slate-700 px-3 xl:px-4 xl:py-1">
             <Menu />
           </div>
           <div className="w-full px-4 xl:px-4 2xl:px-5 xl:py-2 overflow-clip">


### PR DESCRIPTION
###  Description
This pull request addresses the misalignment issue of the **Kebeconfig onboard in the Cluster category** on larger screens (xl+). The Kebeconfig section, which was previously aligned below the icon, has now been properly aligned to the **right side** of the icon for **frontend screens** of xl+ size.

### Related Issue

Fixes #170

###  Changes Made
- [x] Increased the width of the layout menu to ensure that **"Kebeconfig onboard"** appears on the **same line** as the icon for xl+ screens.
- [x] Fixed the alignment of the Kebeconfig section in the Cluster category for xl+ screens.
- [x] Updated CSS/JSX to ensure proper layout and responsiveness for larger screen sizes.

### **Screenshots**

**Before**  
*Screenshot showing the misalignment of the Kebeconfig section (below the icon):*

![Screenshot from 2025-02-16 01-28-27](https://github.com/user-attachments/assets/f4fe847c-a287-4802-baba-38482ee2f132)

**After**  

*Screenshot showing the corrected alignment of the Kebeconfig section (right side of the icon):*

![Screenshot from 2025-02-16 01-29-34](https://github.com/user-attachments/assets/466a7116-019f-43ee-9545-6aa4cbf23901)


### **Checklist**
Please ensure the following before submitting your PR:
- [x] I have reviewed the project's contribution guidelines.
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### **Additional Notes**
This change only affects the frontend layout for xl+ screens and should not impact other screen sizes. Please verify if everything looks good across different device sizes.
