### PR TITLE
Add support for specific workloads in binding policies

### DIFF
--- a/backend/wds/bp/handlers.go
+++ b/backend/wds/bp/handlers.go
@@ -148,8 +148,6 @@ func GetAllBp(ctx *gin.Context) {
 }
 
 // CreateBp creates a new BindingPolicy
-// CreateBp creates a new BindingPolicy
-// CreateBp creates a new BindingPolicy
 func CreateBp(ctx *gin.Context) {
 	fmt.Printf("Debug - Starting CreateBp handler\n")
 	fmt.Printf("Debug - KUBECONFIG: %s\n", os.Getenv("KUBECONFIG"))
@@ -398,7 +396,6 @@ func CreateBp(ctx *gin.Context) {
 
 	// Extract workloads from stored data
 	workloads := []string{}
-	// 1. First add the downsync workloads
 	for i, apiGroup := range storedBP.APIGroups {
 		if i < len(storedBP.Resources) {
 			// Convert resource to lowercase for consistent handling
@@ -415,8 +412,6 @@ func CreateBp(ctx *gin.Context) {
 			}
 		}
 	}
-
-	// 2. Now add the specific workloads
 	for _, workload := range storedBP.SpecificWorkloads {
 		workloadDesc := fmt.Sprintf("Specific: %s/%s", workload.APIVersion, workload.Kind)
 		if workload.Name != "" {
@@ -684,8 +679,6 @@ func GetBpStatus(ctx *gin.Context) {
 			}
 		}
 
-		// Note: We've removed the section that tried to access bp.Spec.Workloads
-		// since that field doesn't exist in the KubeStellar API
 	}
 
 	// If we still don't have clusters or workloads, try to parse the stored rawYAML if available

--- a/backend/wds/bp/utils.go
+++ b/backend/wds/bp/utils.go
@@ -58,10 +58,6 @@ func getClientForBp() (*bpv1alpha1.ControlV1alpha1Client, error) {
 }
 
 // extractWorkloads gets a list of workloads affected by this BP
-// Update the extractWorkloads function in the second file (paste-2.txt)
-// This function is responsible for getting workloads from binding policies
-
-// extractWorkloads gets a list of workloads affected by this BP
 // Now includes both downsync resources and specific workloads
 // extractWorkloads gets a list of workloads affected by this BP
 func extractWorkloads(bp *v1alpha1.BindingPolicy) []string {
@@ -103,9 +99,6 @@ func extractWorkloads(bp *v1alpha1.BindingPolicy) []string {
 			}
 		}
 	}
-
-	// Note: We've removed the section that tried to access bp.Spec.Workloads
-	// since that field doesn't exist in the KubeStellar API
 
 	fmt.Printf("Debug - extractWorkloads - Extracted %d workloads: %v\n", len(workloads), workloads)
 	return workloads

--- a/backend/wds/bp/utils.go
+++ b/backend/wds/bp/utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/katamyra/kubestellarUI/log"
 	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
@@ -57,8 +58,22 @@ func getClientForBp() (*bpv1alpha1.ControlV1alpha1Client, error) {
 }
 
 // extractWorkloads gets a list of workloads affected by this BP
+// Update the extractWorkloads function in the second file (paste-2.txt)
+// This function is responsible for getting workloads from binding policies
+
+// extractWorkloads gets a list of workloads affected by this BP
+// Now includes both downsync resources and specific workloads
+// extractWorkloads gets a list of workloads affected by this BP
 func extractWorkloads(bp *v1alpha1.BindingPolicy) []string {
 	workloads := []string{}
+
+	// Safety check
+	if bp == nil {
+		fmt.Printf("Debug - extractWorkloads - BP is nil\n")
+		return workloads
+	}
+
+	fmt.Printf("Debug - extractWorkloads - Processing %d Downsync rules\n", len(bp.Spec.Downsync))
 
 	// Process downsync resources
 	for _, ds := range bp.Spec.Downsync {
@@ -67,10 +82,16 @@ func extractWorkloads(bp *v1alpha1.BindingPolicy) []string {
 			apiGroupValue = *ds.APIGroup
 		}
 
+		fmt.Printf("Debug - extractWorkloads - Found APIGroup: %s, Resources: %v, Namespaces: %v\n",
+			apiGroupValue, ds.Resources, ds.Namespaces)
+
 		// Add each resource with its API group
 		for _, resource := range ds.Resources {
+			// Convert resource to lowercase for consistent handling
+			resourceLower := strings.ToLower(resource)
+
 			// Format as apiGroup/resource
-			workloadType := fmt.Sprintf("%s/%s", apiGroupValue, resource)
+			workloadType := fmt.Sprintf("%s/%s", apiGroupValue, resourceLower)
 
 			// Add namespaces if specified
 			if len(ds.Namespaces) > 0 {
@@ -83,6 +104,10 @@ func extractWorkloads(bp *v1alpha1.BindingPolicy) []string {
 		}
 	}
 
+	// Note: We've removed the section that tried to access bp.Spec.Workloads
+	// since that field doesn't exist in the KubeStellar API
+
+	fmt.Printf("Debug - extractWorkloads - Extracted %d workloads: %v\n", len(workloads), workloads)
 	return workloads
 }
 
@@ -90,23 +115,56 @@ func extractWorkloads(bp *v1alpha1.BindingPolicy) []string {
 func extractTargetClusters(bp *v1alpha1.BindingPolicy) []string {
 	clusters := []string{}
 
-	for _, selector := range bp.Spec.ClusterSelectors {
-		// If matchLabels contains kubernetes.io/cluster-name, add it
-		if clusterName, ok := selector.MatchLabels["kubernetes.io/cluster-name"]; ok {
-			clusters = append(clusters, clusterName)
+	// Safety check
+	if bp == nil {
+		fmt.Printf("Debug - extractTargetClusters - BP is nil\n")
+		return clusters
+	}
+
+	if len(bp.Spec.ClusterSelectors) == 0 {
+		fmt.Printf("Debug - extractTargetClusters - No ClusterSelectors found\n")
+		return clusters
+	}
+
+	fmt.Printf("Debug - extractTargetClusters - Processing %d ClusterSelectors\n", len(bp.Spec.ClusterSelectors))
+
+	// Iterate through each cluster selector
+	for i, selector := range bp.Spec.ClusterSelectors {
+		fmt.Printf("Debug - extractTargetClusters - Processing selector #%d\n", i)
+
+		// Check if MatchLabels is nil
+		if selector.MatchLabels == nil {
+			fmt.Printf("Debug - extractTargetClusters - MatchLabels is nil for selector #%d\n", i)
+			continue
 		}
 
-		// Handle other selectors that might target clusters differently
+		// Debug all labels in this selector
 		for k, v := range selector.MatchLabels {
-			// Skip the standard cluster name we already processed
+			fmt.Printf("Debug - extractTargetClusters - Label %s=%s\n", k, v)
+
+			// Check specifically for kubernetes.io/cluster-name label
 			if k == "kubernetes.io/cluster-name" {
-				continue
+				fmt.Printf("Debug - extractTargetClusters - Found cluster name: %s\n", v)
+				clusters = append(clusters, v)
 			}
-			// Add as "label:value" format to give context to the label
-			clusters = append(clusters, fmt.Sprintf("%s:%s", k, v))
 		}
 	}
 
+	// If no clusters found using the selector labels, try general labels
+	if len(clusters) == 0 {
+		fmt.Printf("Debug - extractTargetClusters - No clusters found via kubernetes.io/cluster-name, checking all labels\n")
+		for i, selector := range bp.Spec.ClusterSelectors {
+			if selector.MatchLabels != nil {
+				for k, v := range selector.MatchLabels {
+					// Add any label that might identify a cluster
+					clusters = append(clusters, fmt.Sprintf("%s:%s", k, v))
+					fmt.Printf("Debug - extractTargetClusters - Added generic label #%d: %s:%s\n", i, k, v)
+				}
+			}
+		}
+	}
+
+	fmt.Printf("Debug - extractTargetClusters - Returning %d clusters: %v\n", len(clusters), clusters)
 	return clusters
 }
 


### PR DESCRIPTION
### Description
This PR enhances the binding policy system to support targeting specific workload instances alongside general resource types. It allows to define individual workloads by apiVersion, kind, name, and namespace, providing more granular control over which resources are managed.

### Related Issue
Fixes #312 

### Changes Made
- Add WorkloadInfo struct to represent individual targeted workloads
- Extend StoredBindingPolicy to include specific workloads field
- Implement YAML parsing for the workloads section in binding policies
- Add consistent lowercase conversion for resource names
- Implement fallback strategies for retrieving workload information

### Checklist
Please ensure the following before submitting your PR:
- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

