### PR TITLE
fixes active inactive issue for BP backend

### DIFF
--- a/backend/wds/bp/handlers.go
+++ b/backend/wds/bp/handlers.go
@@ -876,26 +876,9 @@ func GetBpStatus(ctx *gin.Context) {
 
 	// Determine if the policy is active based on status fields
 	status := "inactive"
-
-	// Check if any conditions are present and if Synced and Ready are True
-	hasSync := false
-	hasReady := false
-
-	if bp.Status.Conditions != nil {
-		for _, condition := range bp.Status.Conditions {
-			if condition.Type == "Synced" && condition.Status == "True" {
-				hasSync = true
-			}
-			if condition.Type == "Ready" && condition.Status == "True" {
-				hasReady = true
-			}
-		}
-	}
-
-	if hasSync && hasReady {
+	if bp.ObjectMeta.Generation == bp.Status.ObservedGeneration {
 		status = "active"
 	}
-
 	// Initialize clusters and workloads slices
 	clusters := []string{}
 	workloads := []string{}

--- a/backend/wds/bp/utils.go
+++ b/backend/wds/bp/utils.go
@@ -281,6 +281,11 @@ func watchOnBps() {
 			switch event.Type {
 			case "MODIFIED":
 				bp, _ := event.Object.(*v1alpha1.BindingPolicy)
+				if bp.ObjectMeta.Generation == bp.Status.ObservedGeneration {
+					log.LogInfo("reconciled successfully", zap.String("name", bp.Name))
+				} else {
+					log.LogInfo("reconciling...", zap.String("name", bp.Name))
+				}
 				log.LogInfo("BP modified: ", zap.String("name", bp.Name))
 
 			case "ADDED":


### PR DESCRIPTION
### Description

this fixes the inactive state reported for BP from backend of KS UI. @kunal-511 you can update the frontend now to use this endpoint it should reflect the latest state. You might need to call it multiple times because state becomes active after some secs. after controller reconciles it fully.

closes #441 

### Checklist
Please ensure the following before submitting your PR:
- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)
<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->


### Additional Notes
<!-- Add any other context, suggestions, or questions related to this PR. -->
