### PR TITLE
example.env is not present. The actual name of the file is .env.example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ Then go through one of the setup options below:
 
 #### Step 1: Create `.env` File for Frontend Configuration
 
-To configure the frontend, copy the `example.env` file to a `.env` file in the project root directory (where `package.json` is located).
+To configure the frontend, copy the `.env.example` file to a `.env` file in the project root directory (where `package.json` is located).
 
 ```bash
-cp example.env .env
+cp .env.example .env
 ```
 
 **Example `.env` file:**  
@@ -75,7 +75,7 @@ VITE_GIT_COMMIT_HASH=$GIT_COMMIT_HASH
 ```
 
 > [!NOTE] 
-> This is because `.env` files are intended to be a personal environment configuration file. The included `example.env` in the repo is a standard that most other node projects include for the same purpose. You rename the file to `.env` and then change its contents to align with your system and personal needs.
+> This is because `.env` files are intended to be a personal environment configuration file. The included `.env.example` in the repo is a standard that most other node projects include for the same purpose. You rename the file to `.env` and then change its contents to align with your system and personal needs.
 
 ##### Tracking Application Version and Git Commit Hash
 


### PR DESCRIPTION
### Description
In README for the frotnend we specify "example.env" which is not present. The actual name of the file is .env.example. Here I corrected the readme.md

### Related Issue
<!-- Link the issue(s) this PR addresses. -->
Fixes #448 

### Changes Made
<!-- Provide a detailed list of changes made in this PR. -->
- [ ] Updated the readme with the correct name of the file...
