### PR TITLE
Refactor import paths to new module structure

### DIFF
--- a/backend/api/deploy.go
+++ b/backend/api/deploy.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/katamyra/kubestellarUI/k8s"
-	"github.com/katamyra/kubestellarUI/redis"
+	"github.com/kubestellar/ui/k8s"
+	"github.com/kubestellar/ui/redis"
 )
 
 type DeployRequest struct {

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 
 	"github.com/gin-gonic/gin"
-	"github.com/katamyra/kubestellarUI/models"
-	"github.com/katamyra/kubestellarUI/services"
-	"github.com/katamyra/kubestellarUI/utils"
+	"github.com/kubestellar/ui/models"
+	"github.com/kubestellar/ui/services"
+	"github.com/kubestellar/ui/utils"
 )
 
 var (

--- a/backend/auth/auth.go
+++ b/backend/auth/auth.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"log"
 
-	jwtconfig "github.com/katamyra/kubestellarUI/jwt"
-	"github.com/katamyra/kubestellarUI/k8s"
+	jwtconfig "github.com/kubestellar/ui/jwt"
+	"github.com/kubestellar/ui/k8s"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,4 +1,4 @@
-module github.com/katamyra/kubestellarUI
+module github.com/kubestellar/ui
 
 go 1.23.0
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/katamyra/kubestellarUI/routes"
+	"github.com/kubestellar/ui/routes"
 
-	"github.com/katamyra/kubestellarUI/api"
+	"github.com/kubestellar/ui/api"
 	"go.uber.org/zap"
 )
 

--- a/backend/middleware/auth.go
+++ b/backend/middleware/auth.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
-	jwtconfig "github.com/katamyra/kubestellarUI/jwt"
+	jwtconfig "github.com/kubestellar/ui/jwt"
 )
 
 // AuthenticateMiddleware validates JWT token

--- a/backend/models/user.go
+++ b/backend/models/user.go
@@ -3,7 +3,7 @@ package models
 import (
 	"errors"
 
-	"github.com/katamyra/kubestellarUI/auth"
+	"github.com/kubestellar/ui/auth"
 )
 
 type User struct {

--- a/backend/namespace/namespace.go
+++ b/backend/namespace/namespace.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/katamyra/kubestellarUI/k8s"
-	"github.com/katamyra/kubestellarUI/models"
-	"github.com/katamyra/kubestellarUI/redis"
+	"github.com/kubestellar/ui/k8s"
+	"github.com/kubestellar/ui/models"
+	"github.com/kubestellar/ui/redis"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/backend/namespace/resources/service.go
+++ b/backend/namespace/resources/service.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/katamyra/kubestellarUI/models"
-	ns "github.com/katamyra/kubestellarUI/namespace"
+	"github.com/kubestellar/ui/models"
+	ns "github.com/kubestellar/ui/namespace"
 )
 
 // createNamespace handles creating a new namespace

--- a/backend/redis/redis.go
+++ b/backend/redis/redis.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/katamyra/kubestellarUI/log"
+	"github.com/kubestellar/ui/log"
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 )

--- a/backend/routes/bp.go
+++ b/backend/routes/bp.go
@@ -2,7 +2,7 @@ package routes
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/katamyra/kubestellarUI/wds/bp"
+	"github.com/kubestellar/ui/wds/bp"
 )
 
 func setupBindingPolicyRoutes(router *gin.Engine) {

--- a/backend/routes/cluster.go
+++ b/backend/routes/cluster.go
@@ -1,10 +1,11 @@
 package routes
 
 import (
-	"github.com/gin-gonic/gin"
-	"github.com/katamyra/kubestellarUI/api"
-	"github.com/katamyra/kubestellarUI/its/manual/handlers"
 	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/kubestellar/ui/api"
+	"github.com/kubestellar/ui/its/manual/handlers"
 )
 
 func setupClusterRoutes(router *gin.Engine) {

--- a/backend/routes/deployment.go
+++ b/backend/routes/deployment.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
-	"github.com/katamyra/kubestellarUI/wds"
-	"github.com/katamyra/kubestellarUI/wds/deployment"
+	"github.com/kubestellar/ui/wds"
+	"github.com/kubestellar/ui/wds/deployment"
 	"k8s.io/client-go/informers"
 )
 

--- a/backend/routes/gitops.go
+++ b/backend/routes/gitops.go
@@ -2,7 +2,7 @@ package routes
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/katamyra/kubestellarUI/api"
+	"github.com/kubestellar/ui/api"
 )
 
 func setupGitopsRoutes(router *gin.Engine) {

--- a/backend/routes/jwt.go
+++ b/backend/routes/jwt.go
@@ -4,9 +4,9 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/katamyra/kubestellarUI/middleware"
-	"github.com/katamyra/kubestellarUI/models"
-	"github.com/katamyra/kubestellarUI/utils"
+	"github.com/kubestellar/ui/middleware"
+	"github.com/kubestellar/ui/models"
+	"github.com/kubestellar/ui/utils"
 )
 
 // SetupAuthRoutes initializes authentication routes

--- a/backend/routes/namespace.go
+++ b/backend/routes/namespace.go
@@ -2,7 +2,7 @@ package routes
 
 import (
 	"github.com/gin-gonic/gin"
-	nsresources "github.com/katamyra/kubestellarUI/namespace/resources"
+	nsresources "github.com/kubestellar/ui/namespace/resources"
 )
 
 func setupNamespaceRoutes(router *gin.Engine) {

--- a/backend/routes/resources.go
+++ b/backend/routes/resources.go
@@ -2,8 +2,8 @@ package routes
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/katamyra/kubestellarUI/k8s"
-	"github.com/katamyra/kubestellarUI/wds"
+	"github.com/kubestellar/ui/k8s"
+	"github.com/kubestellar/ui/wds"
 )
 
 // SetupRoutes initializes all API routes

--- a/backend/services/clusterService.go
+++ b/backend/services/clusterService.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/katamyra/kubestellarUI/models"
+	"github.com/kubestellar/ui/models"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"

--- a/backend/utils/jwt.go
+++ b/backend/utils/jwt.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	jwtconfig "github.com/katamyra/kubestellarUI/jwt"
+	jwtconfig "github.com/kubestellar/ui/jwt"
 )
 
 type Claims struct {

--- a/backend/wds/bp/handlers.go
+++ b/backend/wds/bp/handlers.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/katamyra/kubestellarUI/log"
-	"github.com/katamyra/kubestellarUI/utils"
 	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
+	"github.com/kubestellar/ui/log"
+	"github.com/kubestellar/ui/utils"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/backend/wds/bp/utils.go
+++ b/backend/wds/bp/utils.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/katamyra/kubestellarUI/log"
 	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
 	bpv1alpha1 "github.com/kubestellar/kubestellar/pkg/generated/clientset/versioned/typed/control/v1alpha1"
+	"github.com/kubestellar/ui/log"
 	"go.uber.org/zap"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"

--- a/backend/wds/deployment/common.go
+++ b/backend/wds/deployment/common.go
@@ -21,8 +21,8 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	FetchYaml "github.com/katamyra/kubestellarUI/github"
-	"github.com/katamyra/kubestellarUI/wds"
+	FetchYaml "github.com/kubestellar/ui/github"
+	"github.com/kubestellar/ui/wds"
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/backend/wds/deployment/details.go
+++ b/backend/wds/deployment/details.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/katamyra/kubestellarUI/wds"
+	"github.com/kubestellar/ui/wds"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/backend/wds/deployment/logs.go
+++ b/backend/wds/deployment/logs.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/katamyra/kubestellarUI/wds"
+	"github.com/kubestellar/ui/wds"
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"

--- a/backend/wds/deployment/status.go
+++ b/backend/wds/deployment/status.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/katamyra/kubestellarUI/wds"
+	"github.com/kubestellar/ui/wds"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 


### PR DESCRIPTION
**Title:**  
Chore: Update module name to `github.com/kubestellar/ui`  

**Description:**  
This PR updates the Go module name from `github.com/katamyra/kubestellarUI` to `github.com/kubestellar/ui` to align with the new repository structure.  

### **Changes Made:**  
- Updated `go.mod` to reflect the new module name.  
- Replaced all occurrences of `github.com/katamyra/kubestellarUI` with `github.com/kubestellar/ui`.  
- Ran `go mod tidy` and `go mod vendor` to update dependencies.  
- Verified that the project builds successfully.  

### **Checklist** ✅  
- [ ] Updated `go.mod` with the correct module name.  
- [ ] Replaced all outdated import paths.  
- [ ] Ran `go mod tidy` and `go mod vendor`.  
- [ ] Tested the project after changes.  

### **Screenshots (if applicable):** 📷  
_(Attach any relevant logs or screenshots)_  

### **Issue Reference:** 🔗  
Closes #376

### **Additional Notes:**  
_(Mention any additional concerns or testing notes)_  