### PR TITLE
Generate command API for ITS manual way

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,3 +6,4 @@ POSTGRES_USER=admin
 POSTGRES_PASSWORD=password
 POSTGRES_DB=jwt_db
 JWT_SECRET=<your-token>
+HOST=<your host>

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,111 @@
+[![Go Report Card](https://goreportcard.com/badge/github.com/kubestellar/kubeflex)](https://goreportcard.com/report/github.com/kubestellar/kubeflex)
+[![GitHub release](https://img.shields.io/github/release/kubestellar/kubeflex/all.svg?style=flat-square)](https://github.com/kubestellar/kubeflex/releases)
+[![CI](https://github.com/kubestellar/kubeflex/actions/workflows/ci.yaml/badge.svg)](https://github.com/kubestellar/kubeflex/actions/workflows/ci.yaml)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=kubestellar_kubeflex&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=kubestellar_kubeflex)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=kubestellar_kubeflex&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=kubestellar_kubeflex)
+
+# <img alt="Logo" width="90px" src="./docs/images/kubeflex-logo.png" style="vertical-align: middle;" />  KubeFlex
+
+A flexible and scalable platform for running Kubernetes control plane APIs.
+
+## Goals
+
+- Provide lightweight Kube API Server instances and selected controllers as a service.
+- Provide a flexible architecture for the storage backend, e.g.:
+    - shared DB for API servers,
+    - dedicated DB for each API server,
+    - etcd DB or Kine + Postgres DB
+- Flexibility in choice of API Server build:
+    - upstream Kube (e.g. `registry.k8s.io/kube-apiserver:v1.27.1`),
+    - trimmed down API Server builds (e.g. [multicluster control plane](https://github.com/open-cluster-management-io/multicluster-controlplane))
+- Single binary CLI for improved user experience:
+    - initialize, install operator, manage lifecycle of control planes and contexts.
+
+## Installation
+
+[kind](https://kind.sigs.k8s.io) and [kubectl](https://kubernetes.io/docs/tasks/tools/) are
+required. A kind hosting cluster is created automatically by the kubeflex CLI. You may
+also install KubeFlex on other Kube distros, as long as they support an nginx ingress
+with SSL passthru, or on OpenShift. See the [User's Guide](docs/users.md) for more details.
+
+Download the latest kubeflex CLI binary release for your OS/Architecture from the
+[release page](https://github.com/kubestellar/kubeflex/releases) and copy it
+to `/usr/local/bin` using the following command:
+
+```shell
+sudo su <<EOF
+bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubeflex/main/scripts/install-kubeflex.sh) --ensure-folder /usr/local/bin --strip-bin
+EOF
+```
+
+If you have [Homebrew](https://brew.sh), use the following commands to install kubeflex:
+
+```shell
+brew tap kubestellar/kubeflex https://github.com/kubestellar/kubeflex
+brew install kubeflex
+```
+
+To upgrade the kubeflex CLI to the latest release, you may run:
+
+```shell
+brew upgrade kubeflex
+```
+
+## Quickstart
+
+Create the hosting kind cluster with ingress controller and install
+the kubeflex operator:
+
+```shell
+kflex init --create-kind
+```
+
+Create a control plane:
+
+```shell
+kflex create cp1
+```
+
+Interact with the new control plane, for example get namespaces and create a new one:
+
+```shell
+kubectl get ns
+kubectl create ns myns
+```
+
+Create a second control plane and check that the namespace created in the
+first control plane is not present:
+
+```shell
+kflex create cp2
+kubectl get ns
+```
+
+To go back to the hosting cluster context, use the `ctx` command:
+
+```shell
+kflex ctx
+```
+
+To switch back to a control plane context, use the
+`ctx <control plane name>` command, e.g:
+
+```shell
+kflex ctx cp1
+```
+
+To delete a control plane, use the `delete <control plane name>` command, e.g:
+
+```shell
+kflex delete cp1
+```
+
+## Next Steps
+
+Read the [User's Guide](docs/users.md) to learn more about using KubeFlex for your project
+and how to create and interact with different types of control planes, such as
+[vcluster](https://www.vcluster.com) and [Open Cluster Management](https://github.com/open-cluster-management-io/multicluster-controlplane).
+
+## Architecture
+
+![image info](./docs/images/kubeflex-high-level-arch.png)

--- a/backend/api/command.go
+++ b/backend/api/command.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+type GenerateCommandRequest struct {
+	ClusterName string `json:"clusterName" binding:"required"`
+}
+
+type GenerateCommandResponse struct {
+	ClusterName string `json:"clusterName"`
+	Token       string `json:"token"`
+	Command     string `json:"command"`
+}
+
+func GenerateCommandHandler(c *gin.Context) {
+	var req GenerateCommandRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload: " + err.Error()})
+		return
+	}
+
+	token := uuid.New().String()
+
+	host := os.Getenv("HOST")
+	if host == "" {
+		host = "http://localhost:4000"
+	}
+
+	command := fmt.Sprintf(
+		"curl -X POST %s/clusters/manual/callback -d '{\"clusterName\": \"%s\", \"token\": \"%s\"}'",
+		host, req.ClusterName, token,
+	)
+
+	response := GenerateCommandResponse{
+		ClusterName: req.ClusterName,
+		Token:       token,
+		Command:     command,
+	}
+
+	c.JSON(http.StatusOK, response)
+}

--- a/backend/routes/cluster.go
+++ b/backend/routes/cluster.go
@@ -43,6 +43,10 @@ func setupClusterRoutes(router *gin.Engine) {
 	router.POST("/clusters/onboard", api.OnboardClusterHandler)
 	router.GET("/clusters/status", api.GetClusterStatusHandler)
 	router.POST("/clusters/import", api.ImportClusterHandler)
+
+	// API for generating command
+	router.POST("/clusters/manual/generateCommand", api.GenerateCommandHandler)
+
 }
 
 func GetKubeInfo() ([]ContextInfo, []string, string, error, []ManagedClusterInfo) {


### PR DESCRIPTION
### Description  
Updated the `GenerateCommandHandler` to dynamically load the host value from an environment variable instead of using a hardcoded URL. This improves flexibility for different deployment environments.  

### Related Issue  
Fixes #286 

### Changes Made  
- [ ] Updated `GenerateCommandHandler` to read `HOST` from environment variables.  
- [ ] Added a fallback to `http://localhost:4000` if `HOST` is not set.  
- [ ] Updated `.env` usage and added support for `godotenv` to load environment variables.  

### Checklist  
- [ ] I have reviewed the project's contribution guidelines.  
- [ ] I have written unit tests for the changes (if applicable).  
- [ ] I have updated the documentation (if applicable).  
- [ ] I have tested the changes locally and ensured they work as expected.  
- [ ] My code follows the project's coding standards.  

### Screenshots or Logs (if applicable)  
N/A  

### Additional Notes  
This change ensures that the generated command includes the correct host URL, making it more adaptable to different environments.