### PR TITLE
Update default branch name to 'main'

### DIFF
--- a/src/components/CreateOptions.tsx
+++ b/src/components/CreateOptions.tsx
@@ -93,7 +93,7 @@ spec:
     repositoryUrl: "",
     path: "",
     credentials: "none",
-    branchSpecifier: "master",
+    branchSpecifier: "main",
     webhook: "none",
   };
   const [formData, setFormData] = useState<FormData>(initialFormData);
@@ -306,7 +306,7 @@ spec:
       const requestBody = {
         repo_url: formData.repositoryUrl,
         folder_path: formData.path,
-        branch: formData.branchSpecifier || "master",
+        branch: formData.branchSpecifier || "main",
         webhook: formData.webhook !== "none" ? formData.webhook : undefined,
       };
 
@@ -317,7 +317,7 @@ spec:
         const pat = storedCredentials[formData.credentials]?.personalAccessToken;
         queryParams.git_username = git_username;
         queryParams.git_token = pat;
-        queryParams.branch = formData.branchSpecifier || "master";
+        queryParams.branch = formData.branchSpecifier || "main";
       }
 
       const response = await axios.post(
@@ -336,7 +336,7 @@ spec:
           repositoryUrl: "",
           path: "",
           credentials: "none",
-          branchSpecifier: "master",
+          branchSpecifier: "main",
           webhook: "none",
         });
         setTimeout(() => window.location.reload(), 4000);

--- a/src/components/Workloads/GitHubTab.tsx
+++ b/src/components/Workloads/GitHubTab.tsx
@@ -79,7 +79,7 @@ export const GitHubTab = ({
               setFormData({ ...formData, repositoryUrl: e.target.value })
             }
             error={!!error && !formData.repositoryUrl}
-            placeholder="e.g., https://github.com/username/repo.git"
+            placeholder="e.g., https://github.com/username/repo"
             InputProps={{
               startAdornment: (
                 <span role="img" aria-label="cluster" style={{ fontSize: "0.9rem", marginRight: "8px" }}>
@@ -204,7 +204,7 @@ export const GitHubTab = ({
               mb: 1,
             }}
           >
-            Branch (default: master)
+            Branch (default: main)
           </Typography>
           <TextField
             fullWidth
@@ -212,7 +212,7 @@ export const GitHubTab = ({
             onChange={(e) =>
               setFormData({ ...formData, branchSpecifier: e.target.value })
             }
-            placeholder="e.g., main, dev-branch"
+            placeholder="e.g., master, dev-branch"
             InputProps={{
               startAdornment: (
                 <span role="img" aria-label="cluster" style={{ fontSize: "0.9rem", marginRight: "8px" }}>


### PR DESCRIPTION
Change all instances of the default branch name from 'master' to 'main' in the CreateOptions and GitHubTab components. Update related placeholder text accordingly.

Fixes #403