### PR TITLE
Fixed the binding policy status issue with some dark mode issues

### DIFF
--- a/src/components/BindingPolicy/BPVisualization.tsx
+++ b/src/components/BindingPolicy/BPVisualization.tsx
@@ -1124,8 +1124,10 @@ const BPVisualization: React.FC<BPVisualizationProps> = ({ policies, clusters: p
         
         setNodes(newNodes);
         setEdges(newEdges);
-        setLoading(false);
       }
+      
+
+      setLoading(false);
     };
 
     generateGraph();

--- a/src/components/BindingPolicy/Dialogs/DeleteDialog.tsx
+++ b/src/components/BindingPolicy/Dialogs/DeleteDialog.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   Typography,
 } from "@mui/material";
+import useTheme from "../../../stores/themeStore";
 
 interface DeleteDialogProps {
   open: boolean;
@@ -21,15 +22,19 @@ const DeleteDialog: React.FC<DeleteDialogProps> = ({
   onConfirm,
   policyName,
 }) => {
+  const theme = useTheme((state) => state.theme)
+  const isDarkTheme = theme === "dark";
   return (
     <Dialog 
       open={open} 
       onClose={onClose}
       PaperProps={{
         sx: {
-          width: '500px', // Fixed width
-          minHeight: '200px', // Minimum height
-          m: 2, // Consistent margin
+          width: '500px', 
+          minHeight: '200px', 
+          m: 2, 
+          backgroundColor: isDarkTheme ? "#1e293b" : "#fff",
+          color: isDarkTheme ? "#fff" : "#000",
         }
       }}
     >

--- a/src/components/BindingPolicy/Dialogs/PolicyDetailDialog.tsx
+++ b/src/components/BindingPolicy/Dialogs/PolicyDetailDialog.tsx
@@ -121,7 +121,7 @@ const PolicyDetailDialog: React.FC<PolicyDetailDialogProps> = ({
         PaperProps={{
           sx: {
             backgroundColor: isDarkTheme ? "#1e293b" : "#fff",
-            color: isDarkTheme ? "#fff" : "inherit",
+            color: isDarkTheme ? "#fff" : "#000",
           },
         }}
       >

--- a/src/hooks/queries/useBPQueries.ts
+++ b/src/hooks/queries/useBPQueries.ts
@@ -266,6 +266,26 @@ export const useBPQueries = () => {
     });
   };
 
+  // GET /api/bp/status?name=policyName - Fetch only status for a specific binding policy
+  const useBindingPolicyStatus = (policyName: string | undefined) => {
+    return useQuery<{status: string}, Error>({
+      queryKey: ['binding-policy-status', policyName],
+      queryFn: async () => {
+        if (!policyName) throw new Error('Policy name is required');
+        
+        console.log(`Fetching status for binding policy: ${policyName}`);
+        const response = await api.get(`/api/bp/status?name=${encodeURIComponent(policyName)}`);
+        
+        // Extract just the status from the response
+        const status = response.data.status || 'Inactive';
+        return { 
+          status: status.charAt(0).toUpperCase() + status.slice(1).toLowerCase() 
+        };
+      },
+      enabled: !!policyName,
+    });
+  };
+
   // POST /api/bp/create - Create binding policy
   const useCreateBindingPolicy = () => {
     return useMutation({
@@ -426,6 +446,7 @@ export const useBPQueries = () => {
   return {
     useBindingPolicies,
     useBindingPolicyDetails,
+    useBindingPolicyStatus,
     useCreateBindingPolicy,
     useDeleteBindingPolicy,
     useDeletePolicies,

--- a/src/pages/BP.tsx
+++ b/src/pages/BP.tsx
@@ -6,6 +6,7 @@ import BPPagination from "../components/BindingPolicy/BPPagination";
 import PreviewDialog from "../components/BindingPolicy/PreviewDialog";
 import DeleteDialog from "../components/BindingPolicy/Dialogs/DeleteDialog";
 import EditBindingPolicyDialog from "../components/BindingPolicy/Dialogs/EditBindingPolicyDialog";
+import CreateBindingPolicyDialog from "../components/BindingPolicy/CreateBindingPolicyDialog";
 import yaml from "js-yaml"; // Import yaml parser
 import {
   BindingPolicyInfo,
@@ -393,7 +394,7 @@ const BP = () => {
     // Update workloads state when workloadsData changes
     if (workloadsData) {
       const workloadData = workloadsData
-        .filter(workload => workload.name !== "kubernetes")
+        .filter(workload => workload.namespace !== "default")
         .map(workload => ({
           name: workload.name,
           type: workload.kind,
@@ -741,11 +742,15 @@ const BP = () => {
                   mb: 2
                 }}
               >
-                <BPVisualization 
-                  policies={bindingPolicies} 
-                  clusters={clusters} 
-                  workloads={workloads} 
-                />
+                {bindingPolicies.length === 0 ? (
+                  <EmptyState onCreateClick={handleCreateDialogOpen} type="policies" />
+                ) : (
+                  <BPVisualization 
+                    policies={bindingPolicies} 
+                    clusters={clusters} 
+                    workloads={workloads} 
+                  />
+                )}
               </Box>
             )}
           </>
@@ -805,6 +810,14 @@ const BP = () => {
           onClose={handleDeleteDialogClose}
           onConfirm={confirmDelete}
           policyName={selectedPolicy?.name}
+        />
+        
+        <CreateBindingPolicyDialog
+          open={createDialogOpen}
+          onClose={() => setCreateDialogOpen(false)}
+          onCreatePolicy={handleCreatePolicySubmit}
+          clusters={clusters}
+          workloads={workloads}
         />
       </Paper>
        {/* Drag & Drop Help Dialog */}


### PR DESCRIPTION
### Description
Fixed the binding policy status issue with some dark mode issues and the BPVisualization

### Related Issue
Fixes #443 

### Changes Made
- Fixed the dark mode issue in delete dialog box.
- Fixed the delete button crust in safari browser.
- Updated the bp status which was coming inactive always
- Updated BPVisualization to show create bp if no bp added 
- Removed all the workloads from default namespace in drag and drop


### Checklist
Please ensure the following before submitting your PR:
- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

