### PR TITLE
Update docker-push.yml

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,12 +1,12 @@
 name: Docker Image Build and Push
-on:
-  workflow_dispatch:
+# on:
+#   workflow_dispatch:
 
-  pull_request:
-    types:
-      - closed
-    branches:
-      - dev
+  # pull_request:
+  #   types:
+  #     - closed
+  #   branches:
+  #     - dev
 
 jobs:
   build-and-push:


### PR DESCRIPTION
## **🔧 Disable Image Push to Quay.io**  

### **📌 Description**  
This PR disables pushing images to [[Quay.io](https://quay.io/)](https://quay.io/) due to unwanted issues affecting deployments or security. The change ensures that no new images are pushed until the root cause is identified and resolved.  

Fixes #384 
### **🛠 Changes Made**  
- Disabled the Quay.io image push step in the CI/CD pipeline.  
- Updated configuration files to prevent accidental pushes.  
- Added comments/documentation on why this change was made.  

### **🎯 Impact**  
- No new images will be pushed to Quay.io.  
- Prevents potential deployment failures or security risks.  
- Requires further investigation before re-enabling.  

### **✅ How to Test**  
1. Run the CI/CD pipeline and ensure no images are pushed to Quay.io.  
2. Check the logs to confirm the push step is skipped.  
3. Validate that other build processes remain unaffected.  

### **🚀 Next Steps**  
- Investigate the root cause of the issue.  
- Implement fixes before re-enabling image push.  
- Communicate with the team about the changes.  

### **📌 Related Issue**  
Closes #<ISSUE_NUMBER>  

### **📷 Screenshots (if applicable)**  
_Add logs or screenshots to support the changes._  

### **⚠️ Checklist**  
- [ ] I have tested the changes.  
- [ ] I have updated relevant documentation.  
- [ ] The pipeline is not breaking due to this change.  



Let me know if you need any modifications! 🚀