### PR TITLE
Added inside box element in Kubeconfig pop-up tab, and added drop shadows to buttons

### DIFF
--- a/src/components/ImportClusters.tsx
+++ b/src/components/ImportClusters.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import Editor from "@monaco-editor/react";
-import { ThemeContext } from "../context/ThemeContext"; 
+import { ThemeContext } from "../context/ThemeContext";
 import { useContext } from "react";
 import {
   Dialog,
@@ -48,35 +48,35 @@ const ImportClusters = ({
 
   const handleFileUpload = async () => {
   };
-  
-  console.log(error);  
+
+  console.log(error);
 
   const handleCancel = () => {
     setSelectedFile(null); // Clear file selection
     setError("");          // Clear error messages
     setActiveOption(null);  // Close the modal
   };
-  
+
 
   return (
-    <Dialog  open={!!activeOption} onClose={onCancel} maxWidth="lg" fullWidth>
-      <DialogTitle sx={{color: theme === "dark" ? "white" : "black" , bgcolor: theme === "dark" ? "#1F2937" : "background.paper"}}>Import Cluster</DialogTitle>
-      <DialogContent sx={{ bgcolor: theme === "dark" ? "#1F2937" : "background.paper"}} >
-        <Box sx={{ width: "100%"}}>
+    <Dialog open={!!activeOption} onClose={onCancel} maxWidth="lg" fullWidth>
+      <DialogTitle sx={{ color: theme === "dark" ? "white" : "black", bgcolor: theme === "dark" ? "#1F2937" : "background.paper" }}>Import Cluster</DialogTitle>
+      <DialogContent sx={{ bgcolor: theme === "dark" ? "#1F2937" : "background.paper" }} >
+        <Box sx={{ width: "100%" }}>
           <Tabs
             value={activeOption}
             onChange={(_event, newValue) => setActiveOption(newValue)}
           >
-            <Tab sx={{color: theme === "dark" ? "white" : "black"}} label="YAML paste" value="option1" />
-            <Tab sx={{color: theme === "dark" ? "white" : "black"}} label="Kubeconfig" value="option2" />
-            <Tab sx={{color: theme === "dark" ? "white" : "black"}} label="API/URL" value="option3" />
-            <Tab sx={{color: theme === "dark" ? "white" : "black"}} label="Manual" value="option4" />
+            <Tab sx={{ color: theme === "dark" ? "white" : "black" }} label="YAML paste" value="option1" />
+            <Tab sx={{ color: theme === "dark" ? "white" : "black" }} label="Kubeconfig" value="option2" />
+            <Tab sx={{ color: theme === "dark" ? "white" : "black" }} label="API/URL" value="option3" />
+            <Tab sx={{ color: theme === "dark" ? "white" : "black" }} label="Manual" value="option4" />
           </Tabs>
 
-          <Box 
-          sx={{ 
-            mt: 2 ,
-          }}
+          <Box
+            sx={{
+              mt: 2,
+            }}
           >
             {activeOption === "option1" && (
               <Box>
@@ -86,60 +86,60 @@ const ImportClusters = ({
                 </Alert>
 
                 <FormControl
-                      fullWidth
-                      sx={{
-                        mb: 2,
-                        input: { color: theme === "dark" ? "white" : "black" },
-                        label: { color: theme === "dark" ? "white" : "black" },
-                        fieldset: {
-                          borderColor: theme === "dark" ? "white" : "black",
-                        },
-                        "& .MuiInputLabel-root.Mui-focused": {
-                          color: theme === "dark" ? "white" : "black",
-                        },
-                      }}
-                    >
-                      <InputLabel>File Type</InputLabel>
-                      <Select
-                        sx={{
+                  fullWidth
+                  sx={{
+                    mb: 2,
+                    input: { color: theme === "dark" ? "white" : "black" },
+                    label: { color: theme === "dark" ? "white" : "black" },
+                    fieldset: {
+                      borderColor: theme === "dark" ? "white" : "black",
+                    },
+                    "& .MuiInputLabel-root.Mui-focused": {
+                      color: theme === "dark" ? "white" : "black",
+                    },
+                  }}
+                >
+                  <InputLabel>File Type</InputLabel>
+                  <Select
+                    sx={{
+                      bgcolor: theme === "dark" ? "#1F2937" : "background.paper",
+                      color: theme === "dark" ? "white" : "black",
+                    }}
+                    value={fileType}
+                    onChange={(e) => {
+                      setFileType(e.target.value as "yaml");
+                      setEditorContent(""); // Clear the editor content on file type change
+                    }}
+                    label="File Type"
+                    MenuProps={{
+                      PaperProps: {
+                        sx: {
                           bgcolor: theme === "dark" ? "#1F2937" : "background.paper",
-                          color: theme === "dark" ? "white" : "black",
-                        }}
-                        value={fileType}
-                        onChange={(e) => {
-                          setFileType(e.target.value as "yaml");
-                          setEditorContent(""); // Clear the editor content on file type change
-                        }}
-                        label="File Type"
-                        MenuProps={{
-                          PaperProps: {
-                            sx: {
-                              bgcolor: theme === "dark" ? "#1F2937" : "background.paper",
-                            },
-                          },
-                        }}
-                      >
-                        <MenuItem sx={{ color: theme === "dark" ? "white" : "black" }} value="yaml">
-                          YAML
-                        </MenuItem>
-                      </Select>
+                        },
+                      },
+                    }}
+                  >
+                    <MenuItem sx={{ color: theme === "dark" ? "white" : "black" }} value="yaml">
+                      YAML
+                    </MenuItem>
+                  </Select>
                 </FormControl>
 
 
                 <Editor
-                    height="400px"
-                    language={fileType}
-                    value={editorContent}
-                    theme={theme === "dark" ? "light" : "vs-dark"} // Switch themes dynamically
-                    options={{
-                      minimap: { enabled: false },
-                      fontSize: 14,
-                      lineNumbers: "on",
-                      scrollBeyondLastLine: false,
-                      automaticLayout: true,
-                    }}
-                    onChange={(value) => setEditorContent(value || "")}
-                  />
+                  height="400px"
+                  language={fileType}
+                  value={editorContent}
+                  theme={theme === "dark" ? "light" : "vs-dark"} // Switch themes dynamically
+                  options={{
+                    minimap: { enabled: false },
+                    fontSize: 14,
+                    lineNumbers: "on",
+                    scrollBeyondLastLine: false,
+                    automaticLayout: true,
+                  }}
+                  onChange={(value) => setEditorContent(value || "")}
+                />
 
                 <DialogActions>
                   <Button onClick={handleCancel}>Cancel</Button>
@@ -155,22 +155,25 @@ const ImportClusters = ({
             )}
 
             {activeOption === "option2" && (
-              <Box sx={{color: theme === "dark" ? "white" : "black"}}>
+              <Box sx={{ color: theme === "dark" ? "white" : "black" }}>
                 <Alert severity="info" sx={{ mb: 2 }}>
                   <AlertTitle>Info</AlertTitle>
                   Select a kubeconfig file to import cluster.
                 </Alert>
 
+              <Box sx={{ mt: 2, border: 2, borderColor: "grey.500", borderRadius: 1, p: 2}}>
                 <Box
                   sx={{
                     border: 2,
                     borderColor: "grey.500",
+                    bgcolor: "#f5f5f5",
                     borderRadius: 1,
                     p: 2,
                     textAlign: "center",
                   }}
                 >
-                  <Button variant="contained" component="label">
+                  <Button variant="contained" component="label"
+                    sx={{boxShadow: 2}}>
                     Select Kubeconfig file
                     <input
                       type="file"
@@ -184,7 +187,7 @@ const ImportClusters = ({
                       }}
                     />
                   </Button>
-
+                  </Box>
                   {selectedFile && (
                     <Box sx={{ mt: 2 }}>
                       Selected file: <strong>{selectedFile.name}</strong>
@@ -198,6 +201,7 @@ const ImportClusters = ({
                     variant="contained"
                     onClick={handleFileUpload}
                     disabled={!selectedFile}
+                    sx={{ boxShadow: 2 }}
                   >
                     Upload & Import
                   </Button>


### PR DESCRIPTION
### Description
<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->
Added an inside box element around the Select Kubeconfig file, along with putting a background color to make it contrast against the button and white background color. I also added drop shadows to all the buttons in the Kubeconfig and API/URL tabs.

### Changes Made
<!-- Provide a detailed list of changes made in this PR. -->
- [ ] Added box element around Select Kubeconfig file button
- [ ] Added background to the new box element for contrast
- [ ] Added dropshadows to all buttons in the Kubeconfig and API/URL tabs

### Checklist
Please ensure the following before submitting your PR:
- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)
<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->
![image](https://github.com/user-attachments/assets/2c6ba60e-8088-4854-86a5-bc7b54a7cb46)
![image](https://github.com/user-attachments/assets/78af830c-9653-4ec5-ad73-a969d4c175f7)


### Additional Notes
<!-- Add any other context, suggestions, or questions related to this PR. -->
Should I get rid of the border on the inside box with the gray background color?

I'll also be adding drop shadows to the buttons in the other tabs.