### PR TITLE
Add Editing, Unsaved Changes Warning, and Policy Detail Dialog to Binding Policy

### DIFF
--- a/src/components/BindingPolicy/BPTable.tsx
+++ b/src/components/BindingPolicy/BPTable.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   Table,
   TableHead,
@@ -11,13 +11,15 @@ import {
   Tooltip,
   Box,
 } from "@mui/material";
-import { Info, Trash2 } from "lucide-react";
+import { Info, Trash2, Edit2 } from "lucide-react";
 import { BindingPolicyInfo } from "../../types/bindingPolicy";
+import PolicyDetailDialog from "./Dialogs/PolicyDetailDialog";
 
 interface BPTableProps {
   policies: BindingPolicyInfo[];
   onPreviewMatches: () => void;
   onDeletePolicy: (policy: BindingPolicyInfo) => void;
+  onEditPolicy: (policy: BindingPolicyInfo) => void;
   activeFilters: { status?: "Active" | "Inactive" };
 }
 
@@ -25,8 +27,16 @@ const BPTable: React.FC<BPTableProps> = ({
   policies,
   onPreviewMatches,
   onDeletePolicy,
+  onEditPolicy,
   activeFilters,
 }) => {
+  const [selectedPolicy, setSelectedPolicy] =
+    useState<BindingPolicyInfo | null>(null);
+
+  const handlePolicyClick = (policy: BindingPolicyInfo) => {
+    setSelectedPolicy(policy);
+  };
+
   const filteredPolicies = policies.filter((policy) => {
     if (!policy) return false;
     if (activeFilters.status && policy.status !== activeFilters.status) {
@@ -36,73 +46,92 @@ const BPTable: React.FC<BPTableProps> = ({
   });
 
   return (
-    <Table>
-      <TableHead>
-        <TableRow>
-          <TableCell>Binding Policy Name</TableCell>
-          <TableCell>Clusters</TableCell>
-          <TableCell>Workload</TableCell>
-          <TableCell>Creation Date</TableCell>
-          <TableCell>Status</TableCell>
-          <TableCell align="right">
-            <Tooltip title="Preview matches">
-              <IconButton size="small" onClick={onPreviewMatches}>
-                <Info />
-              </IconButton>
-            </Tooltip>
-          </TableCell>
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        {filteredPolicies.map((policy) => (
-          <TableRow key={policy.name}>
-            <TableCell>
-              <Button color="primary" sx={{ textTransform: "none" }}>
-                {policy.name}
-              </Button>
-            </TableCell>
-            <TableCell>
-              <Chip label={policy.clusters} size="small" color="success" />
-            </TableCell>
-            <TableCell>
-              <Chip label={policy.workload} size="small" color="success" />
-            </TableCell>
-            <TableCell>{policy.creationDate}</TableCell>
-            <TableCell>
-              <Chip
-                label={policy.status}
-                size="small"
-                color={policy.status === "Active" ? "success" : "error"}
-                sx={{
-                  "& .MuiChip-label": {
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 0.5,
-                  },
-                }}
-                icon={
-                  policy.status === "Active" ? <span>✓</span> : <span>✗</span>
-                }
-              />
-            </TableCell>
+    <>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Binding Policy Name</TableCell>
+            <TableCell>Clusters</TableCell>
+            <TableCell>Workload</TableCell>
+            <TableCell>Creation Date</TableCell>
+            <TableCell>Status</TableCell>
             <TableCell align="right">
-              <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}>
-                <IconButton size="small">
+              <Tooltip title="Preview matches">
+                <IconButton size="small" onClick={onPreviewMatches}>
                   <Info />
                 </IconButton>
-                <IconButton
-                  size="small"
-                  color="error"
-                  onClick={() => onDeletePolicy(policy)}
-                >
-                  <Trash2 />
-                </IconButton>
-              </Box>
+              </Tooltip>
             </TableCell>
           </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+        </TableHead>
+        <TableBody>
+          {filteredPolicies.map((policy) => (
+            <TableRow key={policy.name}>
+              <TableCell>
+                <Button
+                  color="primary"
+                  sx={{ textTransform: "none" }}
+                  onClick={() => handlePolicyClick(policy)}
+                >
+                  {policy.name}
+                </Button>
+              </TableCell>
+              <TableCell>
+                <Chip label={policy.clusters} size="small" color="success" />
+              </TableCell>
+              <TableCell>
+                <Chip label={policy.workload} size="small" color="success" />
+              </TableCell>
+              <TableCell>{policy.creationDate}</TableCell>
+              <TableCell>
+                <Chip
+                  label={policy.status}
+                  size="small"
+                  color={policy.status === "Active" ? "success" : "error"}
+                  sx={{
+                    "& .MuiChip-label": {
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 0.5,
+                    },
+                  }}
+                  icon={
+                    policy.status === "Active" ? <span>✓</span> : <span>✗</span>
+                  }
+                />
+              </TableCell>
+              <TableCell align="right">
+                <Box
+                  sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}
+                >
+                  <IconButton size="small" onClick={() => onEditPolicy(policy)}>
+                    <Edit2 />
+                  </IconButton>
+                  <IconButton size="small">
+                    <Info />
+                  </IconButton>
+                  <IconButton
+                    size="small"
+                    color="error"
+                    onClick={() => onDeletePolicy(policy)}
+                  >
+                    <Trash2 />
+                  </IconButton>
+                </Box>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      {selectedPolicy && (
+        <PolicyDetailDialog
+          open={Boolean(selectedPolicy)}
+          onClose={() => setSelectedPolicy(null)}
+          policy={selectedPolicy}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/components/BindingPolicy/Dialogs/EditBindingPolicyDialog.tsx
+++ b/src/components/BindingPolicy/Dialogs/EditBindingPolicyDialog.tsx
@@ -1,0 +1,164 @@
+import React, { useState, useEffect } from "react";
+import Editor from "@monaco-editor/react";
+import yaml from "js-yaml";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogActions,
+  Button,
+  Alert,
+  AlertTitle,
+  TextField,
+  Snackbar,
+} from "@mui/material";
+import { BindingPolicyInfo } from "../../../types/bindingPolicy";
+
+interface EditBindingPolicyDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (policyData: Partial<BindingPolicyInfo>) => void;
+  policy: BindingPolicyInfo;
+}
+
+const EditBindingPolicyDialog: React.FC<EditBindingPolicyDialogProps> = ({
+  open,
+  onClose,
+  onSave,
+  policy,
+}) => {
+  const [editorContent, setEditorContent] = useState<string>(policy.yaml);
+  const [policyName, setPolicyName] = useState<string>(policy.name);
+  const [error, setError] = useState<string>("");
+  const [showUnsavedChanges, setShowUnsavedChanges] = useState(false);
+
+  useEffect(() => {
+    setEditorContent(policy.yaml);
+    setPolicyName(policy.name);
+  }, [policy]);
+
+  const validateYaml = (content: string): boolean => {
+    try {
+      yaml.load(content);
+      return true;
+    } catch (e) {
+      if (e instanceof Error) {
+        setError(`Invalid YAML format: ${e.message}`);
+      } else {
+        setError("Invalid YAML format");
+      }
+      return false;
+    }
+  };
+
+  const handleSave = () => {
+    if (!validateYaml(editorContent)) {
+      return;
+    }
+
+    onSave({
+      ...policy,
+      name: policyName,
+      yaml: editorContent,
+    });
+    onClose();
+  };
+
+  const handleClose = () => {
+    if (policyName !== policy.name || editorContent !== policy.yaml) {
+      setShowUnsavedChanges(true);
+    } else {
+      onClose();
+    }
+  };
+
+  return (
+    <>
+      <Dialog open={open} onClose={handleClose} maxWidth="lg" fullWidth>
+        <DialogTitle>Edit Binding Policy</DialogTitle>
+        <DialogContent>
+          <Alert severity="info" sx={{ mb: 2 }}>
+            <AlertTitle>Info</AlertTitle>
+            Edit your binding policy configuration. Changes will be applied
+            after saving.
+          </Alert>
+
+          <TextField
+            fullWidth
+            label="Binding Policy Name"
+            value={policyName}
+            onChange={(e) => setPolicyName(e.target.value)}
+            margin="normal"
+            required
+          />
+
+          <div className="rounded-md border mt-4">
+            <Editor
+              height="400px"
+              language="yaml"
+              value={editorContent}
+              theme="vs-dark"
+              options={{
+                minimap: { enabled: false },
+                fontSize: 14,
+                lineNumbers: "on",
+                scrollBeyondLastLine: false,
+                automaticLayout: true,
+              }}
+              onChange={(value) => setEditorContent(value || "")}
+            />
+          </div>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose}>Cancel</Button>
+          <Button
+            variant="contained"
+            onClick={handleSave}
+            disabled={!policyName || !editorContent}
+          >
+            Save Changes
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog
+        open={showUnsavedChanges}
+        onClose={() => setShowUnsavedChanges(false)}
+      >
+        <DialogTitle>Unsaved Changes</DialogTitle>
+        <DialogContent>
+          <Alert severity="warning">
+            <AlertTitle>Warning</AlertTitle>
+            You have unsaved changes. Are you sure you want to close without
+            saving?
+          </Alert>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setShowUnsavedChanges(false)}>
+            Continue Editing
+          </Button>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={() => {
+              setShowUnsavedChanges(false);
+              onClose();
+            }}
+          >
+            Discard Changes
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={!!error}
+        autoHideDuration={6000}
+        onClose={() => setError("")}
+        message={error}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      />
+    </>
+  );
+};
+
+export default EditBindingPolicyDialog;

--- a/src/components/BindingPolicy/Dialogs/PolicyDetailDialog.tsx
+++ b/src/components/BindingPolicy/Dialogs/PolicyDetailDialog.tsx
@@ -1,0 +1,153 @@
+import React from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Box,
+  Typography,
+  Chip,
+  Paper,
+  Grid,
+} from "@mui/material";
+import { BindingPolicyInfo } from "../../../types/bindingPolicy";
+import Editor from "@monaco-editor/react";
+
+interface PolicyDetailDialogProps {
+  open: boolean;
+  onClose: () => void;
+  policy: BindingPolicyInfo;
+}
+
+const PolicyDetailDialog: React.FC<PolicyDetailDialogProps> = ({
+  open,
+  onClose,
+  policy,
+}) => {
+  // Extract binding mode from YAML if not directly provided
+  const bindingMode =
+    policy.bindingMode ||
+    policy.yaml?.match(/bindingMode:\s*(\w+)/)?.[1] ||
+    "N/A";
+
+  // Extract cluster names from YAML
+  const clusterNames =
+    policy.yaml
+      ?.match(/clusterNames:\n(\s+- .+\n?)+/)?.[0]
+      ?.split("\n")
+      ?.filter((line) => line.includes("- "))
+      ?.map((line) => line.replace(/\s+- /, "")) || [];
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
+      <DialogTitle>
+        <Box display="flex" alignItems="center" gap={2}>
+          <Typography variant="h6">{policy.name}</Typography>
+          <Chip
+            label={policy.status}
+            size="small"
+            color={policy.status === "Active" ? "success" : "error"}
+          />
+        </Box>
+      </DialogTitle>
+      <DialogContent>
+        <Grid container spacing={3}>
+          <Grid item xs={12} md={4}>
+            <Paper sx={{ p: 2, height: "100%" }}>
+              <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
+                Policy Information
+              </Typography>
+              <Box display="flex" flexDirection="column" gap={2}>
+                <Box>
+                  <Typography variant="body2" color="text.secondary">
+                    Created
+                  </Typography>
+                  <Typography>{policy.creationDate}</Typography>
+                </Box>
+                <Box>
+                  <Typography variant="body2" color="text.secondary">
+                    Last Modified
+                  </Typography>
+                  <Typography>
+                    {policy.lastModifiedDate || "Not available"}
+                  </Typography>
+                </Box>
+                <Box>
+                  <Typography variant="body2" color="text.secondary">
+                    Binding Mode
+                  </Typography>
+                  <Typography>{bindingMode}</Typography>
+                </Box>
+                <Box>
+                  <Typography variant="body2" color="text.secondary">
+                    Clusters ({policy.clusters})
+                  </Typography>
+                  {clusterNames.length > 0 ? (
+                    clusterNames.map((name, index) => (
+                      <Chip
+                        key={index}
+                        label={name}
+                        size="small"
+                        sx={{ mr: 1, mt: 1 }}
+                      />
+                    ))
+                  ) : (
+                    <Typography color="text.secondary" fontSize="0.875rem">
+                      No specific clusters defined
+                    </Typography>
+                  )}
+                </Box>
+                <Box>
+                  <Typography variant="body2" color="text.secondary">
+                    Workload
+                  </Typography>
+                  <Typography>{policy.workload}</Typography>
+                </Box>
+                <Box>
+                  <Typography variant="body2" color="text.secondary">
+                    Status
+                  </Typography>
+                  <Chip
+                    label={policy.status}
+                    size="small"
+                    color={policy.status === "Active" ? "success" : "error"}
+                    sx={{ mt: 0.5 }}
+                  />
+                </Box>
+              </Box>
+            </Paper>
+          </Grid>
+          <Grid item xs={12} md={8}>
+            <Paper sx={{ p: 2, height: "100%" }}>
+              <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
+                YAML Configuration
+              </Typography>
+              <Box sx={{ mt: 2, border: 1, borderColor: "divider" }}>
+                <Editor
+                  height="400px"
+                  language="yaml"
+                  value={policy.yaml}
+                  theme="vs-dark"
+                  options={{
+                    readOnly: true,
+                    minimap: { enabled: false },
+                    fontSize: 14,
+                    lineNumbers: "on",
+                    scrollBeyondLastLine: false,
+                    automaticLayout: true,
+                  }}
+                />
+              </Box>
+            </Paper>
+          </Grid>
+        </Grid>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default PolicyDetailDialog;

--- a/src/components/CreateBindingPolicyDialog.tsx
+++ b/src/components/CreateBindingPolicyDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Editor from "@monaco-editor/react";
 import yaml from "js-yaml";
 import {
@@ -19,6 +19,7 @@ import {
 interface PolicyData {
   name: string;
   workload: string;
+  yaml: string;
 }
 
 interface CreateBindingPolicyDialogProps {
@@ -153,12 +154,28 @@ spec:
       onCreatePolicy({
         name: policyName,
         workload: "default-workload",
+        yaml: content,
       });
+      // Reset form after successful creation
+      setEditorContent(defaultYamlTemplate);
+      setPolicyName("");
+      setSelectedFile(null);
+      setFileContent("");
       onClose();
     } catch (error) {
       console.error("Error creating binding policy:", error);
     }
   };
+
+  // Reset form when dialog is opened
+  useEffect(() => {
+    if (open) {
+      setEditorContent(defaultYamlTemplate);
+      setPolicyName("");
+      setSelectedFile(null);
+      setFileContent("");
+    }
+  }, [open]);
 
   const handleCancelClick = () => {
     // Only show confirmation if there's content

--- a/src/types/bindingPolicy.ts
+++ b/src/types/bindingPolicy.ts
@@ -3,7 +3,10 @@ export interface BindingPolicyInfo {
     clusters: number;
     workload: string;
     creationDate: string;
+    lastModifiedDate?: string;
+    bindingMode?: string;
     status: "Active" | "Inactive";
+    yaml: string;
 }
 
 export interface ManagedCluster {


### PR DESCRIPTION
### Description
This PR enhances the Binding Policy(UI) feature by adding the ability to edit policy details, a warning for unsaved changes, and a detailed policy view.

### Related Issue
Partially addresses: #54 

### Changes Made
- Users can now modify binding policy details, ensuring flexibility in configuration management.
- Implemented a dialog system that alerts users about unsaved changes before leaving the page.
- Clicking on a policy name now navigates to a dedicated details page.
- Displays important metadata, including (Applied Clusters name, Last Modified Date, Binding Mode, Status, Workloads)

### Checklist
Please ensure the following before submitting your PR:
- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

