### PR TITLE
Update Go version in Dockerfile to 1.23

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the backend
-FROM golang:1.22.3 AS backend-builder
+FROM golang:1.23 AS backend-builder
 
 # Set the working directory
 WORKDIR /app


### PR DESCRIPTION
Upgrade the Go version in the Dockerfile to ensure compatibility with the latest features and improvements.

Fixes #229
