### PR TITLE
Removed the connection mode in drag and drop

### DIFF
--- a/src/components/BindingPolicy/AvailableItemsPanel.tsx
+++ b/src/components/BindingPolicy/AvailableItemsPanel.tsx
@@ -12,12 +12,10 @@ import {
   CircularProgress,
   Alert
 } from '@mui/material';
-import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
-import StorageIcon from '@mui/icons-material/Storage';
-import DnsIcon from '@mui/icons-material/Dns';
 import { Draggable } from '@hello-pangea/dnd';
 import { BindingPolicyInfo, ManagedCluster, Workload } from '../../types/bindingPolicy';
 import StrictModeDroppable from './StrictModeDroppable';
+import KubernetesIcon from './KubernetesIcon';
 
 interface AvailableItemsPanelProps {
   policies: BindingPolicyInfo[];
@@ -91,17 +89,9 @@ const AvailableItemsPanel: React.FC<AvailableItemsPanelProps> = ({
   };
 
   // Get workload icon based on type
-  const getWorkloadIcon = (type: string) => {
-    switch (type.toLowerCase()) {
-      case 'deployment':
-      case 'replicaset':
-        return <DnsIcon fontSize="small" sx={{ color: theme.palette.primary.main }} />;
-      case 'statefulset':
-        return <StorageIcon fontSize="small" sx={{ color: theme.palette.secondary.main }} />;
-      default:
-        return <DnsIcon fontSize="small" sx={{ color: theme.palette.info.main }} />;
-    }
-  };
+  // const getWorkloadIcon = (type: string) => {
+  //   return <KubernetesIcon type="workload" size={20} />;
+  // };
 
   // Render loading state or content for a section
   const renderSection = <T,>(
@@ -117,6 +107,9 @@ const AvailableItemsPanel: React.FC<AvailableItemsPanelProps> = ({
     return (
       <>
         <Typography variant="subtitle1" sx={{ mt: 2, mb: 1, fontWeight: 'medium', display: 'flex', alignItems: 'center' }}>
+          {title === "Policies" && <KubernetesIcon type="policy" size={20} sx={{ mr: 1 }} />}
+          {title === "Clusters" && <KubernetesIcon type="cluster" size={20} sx={{ mr: 1 }} />}
+          {title === "Workloads" && <KubernetesIcon type="workload" size={20} sx={{ mr: 1 }} />}
           {title}
           {isLoading && <CircularProgress size={16} sx={{ ml: 1 }} />}
         </Typography>
@@ -207,13 +200,7 @@ const AvailableItemsPanel: React.FC<AvailableItemsPanelProps> = ({
               justifyContent: 'space-between'
             }}>
               <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                <DragIndicatorIcon 
-                  fontSize="small" 
-                  sx={{ 
-                    mr: 1, 
-                    color: 'action.active' 
-                  }} 
-                />
+                <KubernetesIcon type="policy" size={20} sx={{ mr: 1 }} />
                 <Box>
                   <Typography variant="body2" noWrap sx={{ fontWeight: 'medium' }}>
                     {policy.name}
@@ -258,11 +245,12 @@ const AvailableItemsPanel: React.FC<AvailableItemsPanelProps> = ({
             sx={{
               borderBottom: '1px solid',
               borderColor: 'divider',
-              bgcolor: snapshot.isDragging ? alpha(theme.palette.info.main, 0.1) : 'background.paper',
+              bgcolor: snapshot.isDragging ? alpha(theme.palette.primary.main, 0.1) : 'background.paper',
               '&:last-child': { borderBottom: 'none' },
+              borderLeft: `4px solid ${getClusterStatusColor(cluster.status)}`,
               transition: 'all 0.2s',
               '&:hover': {
-                bgcolor: alpha(theme.palette.info.main, 0.05)
+                bgcolor: alpha(theme.palette.primary.main, 0.05)
               }
             }}
             data-rbd-draggable-id={`cluster-${cluster.name}`}
@@ -270,59 +258,27 @@ const AvailableItemsPanel: React.FC<AvailableItemsPanelProps> = ({
           >
             <Box sx={{ 
               display: 'flex', 
-              flexDirection: 'column',
-              width: '100%'
+              alignItems: 'center',
+              width: '100%',
+              justifyContent: 'space-between'
             }}>
-              <Box sx={{ 
-                display: 'flex', 
-                alignItems: 'center', 
-                justifyContent: 'space-between',
-                width: '100%'
-              }}>
-                <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                  <DragIndicatorIcon 
-                    fontSize="small" 
-                    sx={{ 
-                      mr: 1, 
-                      color: 'action.active' 
-                    }} 
-                  />
-                  <Typography variant="body2" fontWeight="medium" noWrap>
-                    {cluster.name}
-                  </Typography>
-                </Box>
-                <Tooltip title={`Status: ${cluster.status}`}>
-                  <Chip 
-                    label={cluster.status} 
-                    size="small" 
-                    sx={{ 
-                      bgcolor: alpha(getClusterStatusColor(cluster.status), 0.1),
-                      color: getClusterStatusColor(cluster.status),
-                      fontSize: '0.7rem'
-                    }} 
-                  />
-                </Tooltip>
+              <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                <KubernetesIcon type="cluster" size={20} sx={{ mr: 1 }} />
+                <Typography variant="body2" fontWeight="medium" noWrap>
+                  {cluster.name}
+                </Typography>
               </Box>
-              
-              {/* Show labels if any */}
-              {Object.keys(cluster.labels).length > 0 && (
-                <Box sx={{ ml: 5, mt: 0.5, display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-                  {Object.entries(cluster.labels).map(([key, value]) => (
-                    <Tooltip key={key} title={`${key}: ${value}`}>
-                      <Chip 
-                        label={`${key}: ${value}`} 
-                        size="small" 
-                        variant="outlined"
-                        sx={{ 
-                          height: 18, 
-                          fontSize: '0.65rem',
-                          '& .MuiChip-label': { px: 0.8 }
-                        }} 
-                      />
-                    </Tooltip>
-                  ))}
-                </Box>
-              )}
+              <Tooltip title={`Status: ${cluster.status}`}>
+                <Chip 
+                  label={cluster.status} 
+                  size="small" 
+                  sx={{ 
+                    backgroundColor: alpha(getClusterStatusColor(cluster.status), 0.1),
+                    color: getClusterStatusColor(cluster.status),
+                    fontSize: '0.7rem'
+                  }} 
+                />
+              </Tooltip>
             </Box>
           </ListItem>
         );
@@ -347,11 +303,11 @@ const AvailableItemsPanel: React.FC<AvailableItemsPanelProps> = ({
             sx={{
               borderBottom: '1px solid',
               borderColor: 'divider',
-              bgcolor: snapshot.isDragging ? alpha(theme.palette.success.main, 0.1) : 'background.paper',
+              bgcolor: snapshot.isDragging ? alpha(theme.palette.secondary.main, 0.1) : 'background.paper',
               '&:last-child': { borderBottom: 'none' },
               transition: 'all 0.2s',
               '&:hover': {
-                bgcolor: alpha(theme.palette.success.main, 0.05)
+                bgcolor: alpha(theme.palette.secondary.main, 0.05)
               }
             }}
             data-rbd-draggable-id={`workload-${workload.name}`}
@@ -359,56 +315,26 @@ const AvailableItemsPanel: React.FC<AvailableItemsPanelProps> = ({
           >
             <Box sx={{ 
               display: 'flex', 
-              flexDirection: 'column',
-              width: '100%'
+              alignItems: 'center',
+              width: '100%',
+              justifyContent: 'space-between'
             }}>
-              <Box sx={{ 
-                display: 'flex', 
-                alignItems: 'center', 
-                justifyContent: 'space-between',
-                width: '100%'
-              }}>
-                <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                  <DragIndicatorIcon 
-                    fontSize="small" 
-                    sx={{ 
-                      mr: 1, 
-                      color: 'action.active' 
-                    }} 
-                  />
+              <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                <KubernetesIcon type="workload" size={20} sx={{ mr: 1 }} />
+                <Box>
+                  <Typography variant="body2" fontWeight="medium" noWrap>
+                    {workload.name}
+                  </Typography>
                   <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                    {getWorkloadIcon(workload.type)}
-                    <Box sx={{ ml: 0.5 }}>
-                      <Typography variant="body2" fontWeight="medium" noWrap>
-                        {workload.name}
-                      </Typography>
-                      <Typography variant="caption" color="text.secondary" noWrap>
-                        {workload.namespace}/{workload.type}
-                      </Typography>
-                    </Box>
+                    <Typography variant="caption" color="text.secondary" sx={{ mr: 0.5 }}>
+                      {workload.type}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      in {workload.namespace || 'default'}
+                    </Typography>
                   </Box>
                 </Box>
               </Box>
-              
-              {/* Show labels if any */}
-              {Object.keys(workload.labels).length > 0 && (
-                <Box sx={{ ml: 5, mt: 0.5, display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-                  {Object.entries(workload.labels).map(([key, value]) => (
-                    <Tooltip key={key} title={`${key}: ${value}`}>
-                      <Chip 
-                        label={`${key}: ${value}`} 
-                        size="small" 
-                        variant="outlined"
-                        sx={{ 
-                          height: 18, 
-                          fontSize: '0.65rem',
-                          '& .MuiChip-label': { px: 0.8 }
-                        }} 
-                      />
-                    </Tooltip>
-                  ))}
-                </Box>
-              )}
             </Box>
           </ListItem>
         );

--- a/src/components/BindingPolicy/ClusterPanel.tsx
+++ b/src/components/BindingPolicy/ClusterPanel.tsx
@@ -11,7 +11,7 @@ import {
 import { Draggable } from '@hello-pangea/dnd';
 import { ManagedCluster } from '../../types/bindingPolicy';
 import StrictModeDroppable from './StrictModeDroppable';
-import DnsIcon from '@mui/icons-material/Dns';
+import KubernetesIcon from './KubernetesIcon';
 
 interface ClusterPanelProps {
   clusters: ManagedCluster[];
@@ -58,7 +58,7 @@ const ClusterPanel: React.FC<ClusterPanelProps> = ({
             }}
           >
             <Box sx={{ display: 'flex', alignItems: 'center' }}>
-              <DnsIcon sx={{ mr: 1, color: theme.palette.info.main }} />
+              <KubernetesIcon type="cluster" size={24} sx={{ mr: 1 }} />
               <Typography variant="body2" sx={{ fontWeight: 500 }}>
                 {cluster.name}
               </Typography>
@@ -77,11 +77,14 @@ const ClusterPanel: React.FC<ClusterPanelProps> = ({
         display: 'flex', 
         flexDirection: 'column',
         overflow: 'hidden',
-        borderRadius: 2
+        borderRadius: 2,
       }}
     >
       <Box sx={{ p: 2, backgroundColor: theme.palette.primary.main, color: 'white' }}>
-        <Typography variant="h6">Clusters</Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          <KubernetesIcon type="cluster" size={24} sx={{ mr: 1, color: 'white' }} />
+          <Typography variant="h6">Clusters</Typography>
+        </Box>
       </Box>
       <Divider />
       

--- a/src/components/BindingPolicy/ConnectionIcon.tsx
+++ b/src/components/BindingPolicy/ConnectionIcon.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Box, SxProps, Theme } from '@mui/material';
+
+interface ConnectionIconProps {
+  size?: number;
+  color?: string;
+  direction?: 'left-to-right' | 'right-to-left' | 'bidirectional';
+  sx?: SxProps<Theme>;
+}
+
+const ConnectionIcon: React.FC<ConnectionIconProps> = ({ 
+  size = 24, 
+  color = '#9c27b0', 
+  direction = 'left-to-right',
+  sx = {}
+}) => {
+  return (
+    <Box
+      sx={{
+        width: size,
+        height: size,
+        position: 'relative',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        ...sx
+      }}
+    >
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        {/* Base connection line */}
+        <path
+          d="M4 12H20"
+          stroke={color}
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+        
+        {/* Direction arrows */}
+        {(direction === 'left-to-right' || direction === 'bidirectional') && (
+          <path
+            d="M16 8L20 12L16 16"
+            stroke={color}
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        )}
+        
+        {(direction === 'right-to-left' || direction === 'bidirectional') && (
+          <path
+            d="M8 8L4 12L8 16"
+            stroke={color}
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        )}
+        
+        {/* Connection dots */}
+        <circle cx="12" cy="12" r="2" fill={color} />
+      </svg>
+    </Box>
+  );
+};
+
+export default ConnectionIcon; 

--- a/src/components/BindingPolicy/ConnectionManager.tsx
+++ b/src/components/BindingPolicy/ConnectionManager.tsx
@@ -1,14 +1,13 @@
-import React, { useCallback } from 'react';
-import { Box, Button, Typography, Paper, Snackbar, Alert, alpha } from '@mui/material';
-import LinkIcon from '@mui/icons-material/Link';
+import React, { useCallback, useEffect, useImperativeHandle, forwardRef } from 'react';
+import {  Typography, Paper, Snackbar, Alert } from '@mui/material';
 import InfoIcon from '@mui/icons-material/Info';
-import AddLinkIcon from '@mui/icons-material/AddLink';
 import { useConnectionManagerStore } from '../../stores/connectionManagerStore';
 import QuickPolicyDialog from './QuickPolicyDialog';
 import { PolicyConfiguration } from './ConfigurationSidebar';
 import { Workload, ManagedCluster } from '../../types/bindingPolicy';
 import { useCanvasStore } from '../../stores/canvasStore';
 import { usePolicyDragDropStore } from '../../stores/policyDragDropStore';
+
 
 interface ConnectionManagerProps {
   workloads: Workload[];
@@ -29,12 +28,16 @@ export interface QuickPolicyDialogProps {
   } | null;
 }
 
-const ConnectionManager: React.FC<ConnectionManagerProps> = ({
+// Component definition with forwardRef to expose methods
+const ConnectionManager = forwardRef<
+  { completeConnection: (workloadId: string, clusterId: string) => void },
+  ConnectionManagerProps
+>(({
   workloads,
   clusters,
   onQuickPolicySave,
   setSuccessMessage
-}) => {
+}, ref) => {
   // Get state and actions from the connection manager store
   const connectionMode = useConnectionManagerStore(state => state.connectionMode);
   const toggleConnectionMode = useConnectionManagerStore(state => state.toggleConnectionMode);
@@ -44,82 +47,101 @@ const ConnectionManager: React.FC<ConnectionManagerProps> = ({
   const quickPolicyDialogOpen = useConnectionManagerStore(state => state.quickPolicyDialogOpen);
   const setQuickPolicyDialogOpen = useConnectionManagerStore(state => state.setQuickPolicyDialogOpen);
   const currentConnection = useConnectionManagerStore(state => state.currentConnection);
-//  const setCurrentConnection = useConnectionManagerStore(state => state.setCurrentConnection);
-  //const resetConnection = useConnectionManagerStore(state => state.resetConnection);
+  const setCurrentConnection = useConnectionManagerStore(state => state.setCurrentConnection);
+  const resetConnection = useConnectionManagerStore(state => state.resetConnection);
   
   // Get functions from other stores
   const addToCanvas = usePolicyDragDropStore(state => state.addToCanvas);
   const addConnectionLine = useCanvasStore(state => state.addConnectionLine);
   
-  // Handle completing a connection
-//   const handleCompleteConnection = useCallback((workloadId: string, clusterId: string) => {
-//     console.log(`🚨 handleCompleteConnection called with workloadId=${workloadId}, clusterId=${clusterId}`);
-//     console.log(`🚨 Available workloads:`, workloads.map(w => w.name));
-//     console.log(`🚨 Available clusters:`, clusters.map(c => c.name));
-    
-//     if (!workloadId || !clusterId) {
-//       console.error("❌ Missing workload or cluster ID");
-//       return;
-//     }
-    
-//     // Find workload and cluster details - with enhanced handling for hyphenated names
-//     // Try exact matching first
-//     let workload = workloads.find(w => w.name === workloadId);
-//     const cluster = clusters.find(c => c.name === clusterId);
-    
-//     // If workload wasn't found with exact match, try checking if it's a partial match
-//     // This handles cases where only part of a hyphenated name was passed
-//     if (!workload) {
-//       console.log(`⚠️ Workload "${workloadId}" not found with exact match, trying partial match...`);
-//       workload = workloads.find(w => 
-//         w.name.includes(workloadId) || 
-//         workloadId.includes(w.name)
-//       );
+  // Enable connection mode by default
+  useEffect(() => {
+    if (!connectionMode) {
+      toggleConnectionMode();
+    }
+  }, [connectionMode, toggleConnectionMode]);
+
+  // Expose the completeConnection method to parent components
+  useImperativeHandle(ref, () => ({
+    completeConnection: (workloadId: string, clusterId: string) => {
+      console.log(`🚨 completeConnection called with workloadId=${workloadId}, clusterId=${clusterId}`);
+      console.log(`🔍 DEBUG: Current store state:`, {
+        connectionMode,
+        activeConnectionSource: activeConnection.source,
+        activeConnectionType: activeConnection.sourceType,
+        quickPolicyDialogOpen
+      });
       
-//       if (workload) {
-//         console.log(`✅ Found workload with partial match: ${workload.name}`);
-//       }
-//     }
-    
-//     console.log(`🔄 Found workload:`, workload, `and cluster:`, cluster);
-    
-//     if (!workload || !cluster) {
-//       console.error("❌ Could not find workload or cluster");
-//       console.error(`❌ Looked for workload "${workloadId}" and cluster "${clusterId}"`);
+      if (!workloadId || !clusterId) {
+        console.error("❌ Missing workload or cluster ID");
+        return;
+      }
       
-//       // Show an error message
-//       setInvalidConnectionWarning(`Could not find ${!workload ? 'workload' : 'cluster'} with the specified ID. Please try again.`);
-//       return;
-//     }
-    
-//     // Use the actual workload name from the found object to ensure consistency
-//     const actualWorkloadName = workload.name;
-//     const actualClusterName = cluster.name;
-    
-//     // Open quick policy dialog with connection information
-//     console.log(`✅ Setting up connection dialog for ${actualWorkloadName} to ${actualClusterName}`);
-    
-//     setCurrentConnection({
-//       workloadName: actualWorkloadName,
-//       workloadNamespace: workload.namespace || 'default',
-//       clusterName: actualClusterName
-//     });
-    
-//     // Add connection to the canvas if not already present
-//     if (addConnectionLine) {
-//       console.log(`🔄 Adding connection line for workload-${actualWorkloadName} to cluster-${actualClusterName}`);
-//       addConnectionLine(`workload-${actualWorkloadName}`, `cluster-${actualClusterName}`, '#9c27b0');
-//     } else {
-//       console.error('❌ addConnectionLine is not available!');
-//     }
-    
-//     // Open the quick policy dialog
-//     console.log('🚨 Opening quick policy dialog');
-//     setQuickPolicyDialogOpen(true);
-    
-//     // Clear active connection
-//     resetConnection();
-//   }, [workloads, clusters, setInvalidConnectionWarning, setCurrentConnection, setQuickPolicyDialogOpen, addConnectionLine, resetConnection]);
+      // Find workload and cluster details
+      let workload = workloads.find(w => w.name === workloadId);
+      const cluster = clusters.find(c => c.name === clusterId);
+      
+      console.log(`🔍 DEBUG: Available workloads:`, workloads.map(w => w.name));
+      console.log(`🔍 DEBUG: Available clusters:`, clusters.map(c => c.name));
+      
+      // Try partial matching for workload names if needed
+      if (!workload) {
+        console.log(`⚠️ Workload "${workloadId}" not found with exact match, trying partial match...`);
+        workload = workloads.find(w => 
+          w.name.includes(workloadId) || 
+          workloadId.includes(w.name)
+        );
+      }
+      
+      console.log(`🔄 Found workload:`, workload, `and cluster:`, cluster);
+      
+      if (!workload || !cluster) {
+        console.error("❌ Could not find workload or cluster");
+        setInvalidConnectionWarning(`Could not find ${!workload ? 'workload' : 'cluster'} with the specified ID. Please try again.`);
+        return;
+      }
+      
+      // Use the actual workload name from the found object
+      const actualWorkloadName = workload.name;
+      const actualClusterName = cluster.name;
+      
+      // Setup connection information
+      console.log(`✅ Setting up connection dialog for ${actualWorkloadName} to ${actualClusterName}`);
+      
+      try {
+        // Set current connection in store
+        setCurrentConnection({
+          workloadName: actualWorkloadName,
+          workloadNamespace: workload.namespace || 'default',
+          clusterName: actualClusterName
+        });
+        
+        // Add workload and cluster to canvas if they aren't already there
+        if (addToCanvas) {
+          addToCanvas('workload', actualWorkloadName);
+          addToCanvas('cluster', actualClusterName);
+        }
+        
+        // Add connection line
+        if (addConnectionLine) {
+          console.log(`🔄 Adding connection line for workload-${actualWorkloadName} to cluster-${actualClusterName}`);
+          addConnectionLine(`workload-${actualWorkloadName}`, `cluster-${actualClusterName}`, '#9c27b0');
+        }
+        
+        // Open the quick policy dialog
+        console.log('🚨 Opening quick policy dialog');
+        setQuickPolicyDialogOpen(true);
+        
+        // Reset active connection state
+        resetConnection();
+        
+        console.log('✅ Connection process completed successfully');
+      } catch (error) {
+        console.error('❌ Error during connection process:', error);
+        setInvalidConnectionWarning(`An error occurred while setting up the connection: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+  }), [workloads, clusters, setInvalidConnectionWarning, setCurrentConnection, addToCanvas, addConnectionLine, setQuickPolicyDialogOpen, resetConnection, activeConnection.source, activeConnection.sourceType, quickPolicyDialogOpen, connectionMode]);
 
   // Handle quick policy save
   const handleQuickPolicySave = useCallback((config: PolicyConfiguration) => {
@@ -162,69 +184,14 @@ const ConnectionManager: React.FC<ConnectionManagerProps> = ({
     // Close the dialog
     setQuickPolicyDialogOpen(false);
     
-    // Reset connection mode
-    toggleConnectionMode();
+    // Don't reset connection mode since we want it to be the default
     
     console.log('✅ Quick policy created with configuration');
-  }, [currentConnection, workloads, clusters, onQuickPolicySave, addToCanvas, addConnectionLine, setSuccessMessage, setQuickPolicyDialogOpen, toggleConnectionMode]);
+  }, [currentConnection, workloads, clusters, onQuickPolicySave, addToCanvas, addConnectionLine, setSuccessMessage, setQuickPolicyDialogOpen]);
 
   return (
     <>
-      {/* Connection Mode Controls Bar */}
-      <Box sx={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        mb: 1,
-        p: 1,
-        bgcolor: connectionMode ? alpha('#9c27b0', 0.1) : 'transparent',
-        borderRadius: 1,
-        border: connectionMode ? `1px solid ${alpha('#9c27b0', 0.3)}` : 'none'
-      }}>
-        <Typography variant="subtitle1">
-          Connection Mode: <strong>{connectionMode ? 'ENABLED' : 'DISABLED'}</strong>
-        </Typography>
-        
-        <Button
-          variant={connectionMode ? "contained" : "outlined"}
-          color="secondary"
-          startIcon={<LinkIcon />}
-          onClick={() => {
-            console.log('🚨 DIRECT BUTTON CLICK');
-            toggleConnectionMode();
-          }}
-          sx={{ 
-            borderRadius: 28,
-            boxShadow: connectionMode ? 4 : 1,
-            fontWeight: 'bold',
-            border: connectionMode ? '2px solid #9c27b0' : undefined,
-            position: 'relative',
-            zIndex: 1001,
-            pointerEvents: 'auto',
-            cursor: 'pointer',
-            px: 2.5,
-            py: 0.8,
-            '&:hover': {
-              backgroundColor: connectionMode ? '#9c27b0' : alpha('#9c27b0', 0.1),
-              transform: 'translateY(-2px)',
-              boxShadow: 4
-            },
-            transition: 'all 0.2s ease-in-out'
-          }}
-        >
-          <span style={{ 
-            padding: '0 8px',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '6px'
-          }}>
-            {connectionMode ? "Exit Connection Mode" : "Create Connection"}
-          </span>
-        </Button>
-      </Box>
-      
-      {/* Connection Mode Instructions */}
-      {connectionMode && (
+      {connectionMode && activeConnection.source && (
         <Paper
           elevation={3}
           sx={{
@@ -242,46 +209,9 @@ const ConnectionManager: React.FC<ConnectionManagerProps> = ({
         >
           <InfoIcon color="info" sx={{ mr: 1 }} />
           <Typography variant="body2">
-            {activeConnection.source 
-              ? `Select a ${activeConnection.sourceType === 'workload' ? 'cluster' : 'workload'} to complete the connection` 
-              : "Click on a workload or cluster to start a connection"}
+            {`Select a ${activeConnection.sourceType === 'workload' ? 'cluster' : 'workload'} to complete the connection`}
           </Typography>
         </Paper>
-      )}
-      
-      {/* Create Connection floating button - visible only when NOT in connection mode */}
-      {!connectionMode && (
-        <Box
-          sx={{
-            position: 'absolute',
-            top: '80px',
-            right: '30px',
-            zIndex: 100
-          }}
-        >
-          <Button
-            variant="contained"
-            color="secondary"
-            startIcon={<AddLinkIcon />}
-            onClick={toggleConnectionMode}
-            sx={{
-              borderRadius: 28,
-              boxShadow: 3,
-              fontWeight: 'bold',
-              px: 2,
-              py: 1,
-              backgroundColor: '#9c27b0',
-              '&:hover': {
-                backgroundColor: '#7b1fa2',
-                transform: 'scale(1.05)',
-                boxShadow: 5
-              },
-              transition: 'all 0.2s ease-in-out'
-            }}
-          >
-            CREATE CONNECTION
-          </Button>
-        </Box>
       )}
       
       {/* Quick Policy Creation Dialog */}
@@ -315,6 +245,6 @@ const ConnectionManager: React.FC<ConnectionManagerProps> = ({
       </Snackbar>
     </>
   );
-};
+});
 
 export default React.memo(ConnectionManager); 

--- a/src/components/BindingPolicy/ItemTooltip.tsx
+++ b/src/components/BindingPolicy/ItemTooltip.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { Box, Typography, Chip, useTheme, alpha } from '@mui/material';
-import DnsIcon from '@mui/icons-material/Dns';
-import StorageIcon from '@mui/icons-material/Storage';
-import PolicyIcon from '@mui/icons-material/Policy';
+import KubernetesIcon from './KubernetesIcon';
 
 interface ItemTooltipProps {
   title: string;
@@ -35,18 +33,9 @@ const ItemTooltip: React.FC<ItemTooltipProps> = ({
     }
   };
   
-  // Get icon based on type
+  // Get icon based on type - now using KubernetesIcon
   const getIcon = () => {
-    switch (type) {
-      case 'cluster':
-        return <DnsIcon fontSize="small" sx={{ color: getColor() }} />;
-      case 'workload':
-        return <StorageIcon fontSize="small" sx={{ color: getColor() }} />;
-      case 'policy':
-        return <PolicyIcon fontSize="small" sx={{ color: getColor() }} />;
-      default:
-        return null;
-    }
+    return <KubernetesIcon type={type} size={20} />;
   };
   
   return (

--- a/src/components/BindingPolicy/KubernetesIcon.tsx
+++ b/src/components/BindingPolicy/KubernetesIcon.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { Box, Typography, SxProps, Theme } from '@mui/material';
+
+export type IconType = 'workload' | 'cluster' | 'policy';
+
+interface KubernetesIconProps {
+  type: IconType;
+  size?: number;
+  sx?: SxProps<Theme>;
+}
+
+const KubernetesIcon: React.FC<KubernetesIconProps> = ({ type, size = 24, sx = {} }) => {
+  // Define colors based on type
+  const getTypeColor = (): string => {
+    switch (type) {
+      case 'workload':
+        return '#326ce5'; // Kubernetes blue
+      case 'cluster':
+        return '#2196f3'; // Material blue
+      case 'policy':
+        return '#9c27b0'; // Purple for policies
+      default:
+        return '#326ce5';
+    }
+  };
+
+  // Define label based on type
+  const getTypeLabel = (): string => {
+    switch (type) {
+      case 'workload':
+        return 'WD';
+      case 'cluster':
+        return 'CL';
+      case 'policy':
+        return 'BP';
+      default:
+        return '';
+    }
+  };
+
+  const baseColor = getTypeColor();
+
+  return (
+    <Box
+      sx={{
+        width: size,
+        height: size,
+        position: 'relative',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        ...sx
+      }}
+    >
+      {/* Kubernetes heptagon shape (7-sided) */}
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        {/* Heptagon background */}
+        <path
+          d="M12 2L5.15 5.35L2 12L5.15 18.65L12 22L18.85 18.65L22 12L18.85 5.35L12 2Z"
+          fill={baseColor}
+          opacity="0.8"
+        />
+        <path
+          d="M12 2L5.15 5.35L2 12L5.15 18.65L12 22L18.85 18.65L22 12L18.85 5.35L12 2Z"
+          stroke={baseColor}
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+      
+      {/* Text label */}
+      <Typography
+        variant="caption"
+        component="span"
+        sx={{
+          position: 'absolute',
+          color: 'white',
+          fontWeight: 'bold',
+          fontSize: size * 0.35,
+          lineHeight: 1,
+          textAlign: 'center',
+          userSelect: 'none'
+        }}
+      >
+        {getTypeLabel()}
+      </Typography>
+    </Box>
+  );
+};
+
+export default KubernetesIcon; 

--- a/src/components/BindingPolicy/QuickPolicyDialog.tsx
+++ b/src/components/BindingPolicy/QuickPolicyDialog.tsx
@@ -64,25 +64,47 @@ const QuickPolicyDialog: React.FC<QuickPolicyDialogProps> = ({ open, onClose, on
   };
 
   const handleSave = () => {
-    if (!name || !namespace) return;
+    if (!name || !namespace) {
+      console.error("❌ Missing required fields (name or namespace)");
+      return;
+    }
     
-    onSave({
-      name,
-      namespace,
-      propagationMode: propagationMode as 'DownsyncOnly' | 'UpsyncOnly' | 'BidirectionalSync',
-      updateStrategy: updateStrategy as 'ServerSideApply' | 'ForceApply' | 'RollingUpdate' | 'BlueGreenDeployment',
+    console.log("🔄 Quick Policy Dialog - saving policy with:", { 
+      name, 
+      namespace, 
+      propagationMode, 
+      updateStrategy,
       customLabels,
-      deploymentType: 'SelectedClusters',
-      schedulingRules: [],
-      tolerations: []
+      connection 
     });
     
-    // Reset form
-    setName('');
-    setNamespace('default');
-    setPropagationMode('DownsyncOnly');
-    setUpdateStrategy('ServerSideApply');
-    setCustomLabels({});
+    try {
+      // Create the policy configuration object
+      const policyConfig = {
+        name,
+        namespace,
+        propagationMode: propagationMode as 'DownsyncOnly' | 'UpsyncOnly' | 'BidirectionalSync',
+        updateStrategy: updateStrategy as 'ServerSideApply' | 'ForceApply' | 'RollingUpdate' | 'BlueGreenDeployment',
+        customLabels,
+        deploymentType: 'SelectedClusters' as 'SelectedClusters' | 'AllClusters',
+        schedulingRules: [],
+        tolerations: []
+      };
+      
+      // Call the onSave callback with the policy configuration
+      onSave(policyConfig);
+      
+      console.log("✅ Quick Policy Dialog - policy saved successfully:", policyConfig);
+      
+      // Reset form
+      setName('');
+      setNamespace('default');
+      setPropagationMode('DownsyncOnly');
+      setUpdateStrategy('ServerSideApply');
+      setCustomLabels({});
+    } catch (error) {
+      console.error("❌ Error saving policy:", error);
+    }
   };
 
   return (

--- a/src/components/BindingPolicy/WorkloadPanel.tsx
+++ b/src/components/BindingPolicy/WorkloadPanel.tsx
@@ -11,7 +11,7 @@ import {
 import { Draggable } from '@hello-pangea/dnd';
 import { Workload } from '../../types/bindingPolicy';
 import StrictModeDroppable from './StrictModeDroppable';
-import StorageIcon from '@mui/icons-material/Storage';
+import KubernetesIcon from './KubernetesIcon';
 
 interface WorkloadPanelProps {
   workloads: Workload[];
@@ -58,7 +58,7 @@ const WorkloadPanel: React.FC<WorkloadPanelProps> = ({
             }}
           >
             <Box sx={{ display: 'flex', alignItems: 'center' }}>
-              <StorageIcon sx={{ mr: 1, color: theme.palette.success.main }} />
+              <KubernetesIcon type="workload" size={24} sx={{ mr: 1 }} />
               <Typography variant="body2" sx={{ fontWeight: 500 }}>
                 {workload.name}
               </Typography>
@@ -81,7 +81,10 @@ const WorkloadPanel: React.FC<WorkloadPanelProps> = ({
       }}
     >
       <Box sx={{ p: 2, backgroundColor: theme.palette.secondary.main, color: 'white' }}>
-        <Typography variant="h6">Workloads</Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          <KubernetesIcon type="workload" size={24} sx={{ mr: 1, color: 'white' }} />
+          <Typography variant="h6">Workloads</Typography>
+        </Box>
       </Box>
       <Divider />
       

--- a/src/components/BindingPolicy/nodes/ClusterNode.tsx
+++ b/src/components/BindingPolicy/nodes/ClusterNode.tsx
@@ -1,7 +1,7 @@
 import React, { memo } from 'react';
 import { Handle, Position, NodeProps } from 'reactflow';
 import { Box, Typography } from '@mui/material';
-import { Storage as StorageIcon } from '@mui/icons-material';
+import KubernetesIcon from '../KubernetesIcon';
 
 interface ClusterNodeData {
   label: string;
@@ -35,12 +35,13 @@ const ClusterNode: React.FC<NodeProps<ClusterNodeData>> = ({ data }) => {
             justifyContent: 'center',
             backgroundColor: theme === 'dark' ? '#374151' : '#F3F4F6',
             borderRadius: '50%',
-            width: 40,
-            height: 40,
+            width: 48,
+            height: 48,
             mb: 1,
+            padding: '4px',
           }}
         >
-          <StorageIcon sx={{ color: theme === 'dark' ? '#D1D5DB' : '#4B5563' }} />
+          <KubernetesIcon type="cluster" size={40} />
         </Box>
         
         <Typography 

--- a/src/components/BindingPolicy/nodes/PolicyNode.tsx
+++ b/src/components/BindingPolicy/nodes/PolicyNode.tsx
@@ -1,6 +1,7 @@
 import React, { memo } from 'react';
 import { Handle, Position, NodeProps } from 'reactflow';
 import { Box, Typography, Chip } from '@mui/material';
+import KubernetesIcon from '../KubernetesIcon';
 
 interface PolicyNodeData {
   policy: {
@@ -31,16 +32,25 @@ const PolicyNode: React.FC<NodeProps<PolicyNodeData>> = ({ data }) => {
           boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
         }}
       >
-        <Typography 
-          variant="subtitle2" 
-          sx={{ 
-            fontWeight: 600, 
-            color: theme === 'dark' ? '#fff' : '#000',
-            mb: 1
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            mb: 1,
           }}
         >
-          {label}
-        </Typography>
+          <KubernetesIcon type="policy" size={30} sx={{ mr: 1 }} />
+          <Typography 
+            variant="subtitle2" 
+            sx={{ 
+              fontWeight: 600, 
+              color: theme === 'dark' ? '#fff' : '#000',
+            }}
+          >
+            {label}
+          </Typography>
+        </Box>
         
         <Chip 
           label={policy.status} 
@@ -54,12 +64,18 @@ const PolicyNode: React.FC<NodeProps<PolicyNodeData>> = ({ data }) => {
         />
         
         <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 1 }}>
-          <Typography variant="caption" sx={{ color: theme === 'dark' ? '#ccc' : '#666' }}>
-            Clusters: {policy.clusterList?.length || 0}
-          </Typography>
-          <Typography variant="caption" sx={{ color: theme === 'dark' ? '#ccc' : '#666' }}>
-            Workloads: {policy.workloadList?.length || 0}
-          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <KubernetesIcon type="cluster" size={16} sx={{ mr: 0.5 }} />
+            <Typography variant="caption" sx={{ color: theme === 'dark' ? '#ccc' : '#666' }}>
+              {policy.clusterList?.length || 0}
+            </Typography>
+          </Box>
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <KubernetesIcon type="workload" size={16} sx={{ mr: 0.5 }} />
+            <Typography variant="caption" sx={{ color: theme === 'dark' ? '#ccc' : '#666' }}>
+              {policy.workloadList?.length || 0}
+            </Typography>
+          </Box>
         </Box>
       </Box>
       

--- a/src/components/BindingPolicy/nodes/WorkloadNode.tsx
+++ b/src/components/BindingPolicy/nodes/WorkloadNode.tsx
@@ -1,7 +1,7 @@
 import React, { memo } from 'react';
 import { Handle, Position, NodeProps } from 'reactflow';
 import { Box, Typography } from '@mui/material';
-import { Code as CodeIcon } from '@mui/icons-material';
+import KubernetesIcon from '../KubernetesIcon';
 
 interface WorkloadNodeData {
   label: string;
@@ -38,23 +38,24 @@ const WorkloadNode: React.FC<NodeProps<WorkloadNodeData>> = ({ data }) => {
           sx={{
             display: 'flex',
             alignItems: 'center',
-            gap: 1,
-            mb: 0.5,
+            justifyContent: 'center',
+            mb: 1,
           }}
         >
-          <CodeIcon sx={{ fontSize: 16, color: '#3B82F6' }} />
-          <Typography 
-            variant="caption" 
-            sx={{ 
-              color: theme === 'dark' ? '#9CA3AF' : '#4B5563',
-              fontWeight: 600,
-              textTransform: 'uppercase',
-              fontSize: '0.65rem'
-            }}
-          >
-            {workloadType}
-          </Typography>
+          <KubernetesIcon type="workload" size={26} />
         </Box>
+        
+        <Typography 
+          variant="caption" 
+          sx={{ 
+            color: theme === 'dark' ? '#9CA3AF' : '#4B5563',
+            fontWeight: 600,
+            textTransform: 'uppercase',
+            fontSize: '0.65rem'
+          }}
+        >
+          {workloadType}
+        </Typography>
         
         <Typography 
           variant="body2" 
@@ -68,16 +69,18 @@ const WorkloadNode: React.FC<NodeProps<WorkloadNodeData>> = ({ data }) => {
           {workloadName}
         </Typography>
         
-        <Typography 
-          variant="caption" 
-          sx={{ 
-            color: theme === 'dark' ? '#9CA3AF' : '#6B7280',
-            fontSize: '0.65rem',
-            mt: 0.5
-          }}
-        >
-          via {policy}
-        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', mt: 0.5 }}>
+          <KubernetesIcon type="policy" size={14} sx={{ mr: 0.5 }} />
+          <Typography 
+            variant="caption" 
+            sx={{ 
+              color: theme === 'dark' ? '#9CA3AF' : '#6B7280',
+              fontSize: '0.65rem',
+            }}
+          >
+            {policy}
+          </Typography>
+        </Box>
       </Box>
       
       <Handle type="target" position={Position.Top} style={{ background: '#3B82F6' }} />

--- a/src/stores/connectionManagerStore.ts
+++ b/src/stores/connectionManagerStore.ts
@@ -33,7 +33,7 @@ interface ConnectionManagerState {
 // Create the store
 export const useConnectionManagerStore = create<ConnectionManagerState>((set) => ({
   // Initial state
-  connectionMode: false,
+  connectionMode: true,
   activeConnection: {
     source: null,
     sourceType: null,
@@ -77,7 +77,6 @@ export const useConnectionManagerStore = create<ConnectionManagerState>((set) =>
       mouseX: 0,
       mouseY: 0
     },
-    invalidConnectionWarning: null,
-    quickPolicyDialogOpen: false
+    invalidConnectionWarning: null
   })
 })); 


### PR DESCRIPTION
### Description
Removed the connection mode in drag and drop binding policy. Fixed lint warnings and also improved the layout.

### Related Issue
Fixes #342 

### Changes Made
- Removed the connection mode. Instead clusters and workloads can be directly mapped.
- Fixed the lint warnings.
- Added customize icons for the clusters and workloads.
- Improve the layout. 

### Checklist
Please ensure the following before submitting your PR:
- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] My code follows the project's coding standards.
- [x] I have tested the changes locally and ensured they work as expected.

