### PR TITLE
Created Import pop-up table and opens on Import Cluster button

### DIFF
--- a/src/components/ClustersTable.tsx
+++ b/src/components/ClustersTable.tsx
@@ -20,6 +20,8 @@ import {
 } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import useTheme from "../hooks/useTheme";
+import {Plus} from "lucide-react";
+import CreateOptions from "./ImportClusters";
 
 interface ManagedClusterInfo {
   name: string;
@@ -43,11 +45,12 @@ const ClustersTable: React.FC<ClustersTableProps> = ({
   onPageChange,
 }) => {
   const [query, setQuery] = useState("");
-  const [filteredClusters, setFilteredClusters] =
-    useState<ManagedClusterInfo[]>(clusters);
+  const [filteredClusters, setFilteredClusters] = useState<ManagedClusterInfo[]>(clusters);
   const [filter, setFilter] = useState<string>("");
   const [selectAll, setSelectAll] = useState(false);
   const [selectedClusters, setSelectedClusters] = useState<string[]>([]);
+  const [showCreateOptions, setShowCreateOptions] = useState(false);
+  const [activeOption, setActiveOption] = useState<string | null>("option1");
   const { theme } = useTheme();
 
   useEffect(() => {
@@ -120,6 +123,10 @@ const ClustersTable: React.FC<ClustersTableProps> = ({
     setSelectAll(!selectAll);
   };
 
+  const handleCancel = () => {
+    setShowCreateOptions(false);
+  };
+
   return (
     <div className="p-4">
       {/* Search, Filter, and Buttons */}
@@ -182,11 +189,34 @@ const ClustersTable: React.FC<ClustersTableProps> = ({
             <MenuItem value="active">Active</MenuItem>
             <MenuItem value="inactive">Inactive</MenuItem>
             <MenuItem value="pending">Pending</MenuItem>
-          </Select>013
+          </Select>
         </FormControl>
 
         <div className="flex gap-2">
-          <Button variant="outlined">Import Cluster</Button>
+          <Button
+            variant="outlined"
+            startIcon={<Plus size={20} />}
+            onClick={() => {
+              setShowCreateOptions(true);
+              setActiveOption("option1");
+            }}
+            sx={{
+              borderColor: theme === "dark" ? "white" : "blue", // White border in dark mode
+              color: theme === "dark" ? "white" : "blue", // White text in dark mode
+              "&:hover": {
+                borderColor: theme === "dark" ? "white" : "blue", // Keep white border on hover in dark mode
+              },
+            }}
+          >
+            Import Cluster
+          </Button>
+          {showCreateOptions && (
+            <CreateOptions
+              activeOption={activeOption}
+              setActiveOption={setActiveOption}
+              onCancel={handleCancel}
+            />
+          )}
         </div>
       </div>
 
@@ -218,7 +248,7 @@ const ClustersTable: React.FC<ClustersTableProps> = ({
                   <TableCell>{cluster.name}</TableCell>
                   <TableCell>
                     {cluster.labels &&
-                    Object.keys(cluster.labels).length > 0 ? (
+                      Object.keys(cluster.labels).length > 0 ? (
                       <div className="flex flex-wrap gap-2">
                         {Object.entries(cluster.labels).map(([key, value]) => (
                           <span

--- a/src/components/ClustersTable.tsx
+++ b/src/components/ClustersTable.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useCallback } from "react";
-import { useNavigate } from "react-router-dom";
 import {
   Badge,
   Button,
@@ -104,12 +103,6 @@ const ClustersTable: React.FC<ClustersTableProps> = ({
     setFilter(event.target.value as string);
   };
 
-  const navigate = useNavigate();
-
-  const navigateToCreateCluster = () => {
-    navigate("/createcluster"); // Navigate to the page
-  };
-
   const handleCheckboxChange = (clusterName: string) => {
     setSelectedClusters((prev) =>
       prev.includes(clusterName)
@@ -189,13 +182,10 @@ const ClustersTable: React.FC<ClustersTableProps> = ({
             <MenuItem value="active">Active</MenuItem>
             <MenuItem value="inactive">Inactive</MenuItem>
             <MenuItem value="pending">Pending</MenuItem>
-          </Select>
+          </Select>013
         </FormControl>
 
         <div className="flex gap-2">
-          <Button variant="contained" onClick={navigateToCreateCluster}>
-            Create Cluster
-          </Button>
           <Button variant="outlined">Import Cluster</Button>
         </div>
       </div>

--- a/src/components/ImportClusters.tsx
+++ b/src/components/ImportClusters.tsx
@@ -1,0 +1,292 @@
+import { useState } from "react";
+import Editor from "@monaco-editor/react";
+import { ThemeContext } from "../context/ThemeContext"; 
+import { useContext } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogActions,
+  Button,
+  Tabs,
+  Tab,
+  Box,
+  Alert,
+  AlertTitle,
+  TextField,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+} from "@mui/material";
+
+interface Props {
+  activeOption: string | null;
+  setActiveOption: (option: string | null) => void;
+  // setHasUnsavedChanges: (value: boolean) => void;
+  onCancel: () => void;
+}
+
+const ImportClusters = ({
+  activeOption,
+  setActiveOption,
+  // setHasUnsavedChanges,
+  onCancel,
+}: Props) => {
+  const [fileType, setFileType] = useState<"yaml" | "json">("yaml");
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
+  const [editorContent, setEditorContent] = useState<string>("");
+  const [error, setError] = useState<string>("");
+  //const [loading, setLoading] = useState(false);
+  const { theme } = useContext(ThemeContext);
+
+  const [formData, setFormData] = useState({
+    clusterName: "",
+    Region: "",
+    value: "",
+  });
+
+  const handleFileUpload = async () => {
+  };
+  
+  console.log(error);  
+
+  const handleCancel = () => {
+    setSelectedFile(null); // Clear file selection
+    setError("");          // Clear error messages
+    setActiveOption(null);  // Close the modal
+  };
+  
+
+  return (
+    <Dialog  open={!!activeOption} onClose={onCancel} maxWidth="lg" fullWidth>
+      <DialogTitle sx={{color: theme === "dark" ? "white" : "black" , bgcolor: theme === "dark" ? "#1F2937" : "background.paper"}}>Create Deployment</DialogTitle>
+      <DialogContent sx={{ bgcolor: theme === "dark" ? "#1F2937" : "background.paper"}} >
+        <Box sx={{ width: "100%"}}>
+          <Tabs
+            value={activeOption}
+            onChange={(_event, newValue) => setActiveOption(newValue)}
+          >
+            <Tab sx={{color: theme === "dark" ? "white" : "black"}} label="YAML paste" value="option1" />
+            <Tab sx={{color: theme === "dark" ? "white" : "black"}} label="Kubeconfig" value="option2" />
+            <Tab sx={{color: theme === "dark" ? "white" : "black"}} label="API/URL" value="option3" />
+            <Tab sx={{color: theme === "dark" ? "white" : "black"}} label="Manual" value="option4" />
+          </Tabs>
+
+          <Box 
+          sx={{ 
+            mt: 2 ,
+          }}
+          >
+            {activeOption === "option1" && (
+              <Box>
+                <Alert severity="info" sx={{ mb: 2 }}>
+                  <AlertTitle>Info</AlertTitle>
+                  Paste a YAML file.
+                </Alert>
+
+                <FormControl
+                      fullWidth
+                      sx={{
+                        mb: 2,
+                        input: { color: theme === "dark" ? "white" : "black" },
+                        label: { color: theme === "dark" ? "white" : "black" },
+                        fieldset: {
+                          borderColor: theme === "dark" ? "white" : "black",
+                        },
+                        "& .MuiInputLabel-root.Mui-focused": {
+                          color: theme === "dark" ? "white" : "black",
+                        },
+                      }}
+                    >
+                      <InputLabel>File Type</InputLabel>
+                      <Select
+                        sx={{
+                          bgcolor: theme === "dark" ? "#1F2937" : "background.paper",
+                          color: theme === "dark" ? "white" : "black",
+                        }}
+                        value={fileType}
+                        onChange={(e) => {
+                          setFileType(e.target.value as "yaml" | "json");
+                          setEditorContent(""); // Clear the editor content on file type change
+                        }}
+                        label="File Type"
+                        MenuProps={{
+                          PaperProps: {
+                            sx: {
+                              bgcolor: theme === "dark" ? "#1F2937" : "background.paper",
+                            },
+                          },
+                        }}
+                      >
+                        <MenuItem sx={{ color: theme === "dark" ? "white" : "black" }} value="yaml">
+                          YAML
+                        </MenuItem>
+                      </Select>
+                </FormControl>
+
+
+                <Editor
+                    height="400px"
+                    language={fileType}
+                    value={editorContent}
+                    theme={theme === "dark" ? "light" : "vs-dark"} // Switch themes dynamically
+                    options={{
+                      minimap: { enabled: false },
+                      fontSize: 14,
+                      lineNumbers: "on",
+                      scrollBeyondLastLine: false,
+                      automaticLayout: true,
+                    }}
+                    onChange={(value) => setEditorContent(value || "")}
+                  />
+
+                <DialogActions>
+                  <Button onClick={handleCancel}>Cancel</Button>
+                  <Button
+                    variant="contained"
+                    disabled={!editorContent}
+                  >
+                    Upload
+                  </Button>
+                </DialogActions>
+
+              </Box>
+            )}
+
+            {activeOption === "option2" && (
+              <Box sx={{color: theme === "dark" ? "white" : "black"}}>
+                <Alert severity="info" sx={{ mb: 2 }}>
+                  <AlertTitle>Info</AlertTitle>
+                  Select a YAML or JSON file specifying the resources to deploy to
+                  the currently selected namespace.
+                </Alert>
+
+                <Box
+                  sx={{
+                    border: 2,
+                    borderColor: "grey.500",
+                    borderRadius: 1,
+                    p: 2,
+                    textAlign: "center",
+                  }}
+                >
+                  <Button variant="contained" component="label">
+                    Choose YAML or JSON file
+                    <input
+                      type="file"
+                      hidden
+                      accept=".yaml,.yml,.json"
+                      onClick={(e) => (e.currentTarget.value = "")} // Ensure new file selection triggers event
+                      onChange={(e) => {
+                        const file = e.target.files?.[0] || null;
+                        setSelectedFile(file);
+                        // setHasUnsavedChanges(true);
+                      }}
+                    />
+                  </Button>
+
+                  {selectedFile && (
+                    <Box sx={{ mt: 2 }}>
+                      Selected file: <strong>{selectedFile.name}</strong>
+                    </Box>
+                  )}
+                </Box>
+
+                <DialogActions>
+                  <Button onClick={handleCancel}>Cancel</Button>
+                  <Button
+                    variant="contained"
+                    onClick={handleFileUpload}
+                    disabled={!selectedFile}
+                  >
+                    Upload & Deploy
+                  </Button>
+                </DialogActions>
+              </Box>
+            )}
+            {activeOption === "option3" && (
+              <Box
+                className={theme === "dark" ? "bg-gray-800 text-white" : "text-black"}
+                p={2}
+                borderRadius={2}
+              >
+                <Alert severity="info" sx={{ mb: 2 }}>
+                  <AlertTitle>Info</AlertTitle>
+                  Not Developed Full.
+                </Alert>
+
+                <TextField
+                  fullWidth
+                  label="App Name"
+                  value={formData.clusterName}
+                  onChange={(e) =>
+                    setFormData({ ...formData, clusterName: e.target.value })
+                  }
+                  sx={{
+                    mb: 2,
+                    input: { color: theme === "dark" ? "white" : "black" },
+                    label: { color: theme === "dark" ? "white" : "black" },
+                    fieldset: {
+                      borderColor: theme === "dark" ? "white" : "black",
+                    },
+                    "& .MuiInputLabel-root.Mui-focused": {
+                      color: theme === "dark" ? "white" : "black",
+                    },
+                  }}
+                />
+
+
+                <TextField
+                  fullWidth
+                  label="Container Image"
+                  value={formData.Region}
+                  onChange={(e) =>
+                    setFormData({ ...formData, Region: e.target.value })
+                  }
+                  sx={{
+                    mb: 2,
+                    input: { color: theme === "dark" ? "white" : "black" },
+                    label: { color: theme === "dark" ? "white" : "black" },
+                    fieldset: {
+                      borderColor: theme === "dark" ? "white" : "black",
+                    },
+                    "& .MuiInputLabel-root.Mui-focused": {
+                      color: theme === "dark" ? "white" : "black",
+                    },
+                  }}
+                />
+
+                <DialogActions>
+                  <Button onClick={handleCancel} sx={{ color: theme === "dark" ? "white" : "black" }}>
+                    Cancel
+                  </Button>
+                  <Button
+                    variant="contained"
+                    onClick={() => setShowAdvancedOptions(!showAdvancedOptions)}
+                  >
+                    {showAdvancedOptions ? "Hide Advanced Options" : "Show Advanced Options"}
+                  </Button>
+                  <Button variant="contained">Deploy</Button>
+                </DialogActions>
+              </Box>
+            )}
+            {activeOption === "option4" && (
+              <Box className={theme === "dark" ? "bg-gray-800 text-white" : "text-black"} p={2} borderRadius={2}>
+                <Alert severity="info" sx={{ mb: 2 }}>
+                  <AlertTitle>Info</AlertTitle>
+                  Fill out the form to create a deployment.
+                </Alert>
+
+              </Box>
+            )}
+
+          </Box>
+        </Box>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ImportClusters;

--- a/src/components/menu/data.ts
+++ b/src/components/menu/data.ts
@@ -1,7 +1,6 @@
 import {
   HiOutlineHome,
   HiOutlineUser,
-  HiOutlineCube,
   HiOutlineClipboardDocumentList,
   HiOutlinePresentationChartBar,
   HiOutlineServer,
@@ -26,13 +25,7 @@ export const menu = [
         isLink: true,
         url: '/its',
         icon: HiOutlineServer,
-        label: 'Overview',
-      },
-      {
-        isLink: true,
-        url: '/createcluster',
-        icon: HiOutlineCube,
-        label: 'Onboard',
+        label: 'Manage',
       },
     ],
   },


### PR DESCRIPTION
### Description
<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->
Created a pop-up table `ImportClusters.tsx` to import clusters that opens on the Import Cluster button when clicked. I used the `CreateOptions.tsx` file as a base for the pop-up table. I tailored it as much as I can while keeping the table working.

### Changes Made
<!-- Provide a detailed list of changes made in this PR. -->
- [ ] Created import pop-up table `ImportClusters.tsx`
- [ ] Have Import Cluster button on `ClustersTable` to open to `ImportClusters.tsx`
- [ ] Edited table

### Checklist
Please ensure the following before submitting your PR:
- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)
<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->
![Screenshot 2025-02-18 180820](https://github.com/user-attachments/assets/ec80f81d-cdfe-4cd6-b449-585820d20a64)
![Screenshot 2025-02-18 180903](https://github.com/user-attachments/assets/6624e8f9-cb39-465d-bff8-3c729888a0a2)
![Screenshot 2025-02-18 180929](https://github.com/user-attachments/assets/6bc33196-59ac-44bf-b110-4c4ced8f4d0f)
![Screenshot 2025-02-18 180944](https://github.com/user-attachments/assets/eb236387-076e-4ede-a9fe-065de3c9fbe1)


### Additional Notes
<!-- Add any other context, suggestions, or questions related to this PR. -->
Still need to fix up the tabs. Rename the Yaml paste tab to a relevant import option. Add in API/URL textbox and form for manual import. Need to check if the upload file is working on Kubeconfig. And keep tailoring this table.