### PR TITLE
feat: added update service and updated the get/list routes response

### DIFF
--- a/backend/routes/services.go
+++ b/backend/routes/services.go
@@ -9,5 +9,6 @@ func setupServiceRoutes(router *gin.Engine) {
 	router.GET("/api/services/:namespace", resources.GetServiceList)
 	router.GET("/api/services/:namespace/:name", resources.GetServiceByServiceName)
 	router.POST("/api/services/create", resources.CreateService)
+	router.PUT("/api/services/update", resources.UpdateService)
 	router.DELETE("/api/services/delete", resources.DeleteService)
 }

--- a/backend/wds/deployment/common.go
+++ b/backend/wds/deployment/common.go
@@ -323,7 +323,6 @@ func UpdateDeployment(ctx *gin.Context) {
 		deployment.Spec.Replicas = int32Ptr(params.Replicas)
 	}
 
-	// Fix: Use the correct namespace instead of "default"
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		_, updateErr := clientset.AppsV1().Deployments(params.Namespace).Update(context.TODO(), deployment, metav1.UpdateOptions{})
 		return updateErr


### PR DESCRIPTION
I have this in my backlog now its done 

```json
        {
            "metadata": {
                "name": "my-service",
                "namespace": "default",
                "uid": "260101f1-079a-4eaa-a83d-d15d92822dfb",
                "resourceVersion": "23210",
                "creationTimestamp": "2025-03-02T01:56:07+05:30",
                "labels": {
                    "app": "my-app",
                    "environment": "production",
                    "tier": "frontend"
                },
                "annotations": {
                    "prometheus.io/port": "9114",
                    "prometheus.io/scrape": "true",
                    "service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http",
                    "service.beta.kubernetes.io/aws-load-balancer-ssl-cert": "arn:aws:acm:us-west-2:123456789012:certificate/abc123-example",
                    "service.beta.kubernetes.io/aws-load-balancer-ssl-ports": "https"
                },
                "managedFields": [
                    {
                        "manager": "main",
                        "operation": "Update",
                        "apiVersion": "v1",
                        "time": "2025-03-02T02:03:48+05:30",
                        "fieldsType": "FieldsV1"
                    }
                ]
            },
            "status": {
                "loadBalancer": {}
            },
            "spec": {
                "ports": [
                    {
                        "name": "http",
                        "protocol": "TCP",
                        "port": 80,
                        "targetPort": 8080,
                        "nodePort": 32095
                    },
                    {
                        "name": "https",
                        "protocol": "TCP",
                        "port": 443,
                        "targetPort": 8443,
                        "nodePort": 32139
                    }
                ],
                "selector": {
                    "app": "my-app",
                    "version": "v2"
                },
                "clusterIP": "10.99.64.65",
                "clusterIPs": [
                    "10.99.64.65"
                ],
                "type": "LoadBalancer",
                "sessionAffinity": "None",
                "externalTrafficPolicy": "Cluster",
                "ipFamilies": [
                    "IPv4"
                ],
                "ipFamilyPolicy": "SingleStack",
                "allocateLoadBalancerNodePorts": true,
                "internalTrafficPolicy": "Cluster"
            }
        }

``` 