### PR TITLE
Fixed the issue of duplicate routes of binding policy

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/katamyra/kubestellarUI/api"
 	"github.com/katamyra/kubestellarUI/redis"
-	"github.com/katamyra/kubestellarUI/wds/bp"
 	"go.uber.org/zap"
 )
 
@@ -99,11 +98,6 @@ func main() {
 
 	router.POST("api/deploy", api.DeployHandler)
 	router.POST("api/webhook", api.GitHubWebhookHandler)
-
-	router.GET("/api/bp", bp.GetAllBp)
-	router.GET("/api/bp/status", bp.GetBpStatus)
-	router.DELETE("/api/bp/delete/:name", bp.DeleteBp)
-	router.DELETE("/api/bp/delete", bp.DeleteAllBp)
 
 	if err := router.Run(":4000"); err != nil {
 		log.Fatalf("Failed to start server: %v", err)

--- a/backend/routes/bp.go
+++ b/backend/routes/bp.go
@@ -6,6 +6,8 @@ import (
 )
 
 func setupBlueprintRoutes(router *gin.Engine) {
+	router.GET("/api/bp", bp.GetAllBp)
+	router.GET("/api/bp/status", bp.GetBpStatus)
 	router.POST("/api/bp/create", bp.CreateBp)
 	router.DELETE("/api/bp/delete/:name", bp.DeleteBp)
 	router.DELETE("/api/bp/delete", bp.DeleteAllBp)


### PR DESCRIPTION
### Description
The Binding Policy routes was defined twice in main.go and in the routes/bp.go


### Changes Made
- Remove the duplication of the routes. Moved all the binding policy routes to routes/bp.go


### Checklist
Please ensure the following before submitting your PR:
- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

