### PR TITLE
Moving the drag and drop feature inside the create binding policy

### DIFF
--- a/src/components/BindingPolicy/ClusterPanel.tsx
+++ b/src/components/BindingPolicy/ClusterPanel.tsx
@@ -107,7 +107,7 @@ const ClusterPanel: React.FC<ClusterPanelProps> = ({
             {error}
           </Typography>
         ) : clusters.length === 0 ? (
-          <Typography sx={{ p: 2, color: 'text.secondary' }}>
+          <Typography sx={{ p: 2, color: 'text.secondary', textAlign: 'center' }}>
             No clusters available
           </Typography>
         ) : (
@@ -120,7 +120,13 @@ const ClusterPanel: React.FC<ClusterPanelProps> = ({
                 data-rfd-droppable-context-id={provided.droppableProps['data-rfd-droppable-context-id']}
                 sx={{ minHeight: '100%' }}
               >
-                {clusters.map((cluster, index) => renderClusterItem(cluster, index))}
+                {clusters.length === 0 ? (
+                  <Typography sx={{ p: 2, color: 'text.secondary', textAlign: 'center' }}>
+                    All clusters are on the canvas
+                  </Typography>
+                ) : (
+                  clusters.map((cluster, index) => renderClusterItem(cluster, index))
+                )}
                 {provided.placeholder}
               </Box>
             )}

--- a/src/components/BindingPolicy/ConfigurationSidebar.tsx
+++ b/src/components/BindingPolicy/ConfigurationSidebar.tsx
@@ -58,18 +58,20 @@ export interface PolicyConfiguration {
 interface ConfigurationSidebarProps {
   open: boolean;
   onClose: () => void;
-  selectedConnection?: {
+  selectedConnection: {
     source: { type: string; id: string; name: string };
     target: { type: string; id: string; name: string };
-  };
+  } | undefined;
   onSaveConfiguration: (config: PolicyConfiguration) => void;
+  dialogMode?: boolean;
 }
 
 const ConfigurationSidebar: React.FC<ConfigurationSidebarProps> = ({
   open,
   onClose,
   selectedConnection,
-  onSaveConfiguration
+  onSaveConfiguration,
+
 }) => {
   // Form state
   const [name, setName] = useState('');

--- a/src/components/BindingPolicy/ConnectionManager.tsx
+++ b/src/components/BindingPolicy/ConnectionManager.tsx
@@ -14,6 +14,7 @@ interface ConnectionManagerProps {
   clusters: ManagedCluster[];
   onQuickPolicySave: (config: PolicyConfiguration) => void;
   setSuccessMessage: (message: string) => void;
+  dialogMode?: boolean;
 }
 
 // Define the QuickPolicyDialogProps type here since it's not exported from the component
@@ -36,7 +37,7 @@ const ConnectionManager = forwardRef<
   workloads,
   clusters,
   onQuickPolicySave,
-  setSuccessMessage
+  setSuccessMessage,
 }, ref) => {
   // Get state and actions from the connection manager store
   const connectionMode = useConnectionManagerStore(state => state.connectionMode);

--- a/src/components/BindingPolicy/Dialogs/BPHeader.tsx
+++ b/src/components/BindingPolicy/Dialogs/BPHeader.tsx
@@ -12,6 +12,7 @@ import {
 import { Search, Filter, Plus, X, Trash2 } from "lucide-react";
 import CreateBindingPolicyDialog, {PolicyData} from "../CreateBindingPolicyDialog";
 import useTheme from "../../../stores/themeStore";
+import { ManagedCluster, Workload } from "../../../types/bindingPolicy";
 
 interface BPHeaderProps {
   searchQuery: string;
@@ -26,6 +27,8 @@ interface BPHeaderProps {
   selectedPolicies: string[];
   onBulkDelete: () => void;
   policyCount: number;
+  clusters?: ManagedCluster[];
+  workloads?: Workload[];
 }
 
 const BPHeader: React.FC<BPHeaderProps> = ({
@@ -39,6 +42,8 @@ const BPHeader: React.FC<BPHeaderProps> = ({
   selectedPolicies,
   onBulkDelete,
   policyCount,
+  clusters = [],
+  workloads = [],
 }) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const theme = useTheme((state) => state.theme);
@@ -317,6 +322,8 @@ const BPHeader: React.FC<BPHeaderProps> = ({
         open={createDialogOpen}
         onClose={() => setCreateDialogOpen(false)}
         onCreatePolicy={onCreatePolicy}
+        clusters={clusters}
+        workloads={workloads}
       />
     </div>
   );

--- a/src/components/BindingPolicy/PolicyDragDrop.tsx
+++ b/src/components/BindingPolicy/PolicyDragDrop.tsx
@@ -1,7 +1,28 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { BindingPolicyInfo, Workload, ManagedCluster } from '../../types/bindingPolicy';
 import { PolicyConfiguration } from './ConfigurationSidebar';
 import PolicyDragDropContainer from './PolicyDragDropContainer';
+import { 
+  Dialog, 
+  DialogTitle, 
+  DialogContent, 
+  DialogActions, 
+  Button, 
+  Box,
+  Typography,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  IconButton,
+  Tooltip
+} from '@mui/material';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import TuneIcon from '@mui/icons-material/Tune';
+import SaveIcon from '@mui/icons-material/Save';
+import PublishIcon from '@mui/icons-material/Publish';
 
 interface PolicyDragDropProps {
   policies?: BindingPolicyInfo[];
@@ -9,10 +30,115 @@ interface PolicyDragDropProps {
   workloads?: Workload[];
   onPolicyAssign?: (policyName: string, targetType: 'cluster' | 'workload', targetName: string) => void;
   onCreateBindingPolicy?: (clusterId: string, workloadId: string, configuration?: PolicyConfiguration) => void;
+  dialogMode?: boolean;
 }
 
+const HelpDialog: React.FC<{open: boolean, onClose: () => void}> = ({open, onClose}) => {
+  return (
+    <Dialog 
+      open={open} 
+      onClose={onClose} 
+      maxWidth="md"
+      PaperProps={{
+        sx: {
+          maxWidth: '600px'
+        }
+      }}
+    >
+      <DialogTitle>
+        <Box display="flex" alignItems="center">
+          <DragIndicatorIcon sx={{ mr: 1 }} />
+          <Typography variant="h6">How to Use Drag & Drop</Typography>
+        </Box>
+      </DialogTitle>
+      <DialogContent>
+        <Typography paragraph>
+          Follow these steps to create binding policies using the drag & drop interface:
+        </Typography>
+        <List>
+          <ListItem>
+            <ListItemIcon><DragIndicatorIcon color="primary" /></ListItemIcon>
+            <ListItemText 
+              primary="1. Drag clusters and workloads" 
+              secondary="Drag clusters from the left panel and workloads from the right panel onto the canvas area"
+            />
+          </ListItem>
+          <ListItem>
+            <ListItemIcon><ArrowForwardIcon color="primary" /></ListItemIcon>
+            <ListItemText 
+              primary="2. Create connections" 
+              secondary="Click on a workload first, then click on a cluster to create a direct connection between them"
+            />
+          </ListItem>
+          <ListItem>
+            <ListItemIcon><TuneIcon color="primary" /></ListItemIcon>
+            <ListItemText 
+              primary="3. Configure your policy" 
+              secondary="Fill in the details like name, namespace, propagation mode, and update strategy"
+            />
+          </ListItem>
+          <ListItem>
+            <ListItemIcon><SaveIcon color="primary" /></ListItemIcon>
+            <ListItemText 
+              primary="4. Create each policy" 
+              secondary="Click 'Create Policy' to save individual connections"
+            />
+          </ListItem>
+          <ListItem>
+            <ListItemIcon><PublishIcon color="primary" /></ListItemIcon>
+            <ListItemText 
+              primary="5. Deploy your policies" 
+              secondary="When done creating all connections, click 'Deploy Binding Policies' to deploy all connections at once"
+            />
+          </ListItem>
+        </List>
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 2, fontStyle: 'italic' }}>
+          Tip: You can preview the YAML for each connection by switching to the 'Preview YAML' tab in the policy creation dialog.
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} variant="contained">Got it</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
 const PolicyDragDrop: React.FC<PolicyDragDropProps> = (props) => {
-  return <PolicyDragDropContainer {...props} />;
+  const [helpDialogOpen, setHelpDialogOpen] = useState(props.dialogMode ? true : false);
+  
+  return (
+    <Box sx={{ position: 'relative' }}>
+      <Box sx={{ 
+        position: 'fixed', 
+        top: 40, 
+        right: 110, 
+        zIndex: 10 
+      }}>
+        <Tooltip title="View drag & drop instructions">
+          <IconButton 
+            onClick={() => setHelpDialogOpen(true)} 
+            size="small"
+            sx={{ 
+              bgcolor: 'background.paper', 
+              boxShadow: 1,
+              '&:hover': {
+                bgcolor: 'background.paper',
+              }
+            }}
+          >
+            <HelpOutlineIcon />
+          </IconButton>
+        </Tooltip>
+      </Box>
+      
+      <PolicyDragDropContainer {...props} />
+      
+      <HelpDialog 
+        open={helpDialogOpen} 
+        onClose={() => setHelpDialogOpen(false)} 
+      />
+    </Box>
+  );
 };
 
 export default React.memo(PolicyDragDrop);

--- a/src/components/BindingPolicy/PolicyPanels.tsx
+++ b/src/components/BindingPolicy/PolicyPanels.tsx
@@ -7,19 +7,22 @@ import WorkloadPanel from './WorkloadPanel';
 interface ClusterPanelContainerProps {
   clusters: ManagedCluster[];
   loading: boolean;
-  error?: string;
+  error: string | undefined;
+  compact?: boolean;
 }
 
 interface WorkloadPanelContainerProps {
   workloads: Workload[];
   loading: boolean;
-  error?: string;
+  error: string | undefined;
+  compact?: boolean;
 }
 
 export const ClusterPanelContainer: React.FC<ClusterPanelContainerProps> = ({
   clusters,
   loading,
-  error
+  error,
+
 }) => {
   return (
     <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
@@ -36,7 +39,8 @@ export const ClusterPanelContainer: React.FC<ClusterPanelContainerProps> = ({
 export const WorkloadPanelContainer: React.FC<WorkloadPanelContainerProps> = ({
   workloads,
   loading,
-  error
+  error,
+
 }) => {
   return (
     <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>

--- a/src/components/BindingPolicy/QuickPolicyDialog.tsx
+++ b/src/components/BindingPolicy/QuickPolicyDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { 
   Dialog, 
   DialogTitle, 
@@ -11,11 +11,18 @@ import {
   Switch, 
   Box, 
   Typography, 
-  Chip 
+  Chip,
+  Tabs,
+  Tab
 } from '@mui/material';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import LocalOfferIcon from '@mui/icons-material/LocalOffer';
+import CodeIcon from '@mui/icons-material/Code';
+import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
 import { PolicyConfiguration } from './ConfigurationSidebar';
+import Editor from "@monaco-editor/react";
+import yaml from "js-yaml";
+import useTheme from "../../stores/themeStore";
 
 export interface QuickPolicyDialogProps {
   open: boolean;
@@ -29,6 +36,10 @@ export interface QuickPolicyDialogProps {
 }
 
 const QuickPolicyDialog: React.FC<QuickPolicyDialogProps> = ({ open, onClose, onSave, connection }) => {
+  const theme = useTheme((state) => state.theme);
+  const isDarkTheme = theme === "dark";
+  
+  const [activeTab, setActiveTab] = useState<'form' | 'preview'>('form');
   const [name, setName] = useState('');
   const [namespace, setNamespace] = useState('default');
   const [propagationMode, setPropagationMode] = useState<'DownsyncOnly' | 'UpsyncOnly' | 'BidirectionalSync'>('DownsyncOnly');
@@ -37,6 +48,7 @@ const QuickPolicyDialog: React.FC<QuickPolicyDialogProps> = ({ open, onClose, on
   const [customLabels, setCustomLabels] = useState<Record<string, string>>({});
   const [labelKey, setLabelKey] = useState('');
   const [labelValue, setLabelValue] = useState('');
+  const [generatedYaml, setGeneratedYaml] = useState('');
 
   // Initialize form when connection changes
   useEffect(() => {
@@ -45,6 +57,68 @@ const QuickPolicyDialog: React.FC<QuickPolicyDialogProps> = ({ open, onClose, on
       setNamespace(connection.workloadNamespace || 'default');
     }
   }, [connection]);
+  const updateYamlPreview = useCallback(() => {
+    if (!connection) {
+      setGeneratedYaml('# No connection selected');
+      return;
+    }
+
+    try {
+      // Create policy object from form values
+      const policyObj = {
+        apiVersion: 'policy.kubestellar.io/v1alpha1',
+        kind: 'BindingPolicy',
+        metadata: {
+          name: name || `${connection.workloadName}-to-${connection.clusterName}`,
+          namespace: namespace || connection.workloadNamespace || 'default',
+          ...(Object.keys(customLabels).length > 0 && { labels: customLabels })
+        },
+        spec: {
+          clusterSelectors: [
+            {
+              matchLabels: {
+                'kubernetes.io/cluster-name': connection.clusterName
+              }
+            }
+          ],
+          downsync: [
+            {
+              apiGroup: 'apps/v1',
+              resources: ['deployments'],
+              namespace: namespace || connection.workloadNamespace || 'default',
+              resourceNames: [connection.workloadName]
+            }
+          ],
+          propagationMode: propagationMode,
+          updateStrategy: updateStrategy
+        }
+      };
+
+      // Convert to YAML
+      const yamlString = yaml.dump(policyObj, {
+        indent: 2,
+        lineWidth: -1
+      });
+      
+      setGeneratedYaml(yamlString);
+    } catch (error) {
+      console.error('Error generating YAML preview:', error);
+      setGeneratedYaml('# Error generating YAML preview');
+    }
+  }, [connection, name, namespace, customLabels, propagationMode, updateStrategy]);
+  // Update YAML preview whenever form values change
+  useEffect(() => {
+    updateYamlPreview();
+  }, [name, namespace, propagationMode, updateStrategy, customLabels, connection, updateYamlPreview]);
+
+  const handleTabChange = (_event: React.SyntheticEvent, newValue: 'form' | 'preview') => {
+    setActiveTab(newValue);
+    if (newValue === 'preview') {
+      updateYamlPreview();
+    }
+  };
+
+ 
 
   const handleAddLabel = () => {
     if (labelKey && labelValue) {
@@ -107,123 +181,181 @@ const QuickPolicyDialog: React.FC<QuickPolicyDialogProps> = ({ open, onClose, on
     }
   };
 
+  const renderFormContent = () => (
+    <>
+      {connection && (
+        <Box sx={{ mb: 3, display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Typography variant="body2" color="text.secondary">
+            Creating connection:
+          </Typography>
+          <Chip 
+            size="small" 
+            label={connection.workloadName} 
+            color="success" 
+          />
+          <ArrowForwardIcon fontSize="small" color="action" />
+          <Chip 
+            size="small" 
+            label={connection.clusterName}
+            color="info" 
+          />
+        </Box>
+      )}
+      
+      <TextField
+        autoFocus
+        margin="dense"
+        label="Policy Name"
+        fullWidth
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        sx={{ mb: 2 }}
+      />
+      
+      <TextField
+        margin="dense"
+        label="Namespace"
+        fullWidth
+        value={namespace}
+        onChange={(e) => setNamespace(e.target.value)}
+        sx={{ mb: 2 }}
+      />
+      
+      <TextField
+        select
+        margin="dense"
+        label="Propagation Mode"
+        fullWidth
+        value={propagationMode}
+        onChange={(e) => setPropagationMode(e.target.value as 'DownsyncOnly' | 'UpsyncOnly' | 'BidirectionalSync')}
+        sx={{ mb: 2 }}
+      >
+        <MenuItem value="DownsyncOnly">Downsync Only</MenuItem>
+        <MenuItem value="UpsyncOnly">Upsync Only</MenuItem>
+        <MenuItem value="BidirectionalSync">Bidirectional Sync</MenuItem>
+      </TextField>
+      
+      <TextField
+        select
+        margin="dense"
+        label="Update Strategy"
+        fullWidth
+        value={updateStrategy}
+        onChange={(e) => setUpdateStrategy(e.target.value as 'ServerSideApply' | 'ForceApply' | 'RollingUpdate' | 'BlueGreenDeployment')}
+        sx={{ mb: 2 }}
+      >
+        <MenuItem value="ServerSideApply">Server Side Apply</MenuItem>
+        <MenuItem value="ForceApply">Force Apply</MenuItem>
+        <MenuItem value="RollingUpdate">Rolling Update</MenuItem>
+        <MenuItem value="BlueGreenDeployment">Blue-Green Deployment</MenuItem>
+      </TextField>
+      
+      <FormControlLabel
+        control={
+          <Switch 
+            checked={addLabels} 
+            onChange={(e) => setAddLabels(e.target.checked)} 
+          />
+        }
+        label="Add custom labels"
+        sx={{ mb: 1 }}
+      />
+      
+      {addLabels && (
+        <Box sx={{ mb: 2 }}>
+          <Box sx={{ display: 'flex', mb: 1 }}>
+            <TextField
+              size="small"
+              label="Key"
+              value={labelKey}
+              onChange={(e) => setLabelKey(e.target.value)}
+              sx={{ mr: 1, flexGrow: 1 }}
+            />
+            <TextField
+              size="small"
+              label="Value"
+              value={labelValue}
+              onChange={(e) => setLabelValue(e.target.value)}
+              sx={{ mr: 1, flexGrow: 1 }}
+            />
+            <Button onClick={handleAddLabel} disabled={!labelKey || !labelValue}>
+              Add
+            </Button>
+          </Box>
+          
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+            {Object.entries(customLabels).map(([key, value]) => (
+              <Chip
+                key={key}
+                label={`${key}: ${value}`}
+                onDelete={() => handleRemoveLabel(key)}
+                size="small"
+                icon={<LocalOfferIcon fontSize="small" />}
+              />
+            ))}
+          </Box>
+        </Box>
+      )}
+    </>
+  );
+
+  const renderYamlPreview = () => (
+    <Box sx={{ height: "450px", border: `1px solid ${isDarkTheme ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.1)'}` }}>
+      <Editor
+        height="100%"
+        language="yaml"
+        value={generatedYaml}
+        theme={isDarkTheme ? "vs-dark" : "light"}
+        options={{
+          readOnly: true,
+          minimap: { enabled: false },
+          fontSize: 14,
+          lineNumbers: "on",
+          scrollBeyondLastLine: false,
+          automaticLayout: true,
+          fontFamily: "'JetBrains Mono', monospace",
+          padding: { top: 10 },
+        }}
+      />
+    </Box>
+  );
+
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+    <Dialog 
+      open={open} 
+      onClose={onClose} 
+      maxWidth="md" 
+      fullWidth
+      PaperProps={{
+        sx: {
+          maxHeight: '90vh', // Increase max height
+          width: '700px',    // Set a custom width
+          margin: 'auto'
+        }
+      }}
+    >
       <DialogTitle>Create Binding Policy</DialogTitle>
-      <DialogContent>
-        {connection && (
-          <Box sx={{ mb: 3, display: 'flex', alignItems: 'center', gap: 1 }}>
-            <Typography variant="body2" color="text.secondary">
-              Creating connection:
-            </Typography>
-            <Chip 
-              size="small" 
-              label={connection.workloadName} 
-              color="success" 
-            />
-            <ArrowForwardIcon fontSize="small" color="action" />
-            <Chip 
-              size="small" 
-              label={connection.clusterName}
-              color="info" 
-            />
-          </Box>
-        )}
-        
-        <TextField
-          autoFocus
-          margin="dense"
-          label="Policy Name"
-          fullWidth
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          sx={{ mb: 2 }}
-        />
-        
-        <TextField
-          margin="dense"
-          label="Namespace"
-          fullWidth
-          value={namespace}
-          onChange={(e) => setNamespace(e.target.value)}
-          sx={{ mb: 2 }}
-        />
-        
-        <TextField
-          select
-          margin="dense"
-          label="Propagation Mode"
-          fullWidth
-          value={propagationMode}
-          onChange={(e) => setPropagationMode(e.target.value as 'DownsyncOnly' | 'UpsyncOnly' | 'BidirectionalSync')}
-          sx={{ mb: 2 }}
+      <DialogContent sx={{ pb: 1, minHeight: '500px' }}>
+        <Tabs
+          value={activeTab}
+          onChange={handleTabChange}
+          sx={{ mb: 2, borderBottom: 1, borderColor: 'divider' }}
         >
-          <MenuItem value="DownsyncOnly">Downsync Only</MenuItem>
-          <MenuItem value="UpsyncOnly">Upsync Only</MenuItem>
-          <MenuItem value="BidirectionalSync">Bidirectional Sync</MenuItem>
-        </TextField>
+          <Tab 
+            icon={<FormatListBulletedIcon fontSize="small" />} 
+            iconPosition="start" 
+            label="Form" 
+            value="form" 
+          />
+          <Tab 
+            icon={<CodeIcon fontSize="small" />} 
+            iconPosition="start" 
+            label="Preview YAML" 
+            value="preview" 
+          />
+        </Tabs>
         
-        <TextField
-          select
-          margin="dense"
-          label="Update Strategy"
-          fullWidth
-          value={updateStrategy}
-          onChange={(e) => setUpdateStrategy(e.target.value as 'ServerSideApply' | 'ForceApply' | 'RollingUpdate' | 'BlueGreenDeployment')}
-          sx={{ mb: 2 }}
-        >
-          <MenuItem value="ServerSideApply">Server Side Apply</MenuItem>
-          <MenuItem value="ForceApply">Force Apply</MenuItem>
-          <MenuItem value="RollingUpdate">Rolling Update</MenuItem>
-          <MenuItem value="BlueGreenDeployment">Blue-Green Deployment</MenuItem>
-        </TextField>
-        
-        <FormControlLabel
-          control={
-            <Switch 
-              checked={addLabels} 
-              onChange={(e) => setAddLabels(e.target.checked)} 
-            />
-          }
-          label="Add custom labels"
-          sx={{ mb: 1 }}
-        />
-        
-        {addLabels && (
-          <Box sx={{ mb: 2 }}>
-            <Box sx={{ display: 'flex', mb: 1 }}>
-              <TextField
-                size="small"
-                label="Key"
-                value={labelKey}
-                onChange={(e) => setLabelKey(e.target.value)}
-                sx={{ mr: 1, flexGrow: 1 }}
-              />
-              <TextField
-                size="small"
-                label="Value"
-                value={labelValue}
-                onChange={(e) => setLabelValue(e.target.value)}
-                sx={{ mr: 1, flexGrow: 1 }}
-              />
-              <Button onClick={handleAddLabel} disabled={!labelKey || !labelValue}>
-                Add
-              </Button>
-            </Box>
-            
-            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-              {Object.entries(customLabels).map(([key, value]) => (
-                <Chip
-                  key={key}
-                  label={`${key}: ${value}`}
-                  onDelete={() => handleRemoveLabel(key)}
-                  size="small"
-                  icon={<LocalOfferIcon fontSize="small" />}
-                />
-              ))}
-            </Box>
-          </Box>
-        )}
+        {activeTab === 'form' ? renderFormContent() : renderYamlPreview()}
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>Cancel</Button>

--- a/src/components/BindingPolicy/WorkloadPanel.tsx
+++ b/src/components/BindingPolicy/WorkloadPanel.tsx
@@ -130,7 +130,7 @@ const WorkloadPanel: React.FC<WorkloadPanelProps> = ({
             {error}
           </Typography>
         ) : workloads.length === 0 ? (
-          <Typography sx={{ p: 2, color: 'text.secondary' }}>
+          <Typography sx={{ p: 2, color: 'text.secondary', textAlign: 'center' }}>
             No workloads available
           </Typography>
         ) : (
@@ -143,7 +143,13 @@ const WorkloadPanel: React.FC<WorkloadPanelProps> = ({
                 data-rbd-droppable-context-id={provided.droppableProps['data-rfd-droppable-context-id']}
                 sx={{ minHeight: '100%' }}
               >
-                {workloads.map((workload, index) => renderWorkloadItem(workload, index))}
+                {workloads.length === 0 ? (
+                  <Typography sx={{ p: 2, color: 'text.secondary', textAlign: 'center' }}>
+                    All workloads are on the canvas
+                  </Typography>
+                ) : (
+                  workloads.map((workload, index) => renderWorkloadItem(workload, index))
+                )}
                 {provided.placeholder}
               </Box>
             )}


### PR DESCRIPTION
### Description
Moving the drag and drop feature inside the create binding policy dialog. You can directly access it from the create binding policy.

### Related Issue
Fixes #395 

### Changes Made
- Added drag and drop inside the create bp dialog.
- Removed the drag and drop from the main tab.
- Added new button "create" workload.
- UI improved to make it consistent.
- Now clusters and workloads if present on canvas will not be shown on the available panel.

### Checklist
Please ensure the following before submitting your PR:
- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.
