### PR TITLE
 Ensure Cluster Name Label is Fully Visible on Focus

### DIFF
--- a/src/components/ImportClusters.tsx
+++ b/src/components/ImportClusters.tsx
@@ -145,8 +145,11 @@ const ImportClusters = ({ activeOption, setActiveOption, onCancel }: Props) => {
     borderColor: 'divider',
     borderRadius: 1,
     p: 3,
+    overflowY: 'auto',  // Scroll in the right place
+    flexGrow: 1,        //Ensures proper height
+    minHeight: 0,       //Prevents flexbox shrinking issues
     bgcolor: theme === 'dark' ? 'rgba(255, 255, 255, 0.03)' : 'rgba(0, 0, 0, 0.02)',
-  };
+  };  
 
   const formContentStyles = {
     display: 'flex',
@@ -450,9 +453,10 @@ const ImportClusters = ({ activeOption, setActiveOption, onCancel }: Props) => {
                   <Box
                     sx={{
                       flex: 1,
-                      overflow: 'auto',
                       display: 'flex',
                       flexDirection: 'column',
+                      overflow: 'visible', //Prevents label cutting
+                      minHeight: 0,        //Ensures proper flex behavior
                     }}
                   >
                     <Box sx={formContentStyles}>

--- a/src/components/ImportClusters.tsx
+++ b/src/components/ImportClusters.tsx
@@ -149,7 +149,7 @@ const ImportClusters = ({ activeOption, setActiveOption, onCancel }: Props) => {
     flexGrow: 1,        //Ensures proper height
     minHeight: 0,       //Prevents flexbox shrinking issues
     bgcolor: theme === 'dark' ? 'rgba(255, 255, 255, 0.03)' : 'rgba(0, 0, 0, 0.02)',
-  };  
+  };
 
   const formContentStyles = {
     display: 'flex',


### PR DESCRIPTION
## Description  
This PR fixes an issue where the **"Cluster Name"** label was getting partially hidden when the input field was focused.  
The fix involves adjusting the **flex and overflow properties** to ensure the label remains fully visible.  

## Related Issue  
Fixes #238

## Changes Made  
- ✅ Added `overflow: 'visible'` to prevent label clipping.  
- ✅ Moved `overflowY: 'auto'` to `tabContentStyles` for correct scrolling behavior.  
- ✅ Ensured `flexGrow: 1` and `minHeight: 0` to prevent shrinking issues.  

## Checklist  
- [x] I have reviewed the project's contribution guidelines.  
- [x] I have tested the changes locally and ensured they work as expected.  
- [x] My code follows the project's coding standards.  

## Screenshots 
**Before (Issue Present)**  
![Screenshot from 2025-02-25 19-08-49](https://github.com/user-attachments/assets/8dd68cef-8fbf-45c5-9189-e7ed83ec6ed0)



**After (Fixed)**  
![Screenshot from 2025-02-25 19-09-38](https://github.com/user-attachments/assets/eced2110-1ccb-4378-aa20-e57af78a4288)


## Additional Notes  
- This fix was tested with multiple input fields to ensure no regressions.  
- If there are any additional UI changes required, let me know! 🚀  
