### PR TITLE
Fixed the issues in binding policy creation

### DIFF
--- a/backend/routes/bp.go
+++ b/backend/routes/bp.go
@@ -8,6 +8,7 @@ import (
 func setupBindingPolicyRoutes(router *gin.Engine) {
 	router.GET("/api/bp", bp.GetAllBp)
 	router.GET("/api/bp/status", bp.GetBpStatus)
+	router.GET("/api/bp/workload-sync-status", bp.GetWorkloadSyncStatus)
 	router.POST("/api/bp/create", bp.CreateBp)
 	router.POST("/api/bp/create-json", bp.CreateBpFromJson)
 	router.POST("/api/bp/quick-connect", bp.CreateQuickBindingPolicy)

--- a/src/components/BindingPolicy/CreateBindingPolicyDialog.tsx
+++ b/src/components/BindingPolicy/CreateBindingPolicyDialog.tsx
@@ -199,9 +199,21 @@ const CreateBindingPolicyDialog: React.FC<CreateBindingPolicyDialogProps> = ({
       console.log(`Creating a single policy with workloads: ${policyCanvasEntities.workloads} and clusters: ${policyCanvasEntities.clusters}`);
       
       try {
+        // Format workload IDs to include namespace information
+        const formattedWorkloadIds = policyCanvasEntities.workloads.map(workloadId => {
+          const workload = workloads.find(w => w.name === workloadId);
+          if (workload) {
+            // Use kind/name/namespace format which is supported by parseWorkloadIdentifier
+            return `${workload.type}/${workload.name}/${workload.namespace || 'default'}`;
+          }
+          return workloadId;
+        });
+        
+        console.log(`Creating a single policy with formatted workload IDs:`, formattedWorkloadIds);
+        
         // Call quick-connect API with all workloads and all clusters
         const result = await quickConnectMutation.mutateAsync({
-          workloadIds: policyCanvasEntities.workloads,
+          workloadIds: formattedWorkloadIds,
           clusterIds: policyCanvasEntities.clusters,
           policyName,
           namespace: 'default'

--- a/src/components/BindingPolicy/PolicyDragDropContainer.tsx
+++ b/src/components/BindingPolicy/PolicyDragDropContainer.tsx
@@ -451,13 +451,17 @@ const PolicyDragDropContainer: React.FC<PolicyDragDropContainerProps> = ({
         policyName
       });
       
-      // Format workload IDs properly if needed
-      const formattedWorkloadIds = allWorkloadIds.map(id => {
-        // Check if workload exists in the workloads array
-        const workload = workloads.find(w => w.name === id);
-        // Return the properly formatted ID with required metadata
-        return workload ? id : id;
+      // Format workload IDs to include namespace information for backend parsing
+      const formattedWorkloadIds = allWorkloadIds.map(workloadId => {
+        const workload = workloads.find(w => w.name === workloadId);
+        if (workload) {
+          // Use kind/name/namespace format which is supported by parseWorkloadIdentifier
+          return `${workload.type}/${workload.name}/${workload.namespace || 'default'}`;
+        }
+        return workloadId;
       });
+      
+      console.log('Using formatted workload IDs with namespaces:', formattedWorkloadIds);
       
       try {
         // Call the quick-connect API with all workloads and clusters in a single call
@@ -793,10 +797,22 @@ const PolicyDragDropContainer: React.FC<PolicyDragDropContainerProps> = ({
                     policyName
                   });
                   
+                  // Format workload IDs to include namespace information
+                  const formattedCanvasWorkloadIds = canvasEntities.workloads.map(workloadId => {
+                    const workload = workloads.find(w => w.name === workloadId);
+                    if (workload) {
+                      // Use kind/name/namespace format which is supported by parseWorkloadIdentifier
+                      return `${workload.type}/${workload.name}/${workload.namespace || 'default'}`;
+                    }
+                    return workloadId;
+                  });
+                  
+                  console.log('Using formatted workload IDs with namespaces:', formattedCanvasWorkloadIds);
+                  
                   // Use the quick connect API with all workloads and all clusters in a single call
                   // Make sure we're explicitly passing arrays to the API
                   const response = await quickConnectMutation.mutateAsync({
-                    workloadIds: canvasEntities.workloads,
+                    workloadIds: formattedCanvasWorkloadIds,
                     clusterIds: canvasEntities.clusters,
                     policyName: policyName,
                     namespace: 'default'

--- a/src/components/menu/data.ts
+++ b/src/components/menu/data.ts
@@ -43,13 +43,6 @@ export const menu = [
         icon: HiOutlineCog,
         label: `WEC'S Topology`,
       },
-    ],
-  },
-  {
-    catalog: 'Binding Policies',
-    centered: true,
-    marginTop: '1rem',
-    listItems: [
       {
         isLink: true,
         url: '/bp/manage',

--- a/src/pages/BP.tsx
+++ b/src/pages/BP.tsx
@@ -365,8 +365,9 @@ const BP = () => {
         console.warn("bindingPoliciesData is not an array:", bindingPoliciesData);
         setBindingPolicies([]);
       }
-    } else {
-      // If no data, set to empty array
+    } else if (!bindingPoliciesLoading) {
+      // If no data and not loading, set to empty array
+      console.log('No binding policies data and not loading, clearing state');
       setBindingPolicies([]);
     }
     
@@ -439,6 +440,11 @@ const BP = () => {
         // Use the mutation instead of direct API call
         await deleteBindingPolicyMutation.mutateAsync(selectedPolicy.name);
         
+        // Immediately update the local state to remove the deleted policy
+        setBindingPolicies(current => 
+          current.filter(policy => policy.name !== selectedPolicy.name)
+        );
+        
         // Update UI state after successful deletion
         setSuccessMessage(
           `Binding Policy "${selectedPolicy.name}" deleted successfully`
@@ -453,7 +459,7 @@ const BP = () => {
         setSelectedPolicy(null);
       }
     }
-  }, [selectedPolicy, deleteBindingPolicyMutation, setSuccessMessage, setDeleteDialogOpen, setSelectedPolicy]);
+  }, [selectedPolicy, deleteBindingPolicyMutation, setSuccessMessage, setDeleteDialogOpen, setSelectedPolicy, setBindingPolicies]);
 
   const handleCreatePolicySubmit = useCallback(async (policyData: PolicyData) => {
     try {
@@ -588,6 +594,11 @@ const BP = () => {
       // Use the mutation for deleting multiple binding policies
       await deleteMultiplePoliciesMutation.mutateAsync(selectedPolicies);
       
+      // Immediately update the local state to remove the deleted policies
+      setBindingPolicies(current => 
+        current.filter(policy => !selectedPolicies.includes(policy.name))
+      );
+      
       setSuccessMessage(
         `Successfully deleted ${selectedPolicies.length} binding policies`
       );
@@ -598,7 +609,7 @@ const BP = () => {
         `Error deleting binding policies`
       );
     }
-  }, [selectedPolicies, deleteMultiplePoliciesMutation, setSuccessMessage, setSelectedPolicies]);
+  }, [selectedPolicies, deleteMultiplePoliciesMutation, setSuccessMessage, setSelectedPolicies, setBindingPolicies]);
 
   // Modify the conditional return for loading to use the component:
   if (loading) {
@@ -671,9 +682,9 @@ const BP = () => {
             {clusters.length === 0 && workloads.length === 0 ? (
               <EmptyState onCreateClick={() => navigate('/resources')} type="both" />
             ) : clusters.length === 0 ? (
-              <EmptyState onCreateClick={() => navigate('/clusters')} type="clusters" />
+              <EmptyState onCreateClick={() => navigate('/its')} type="clusters" />
             ) : workloads.length === 0 ? (
-              <EmptyState onCreateClick={() => navigate('/workloads')} type="workloads" />
+              <EmptyState onCreateClick={() => navigate('/workloads/manage')} type="workloads" />
             ) : bindingPolicies.length === 0 ? (
               <EmptyState onCreateClick={handleCreateDialogOpen} type="policies" />
             ) : (


### PR DESCRIPTION
### Description
Made the changes in the binding policy backend to solve the issue that binding objects are now getting created. Also the pods are shown under the WEC after creation of a binding policy.

### Related Issue
Fixes #446 

### Changes Made
- Implemented a function to ensure workloads are properly deployed to target clusters
- Fixed the  problem  that when the binding policy is created, it's not properly setting the workloads field in a way the KubeStellar controller can recognize it.
- Moved Manage Policies under manage under management section

### Checklist
Please ensure the following before submitting your PR:
- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)
![image](https://github.com/user-attachments/assets/3ea5a9d8-f46a-4751-b68c-b38dd1e378f7)


