### PR TITLE
Fixed the drag and drop binding policy

### DIFF
--- a/backend/k8s/resources.go
+++ b/backend/k8s/resources.go
@@ -4,10 +4,16 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	"gopkg.in/yaml.v3"
-	"io"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -16,11 +22,6 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/tools/cache"
-	"log"
-	"net/http"
-	"strings"
-	"sync"
-	"time"
 )
 
 // mapResourceToGVR maps resource types to their GroupVersionResource (GVR)
@@ -159,7 +160,7 @@ func autoLabelling(obj *unstructured.Unstructured) {
 	if labels == nil {
 		labels = make(map[string]string)
 	}
-	labelKey := "kubernetes.io/name"
+	labelKey := "kubernetes.io/metadata.name"
 
 	if _, exists := labels[labelKey]; !exists {
 		labels[labelKey] = obj.GetName()

--- a/src/components/BindingPolicy/AvailableItemsPanel.tsx
+++ b/src/components/BindingPolicy/AvailableItemsPanel.tsx
@@ -327,7 +327,7 @@ const AvailableItemsPanel: React.FC<AvailableItemsPanelProps> = ({
                   </Typography>
                   <Box sx={{ display: 'flex', alignItems: 'center' }}>
                     <Typography variant="caption" color="text.secondary" sx={{ mr: 0.5 }}>
-                      {workload.type}
+                      {workload.kind}
                     </Typography>
                     <Typography variant="caption" color="text.secondary">
                       in {workload.namespace || 'default'}

--- a/src/components/BindingPolicy/CanvasItems.tsx
+++ b/src/components/BindingPolicy/CanvasItems.tsx
@@ -700,7 +700,7 @@ const CanvasItems: React.FC<CanvasItemsProps> = ({
                       </Box>
                       
                       <Typography variant="caption" color="text.secondary" noWrap>
-                        Type: {workload.type}
+                        Type: {workload.kind}
                       </Typography>
                       
                       {Object.keys(getItemLabels('workload', workloadId)).length > 0 && (

--- a/src/components/BindingPolicy/PolicyCanvas.tsx
+++ b/src/components/BindingPolicy/PolicyCanvas.tsx
@@ -620,9 +620,9 @@ const PolicyCanvas: React.FC<PolicyCanvasProps> = ({
       return (
         <ItemTooltip 
           title={workload.name}
-          subtitle={`${workload.namespace}/${workload.type}`}
+          subtitle={`${workload.namespace}/${workload.kind}`}
           labels={getItemLabels('workload', itemId)}
-          description={workload.description || `${workload.type} workload`}
+          description={`${workload.kind} workload`}
           type="workload"
         />
       );
@@ -1236,7 +1236,7 @@ const PolicyCanvas: React.FC<PolicyCanvasProps> = ({
                                   textOverflow: 'ellipsis',
                                   whiteSpace: 'nowrap'
                                 }}>
-                                  Type: {workload?.type || 'Unknown'}
+                                  Type: {workload?.kind || 'Unknown'}
                                 </Typography>
                                 <Typography variant="caption" color="text.secondary" sx={{ 
                                   display: 'block',

--- a/src/components/BindingPolicy/PolicyDragDropContainer.tsx
+++ b/src/components/BindingPolicy/PolicyDragDropContainer.tsx
@@ -154,17 +154,22 @@ const PolicyDragDropContainer: React.FC<PolicyDragDropContainerProps> = ({
   }, []);
   
   // Function to generate YAML preview wrapped in useCallback
-  const generateBindingPolicyPreview = useCallback(async (clusterIds: string[], workloadIds: string[], config?: PolicyConfiguration) => {
+  const generateBindingPolicyPreview = useCallback(async (
+    requestData: {
+      workloadLabels: Record<string, string>,
+      clusterLabels: Record<string, string>,
+      resources: Array<{type: string, createOnly: boolean}>,
+      namespacesToSync?: string[],
+      namespace?: string,
+      policyName?: string
+    },
+    config?: PolicyConfiguration
+  ) => {
     if (!config) return;
     
     try {
-      // Generate the YAML preview using the updated API that accepts arrays
-      const generateYamlResponse = await generateYamlMutation.mutateAsync({
-        workloadIds,
-        clusterIds,
-        namespace: config.namespace || "default",
-        policyName: config.name
-      });
+      // Generate the YAML preview using the updated API format
+      const generateYamlResponse = await generateYamlMutation.mutateAsync(requestData);
       
       // Update the preview YAML
       setPreviewYaml(generateYamlResponse.yaml);
@@ -245,6 +250,17 @@ const PolicyDragDropContainer: React.FC<PolicyDragDropContainerProps> = ({
       clusterIds
     });
     
+    // Find the workload object to get its namespace
+    const firstWorkloadId = workloadIds[0];
+    const workloadObj = workloads.find(w => w.name === firstWorkloadId);
+    
+    if (!workloadObj) {
+      console.error('Workload not found:', firstWorkloadId);
+      return;
+    }
+    
+    const workloadNamespace = workloadObj.namespace || 'default';
+    
     // Generate a name for the policy that includes all workloads
     const workloadNames = workloadIds.join("-");
     const policyName = `${workloadNames}-to-clusters-${Date.now()}`;
@@ -252,7 +268,7 @@ const PolicyDragDropContainer: React.FC<PolicyDragDropContainerProps> = ({
     // Create default configuration
     const defaultConfig: PolicyConfiguration = {
       name: policyName,
-      namespace: 'default',
+      namespace: workloadNamespace, // Use the namespace from the workload
       propagationMode: 'DownsyncOnly',
       updateStrategy: 'ServerSideApply',
       deploymentType: 'SelectedClusters',
@@ -262,7 +278,6 @@ const PolicyDragDropContainer: React.FC<PolicyDragDropContainerProps> = ({
     };
     
     // For display purposes only - we'll use the actual arrays in the API call
-    const firstWorkloadId = workloadIds[0];
     const clusterIdsStr = clusterIds.join(", ");
     
     // Store IDs for UI display (maintain backward compatibility)
@@ -270,10 +285,75 @@ const PolicyDragDropContainer: React.FC<PolicyDragDropContainerProps> = ({
     setCurrentClusterId(clusterIdsStr);   
     setCurrentConfig(defaultConfig);
     
-    // Generate YAML preview using all workload and cluster IDs
-    generateBindingPolicyPreview(clusterIds, workloadIds, defaultConfig);
-  }, [canvasEntities, generateBindingPolicyPreview]);
+    // Convert workload IDs to workload labels - use proper app label format
+    const workloadLabels = {
+      'kubernetes.io/metadata.name': firstWorkloadId
+    };
+    
+    // Convert cluster IDs to cluster labels - use 'name' as the key based on actual data
+    const clusterLabels = {
+      'name': clusterIds[0]
+    };
+    
+    // Dynamically generate resources based on workload kind
+    const resources = generateResourcesFromWorkload(workloadObj);
+    
+    // Generate YAML preview using the new format
+    generateBindingPolicyPreview({
+      workloadLabels,
+      clusterLabels,
+      resources,
+      namespacesToSync: [workloadNamespace], // Use the namespace from the workload
+      namespace: workloadNamespace, // Use the namespace from the workload
+      policyName
+    }, defaultConfig);
+  }, [canvasEntities, generateBindingPolicyPreview, workloads]);
 
+  // Helper function to generate resources array from workload
+  const generateResourcesFromWorkload = useCallback((workload: Workload) => {
+    console.log('🔍 DEBUG - Generating resources from workload:', workload);
+    
+    const resources = [
+      // Always include namespaces
+      { type: 'namespaces', createOnly: false }
+    ];
+    
+    // Convert the workload kind to lowercase and pluralize
+    if (workload.kind) {
+      const kindLower = workload.kind.toLowerCase();
+      let resourceType = kindLower;
+      
+      // Simple pluralization - add 's' if not already ending with 's'
+      if (!resourceType.endsWith('s')) {
+        resourceType += 's';
+      }
+      
+      console.log(`🔍 DEBUG - Adding resource from kind: ${resourceType}`);
+      
+      // Add the workload's resource type
+      resources.push({ type: resourceType, createOnly: false });
+      
+      // For deployments, add dependent resources
+      if (kindLower === 'deployment') {
+        resources.push({ type: 'replicasets', createOnly: false });
+        // Don't include pods as they should be managed by controllers
+        resources.push({ type: 'services', createOnly: false });
+      } else if (kindLower === 'statefulset') {
+        resources.push({ type: 'services', createOnly: false });
+        // Don't include pods as they should be managed by controllers
+      }
+    } else {
+      console.warn("🔍 DEBUG - Workload kind missing, adding deployment as default resource type");
+      // If workload kind is missing, default to deployment
+      resources.push({ type: 'deployments', createOnly: false });
+      resources.push({ type: 'replicasets', createOnly: false });
+      resources.push({ type: 'services', createOnly: false });
+    }
+    
+    console.log('🔍 DEBUG - Final resources array:', resources);
+    return resources;
+  }, []);
+  
   // Handle saving configuration from the sidebar
   const handleSaveConfiguration = useCallback(async (config: PolicyConfiguration) => {
     console.log('🔍 DEBUG - handleSaveConfiguration called with config:', config);
@@ -294,10 +374,21 @@ const PolicyDragDropContainer: React.FC<PolicyDragDropContainerProps> = ({
       workloadId = selectedConnection.target.id;
     }
     
+    // Find the workload object to get its namespace
+    const workloadObj = workloads.find(w => w.name === workloadId);
+    
+    if (!workloadObj) {
+      console.error('Workload not found:', workloadId);
+      return;
+    }
+    
+    const workloadNamespace = workloadObj.namespace || 'default';
+    
     console.log('🔍 DEBUG - Processing connection in handleSaveConfiguration:', {
       workloadId,
       clusterIdsString,
-      selectedConnection
+      selectedConnection,
+      workloadNamespace
     });
     
     setCurrentWorkloadId(workloadId);
@@ -305,7 +396,24 @@ const PolicyDragDropContainer: React.FC<PolicyDragDropContainerProps> = ({
     setCurrentConfig(config);
       
     // Generate YAML preview with all clusters as a comma-separated string
-    const yaml = await generateBindingPolicyPreview(canvasEntities.clusters.map(String), canvasEntities.workloads.map(String), config);
+    const yaml = await generateBindingPolicyPreview({
+      workloadLabels: {
+        'kubernetes.io/metadata.name': workloadId
+      },
+      clusterLabels: {
+        'name': canvasEntities.clusters[0] // Use 'name' as key
+      },
+      resources: [
+        { type: 'deployments', createOnly: false },
+        { type: 'pods', createOnly: false },
+        { type: 'services', createOnly: false },
+        { type: 'replicasets', createOnly: false },
+        { type: 'namespaces', createOnly: false }
+      ],
+      namespacesToSync: [workloadNamespace], // Use the namespace from the workload
+      namespace: workloadNamespace, // Use the namespace from the workload
+      policyName: config.name
+    }, config);
     
     if (yaml) {
       // Store the edited YAML with a key based on the workload (since we're using all clusters)
@@ -331,7 +439,7 @@ const PolicyDragDropContainer: React.FC<PolicyDragDropContainerProps> = ({
         labels: config.customLabels
       });
     }
-  }, [selectedConnection, generateBindingPolicyPreview, canvasEntities.clusters, canvasEntities.workloads]);
+  }, [selectedConnection, generateBindingPolicyPreview, canvasEntities.clusters, canvasEntities.workloads, workloads]);
 
  
 
@@ -435,68 +543,148 @@ const PolicyDragDropContainer: React.FC<PolicyDragDropContainerProps> = ({
     setDeploymentError(null);
     
     try {
-      // Create a single policy with all workloads and clusters
-      // Instead of processing each policy separately, combine them
-      const allWorkloadIds = policiesToDeploy.flatMap(policy => policy.workloadIds);
-      const allClusterIds = canvasEntities.clusters;
+      // Get the first workload and cluster
+      const workloadId = policiesToDeploy[0].workloadIds[0];
+      const clusterId = policiesToDeploy[0].clusterIds[0];
       
-      // Create a unique policy name that includes all workloads
-      const timestamp = Date.now();
-      const workloadNames = allWorkloadIds.join("-");
-      const policyName = `${workloadNames}-binding-${timestamp}`;
+      // Find the workload object to get its namespace
+      const workloadObj = workloads.find(w => w.name === workloadId);
       
-      console.log('🔍 DEBUG - Creating single policy for all workloads and clusters:', {
-        workloadIds: allWorkloadIds,
-        clusterIds: allClusterIds,
-        policyName
-      });
-      
-      // Format workload IDs properly if needed
-      const formattedWorkloadIds = allWorkloadIds.map(id => {
-        // Check if workload exists in the workloads array
-        const workload = workloads.find(w => w.name === id);
-        // Return the properly formatted ID with required metadata
-        return workload ? id : id;
-      });
-      
-      try {
-        // Call the quick-connect API with all workloads and clusters in a single call
-        const result = await quickConnectMutation.mutateAsync({
-          workloadIds: formattedWorkloadIds,
-          clusterIds: allClusterIds,
-          policyName,
-          namespace: 'default'
-        });
-        console.log(result)
-        // Show success message
-        setSuccessMessage(`Successfully created binding policy "${policyName}" connecting ${formattedWorkloadIds.length} workloads to ${allClusterIds.length} clusters`);
-        
-        // Close the dialog after successful deployment
-        setDeploymentDialogOpen(false);
-        
-        // Clear the canvas to avoid duplication
-        if (onClearCanvas) {
-          onClearCanvas();
-        }
-      } catch (error) {
-        console.error('❌ Failed to deploy policy:', error);
-        setDeploymentError(
-          error instanceof Error 
-            ? error.message 
-            : 'Failed to deploy binding policy. Please try again.'
-        );
+      if (!workloadObj) {
+        setDeploymentError(`Workload not found: ${workloadId}`);
+        setDeploymentLoading(false);
+        return;
       }
-    } catch (error: unknown) {
-      console.error('Error deploying binding policies:', error);
+      
+      const workloadNamespace = workloadObj.namespace || 'default';
+      
+      // Create a unique policy name
+      const timestamp = Date.now();
+      const policyName = `${workloadId}-to-${clusterId}-${timestamp}`;
+      
+      console.log('🔍 DEBUG - Creating binding policy:', {
+        workloadId,
+        clusterId,
+        policyName,
+        namespace: workloadNamespace
+      });
+      
+      // Generate resources based on workload kind
+      const resources = generateResourcesFromWorkload(workloadObj);
+      
+      // Convert to the format with correct labels that match actual data
+      const requestData = {
+        workloadLabels: {
+          'kubernetes.io/metadata.name': workloadId
+        },
+        clusterLabels: {
+          'name': clusterId // Use 'name' as key based on actual data
+        },
+        resources,
+        namespacesToSync: [workloadNamespace],
+        policyName: policyName,
+        namespace: workloadNamespace
+      };
+      
+      // Call the quick-connect API with the new format
+      const result = await quickConnectMutation.mutateAsync(requestData);
+      console.log('API response:', result);
+      
+      // Show success message
+      setSuccessMessage(`Successfully created binding policy "${policyName}" connecting ${workloadId} to ${clusterId}`);
+      
+      // Close the dialog after successful deployment
+      setDeploymentDialogOpen(false);
+      
+      // Clear the canvas to avoid duplication
+      if (onClearCanvas) {
+        onClearCanvas();
+      }
+      
+      // Reset loading state after successful completion
+      setDeploymentLoading(false);
+    } catch (error) {
+      console.error('❌ Failed to deploy policy:', error);
       setDeploymentError(
         error instanceof Error 
           ? error.message 
-          : 'Failed to deploy binding policies. Please try again.'
+          : 'Failed to deploy binding policy. Please try again.'
       );
-    } finally {
+      // Ensure loading state is reset on error
       setDeploymentLoading(false);
     }
-  }, [policiesToDeploy, quickConnectMutation, canvasEntities.clusters, workloads, setSuccessMessage, onClearCanvas]);
+  }, [policiesToDeploy, quickConnectMutation, setSuccessMessage, onClearCanvas, workloads, generateResourcesFromWorkload]);
+
+  // Update the handleCreateFromPreview function
+  const handleCreateFromPreview = useCallback(async () => {
+    if (!previewYaml) return;
+    
+    // Set loading state
+    setDeploymentLoading(true);
+    setDeploymentError(null);
+    
+    try {
+      // Get current workload and cluster IDs
+      const workloadId = currentWorkloadId;
+      const clusterId = currentClusterId.split(', ')[0]; // Get first cluster if multiple
+      
+      // Find the workload object to get its namespace
+      const workloadObj = workloads.find(w => w.name === workloadId);
+      
+      if (!workloadObj) {
+        console.error('Workload not found:', workloadId);
+        setDeploymentError(`Workload not found: ${workloadId}`);
+        setDeploymentLoading(false); // Reset loading on error
+        return;
+      }
+      
+      const workloadNamespace = workloadObj.namespace || 'default';
+      
+      // Generate resources based on workload kind
+      const resources = generateResourcesFromWorkload(workloadObj);
+      
+      // Prepare request with correct label keys from actual data
+      const requestData = {
+        workloadLabels: {
+          'kubernetes.io/metadata.name': workloadId
+        },
+        clusterLabels: {
+          'name': clusterId // Use 'name' as key
+        },
+        resources,
+        namespacesToSync: [workloadNamespace],
+        policyName: currentConfig?.name || `${workloadId}-to-${clusterId}`,
+        namespace: workloadNamespace
+      };
+      
+      console.log('Creating binding policy with:', requestData);
+      
+      // Use the quick connect API with the new format
+      const response = await quickConnectMutation.mutateAsync(requestData);
+      
+      console.log('API Response:', response);
+      
+      // Show success message
+      setSuccessMessage(`Binding policy "${requestData.policyName}" created successfully`);
+      
+      // Close the dialog
+      setShowPreviewDialog(false);
+      
+      // Clear the canvas
+      if (onClearCanvas) {
+        onClearCanvas();
+      }
+      
+      // Reset loading state after successful completion
+      setDeploymentLoading(false);
+    } catch (error) {
+      console.error('Failed to create binding policy:', error);
+      setDeploymentError(error instanceof Error ? error.message : 'Failed to create binding policy');
+      
+      // Reset loading state on error
+      setDeploymentLoading(false);
+    }
+  }, [previewYaml, currentWorkloadId, currentClusterId, currentConfig, quickConnectMutation, setSuccessMessage, onClearCanvas, setDeploymentError, workloads, generateResourcesFromWorkload]);
 
   // Main layout for the drag and drop interface
   return (
@@ -609,10 +797,34 @@ const PolicyDragDropContainer: React.FC<PolicyDragDropContainerProps> = ({
                         color: theme === "dark" ? "rgba(255, 255, 255, 0.5) !important" : undefined
                       }
                     }}
-                    disabled={canvasEntities?.clusters.length === 0 || canvasEntities?.workloads.length === 0}
+                    disabled={canvasEntities?.clusters.length === 0 || canvasEntities?.workloads.length === 0 || deploymentLoading}
                     onClick={prepareForDeployment}
                   >
-                    Deploy Binding Policies
+                    {deploymentLoading ? (
+                      <>
+                        <Box component="span" sx={{ display: 'inline-flex', mr: 1, alignItems: 'center' }}>
+                          <Box
+                            component="span"
+                            sx={{
+                              width: 16,
+                              height: 16,
+                              borderRadius: '50%',
+                              border: '2px solid currentColor',
+                              borderRightColor: 'transparent',
+                              animation: 'spin 1s linear infinite',
+                              display: 'inline-block',
+                              '@keyframes spin': {
+                                '0%': { transform: 'rotate(0deg)' },
+                                '100%': { transform: 'rotate(360deg)' }
+                              }
+                            }}
+                          />
+                        </Box>
+                        Deploying...
+                      </>
+                    ) : (
+                      'Deploy Binding Policies'
+                    )}
                   </Button>
                 </Box>
               )}
@@ -649,7 +861,7 @@ const PolicyDragDropContainer: React.FC<PolicyDragDropContainerProps> = ({
         dialogMode={dialogMode}
       />
       
-      {/* Preview YAML Dialog - Now with only Close button */}
+      {/* Preview YAML Dialog - Now with save functionality */}
       <Dialog
         open={showPreviewDialog}
         onClose={() => setShowPreviewDialog(false)}
@@ -761,14 +973,6 @@ const PolicyDragDropContainer: React.FC<PolicyDragDropContainerProps> = ({
         }}>
           <Button 
             onClick={() => {
-              // Save current edits before closing
-              if (currentWorkloadId && previewYaml) {
-                const connectionKey = `${currentWorkloadId}-${currentClusterId}`;
-                setEditedPolicyYaml(prev => ({
-                  ...prev,
-                  [connectionKey]: previewYaml
-                }));
-              }
               setShowPreviewDialog(false);
             }}
             sx={{
@@ -780,46 +984,7 @@ const PolicyDragDropContainer: React.FC<PolicyDragDropContainerProps> = ({
           <Button 
             variant="contained"
             color="primary"
-            onClick={async () => {
-              if (previewYaml) {
-                try {
-                  // Prepare policy data using the edited YAML
-                  const policyName = currentConfig?.name || `multi-binding-${Date.now()}`;
-                  
-                  // Log all workload and cluster IDs that will be sent
-                  console.log('Creating a single binding policy with:', {
-                    workloadIds: canvasEntities.workloads,
-                    clusterIds: canvasEntities.clusters,
-                    policyName
-                  });
-                  
-                  // Use the quick connect API with all workloads and all clusters in a single call
-                  // Make sure we're explicitly passing arrays to the API
-                  const response = await quickConnectMutation.mutateAsync({
-                    workloadIds: canvasEntities.workloads,
-                    clusterIds: canvasEntities.clusters,
-                    policyName: policyName,
-                    namespace: 'default'
-                  });
-                  
-                  console.log('API Response:', response);
-                  
-                  // Show success message with count of workloads and clusters
-                  setSuccessMessage(`Binding policy "${policyName}" created successfully connecting ${canvasEntities.workloads.length} workloads to ${canvasEntities.clusters.length} clusters`);
-                  
-                  // Close the dialog
-                  setShowPreviewDialog(false);
-                  
-                  // Clear the canvas
-                  if (onClearCanvas) {
-                    onClearCanvas();
-                  }
-                } catch (error) {
-                  console.error('Failed to create binding policy:', error);
-                  setDeploymentError(error instanceof Error ? error.message : 'Failed to create binding policy');
-                }
-              }
-            }}
+            onClick={handleCreateFromPreview}
             sx={{
               bgcolor: theme === "dark" ? "#2563eb" : undefined,
               color: theme === "dark" ? "#FFFFFF" : undefined,

--- a/src/components/BindingPolicy/WorkloadPanel.tsx
+++ b/src/components/BindingPolicy/WorkloadPanel.tsx
@@ -7,7 +7,8 @@ import {
   Divider,
   useTheme,
   alpha,
-  Button
+  Button,
+  Chip
 } from '@mui/material';
 import { Draggable } from '@hello-pangea/dnd';
 import { Workload } from '../../types/bindingPolicy';
@@ -71,6 +72,36 @@ const WorkloadPanel: React.FC<WorkloadPanelProps> = ({
                 {workload.name}
               </Typography>
             </Box>
+            
+            {/* Display workload type and namespace */}
+            <Box sx={{ mt: 1, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                Type: {workload.kind}
+              </Typography>
+              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                Namespace: {workload.namespace}
+              </Typography>
+            </Box>
+            
+            {/* Display workload labels */}
+            {workload.labels && Object.keys(workload.labels).length > 0 && (
+              <Box sx={{ mt: 1, display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                {Object.entries(workload.labels).map(([key, value]) => (
+                  <Chip
+                    key={key}
+                    size="small"
+                    label={`${key}: ${value}`}
+                    sx={{ 
+                      fontSize: '0.625rem',
+                      height: 20,
+                      '& .MuiChip-label': { px: 1 },
+                      bgcolor: alpha(theme.palette.secondary.main, 0.1),
+                      color: theme.palette.secondary.main
+                    }}
+                  />
+                ))}
+              </Box>
+            )}
           </Box>
         )}
       </Draggable>

--- a/src/components/CreateOptions.tsx
+++ b/src/components/CreateOptions.tsx
@@ -70,10 +70,10 @@ const CreateOptions = ({
   const initialEditorContent = `apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-${randomStrings}
+  name: test-${randomStrings}
   namespace: test-${randomStrings}
   labels:
-    app.kubernetes.io/name: example
+    kubernetes.io/metadata.name: example-${randomStrings}
 spec:
   replicas: 2
   selector:

--- a/src/components/Workloads/UploadFileTab.tsx
+++ b/src/components/Workloads/UploadFileTab.tsx
@@ -11,6 +11,8 @@ import Editor from "@monaco-editor/react";
 interface YamlDocument {
   metadata?: {
     name?: string;
+    namespace?: string;
+    labels?: Record<string, unknown>;
   };
   [key: string]: unknown;
 }
@@ -96,6 +98,15 @@ export const UploadFileTab = ({
         const yamlObj = yaml.load(fileContent) as YamlDocument;
         if (yamlObj && yamlObj.metadata) {
           yamlObj.metadata.name = newName;
+          // Set namespace to match the name
+          yamlObj.metadata.namespace = newName;
+          // Ensure labels object exists
+          if (!yamlObj.metadata.labels) {
+            yamlObj.metadata.labels = {};
+          }
+          // Set kubernetes.io/metadata.name label to match the name
+          yamlObj.metadata.labels["kubernetes.io/metadata.name"] = newName;
+          
           const updatedYaml = yaml.dump(yamlObj);
           const updatedFile = new File([updatedYaml], selectedFile.name, {
             type: selectedFile.type,

--- a/src/components/Workloads/YamlTab.tsx
+++ b/src/components/Workloads/YamlTab.tsx
@@ -19,6 +19,8 @@ interface Props {
 interface YamlDocument {
   metadata?: {
     name?: string;
+    namespace?: string;
+    labels?: Record<string, unknown>;
   };
   [key: string]: unknown;
 }
@@ -78,14 +80,34 @@ export const YamlTab = ({
         documents[nameDocumentIndex].metadata
       ) {
         documents[nameDocumentIndex].metadata!.name = newName;
+        documents[nameDocumentIndex].metadata!.namespace = newName;
+        if (!documents[nameDocumentIndex].metadata!.labels) {
+          documents[nameDocumentIndex].metadata!.labels = {};
+        }
+        (documents[nameDocumentIndex].metadata!.labels as Record<string, unknown>)["kubernetes.io/metadata.name"] = newName;
       } else {
         if (documents.length === 0) {
-          documents.push({ metadata: { name: newName } });
+          documents.push({ 
+            metadata: { 
+              name: newName,
+              namespace: newName,
+              labels: { "kubernetes.io/metadata.name": newName }
+            } 
+          });
         } else {
           if (!documents[0].metadata) {
-            documents[0].metadata = { name: newName };
+            documents[0].metadata = { 
+              name: newName,
+              namespace: newName,
+              labels: { "kubernetes.io/metadata.name": newName }
+            };
           } else {
             documents[0].metadata.name = newName;
+            documents[0].metadata.namespace = newName;
+            if (!documents[0].metadata.labels) {
+              documents[0].metadata.labels = {};
+            }
+            (documents[0].metadata.labels as Record<string, unknown>)["kubernetes.io/metadata.name"] = newName;
           }
           setNameDocumentIndex(0);
         }

--- a/src/hooks/queries/useBPQueries.ts
+++ b/src/hooks/queries/useBPQueries.ts
@@ -53,30 +53,44 @@ interface DownsyncItem {
   namespaces?: string[];
 }
 
+// Resource configuration with createOnly option
+interface ResourceConfig {
+  type: string;
+  createOnly: boolean;
+}
+
 interface GenerateYamlRequest {
-  workloadIds: string[];
-  clusterIds: string[];
-  namespace: string;
+  workloadLabels: Record<string, string>;
+  clusterLabels: Record<string, string>;
+  resources: ResourceConfig[];
+  namespacesToSync?: string[];
+  namespace?: string;
   policyName?: string;
+  // For backward compatibility
+  workloadIds?: string[];
+  clusterIds?: string[];
 }
 
 interface QuickConnectRequest {
-  workloadIds: string[];
-  clusterIds: string[];
+  workloadLabels: Record<string, string>;
+  clusterLabels: Record<string, string>;
+  resources: ResourceConfig[];
+  namespacesToSync?: string[];
   policyName?: string;
   namespace?: string;
+  // For backward compatibility
+  workloadIds?: string[];
+  clusterIds?: string[];
 }
 
 interface GenerateYamlResponse {
   bindingPolicy: {
     bindingMode: string;
-    clusterIds: string[];
     clusters: string[];
     clustersCount: number;
     name: string;
     namespace: string;
     status: string;
-    workloadIds: string[];
     workloads: string[];
     workloadsCount: number;
   };
@@ -407,28 +421,58 @@ export const useBPQueries = () => {
     });
   };
 
-  // Generate YAML for binding policy
-  const useGenerateBindingPolicyYaml = () => {
-    return useMutation<GenerateYamlResponse, Error, GenerateYamlRequest>({
-      mutationFn: async (request) => {
-        console.log("Generating YAML for binding policy:", request);
-        const response = await api.post('/api/bp/generate-yaml', request);
-        console.log("Generated YAML response:", response.data);
-        return response.data;
-      },
-      onError: (error: Error) => {
-        console.error("Error generating binding policy YAML:", error);
-        toast.error('Failed to generate binding policy YAML');
-      }
-    });
-  };
-
   // Quick connect API for drag and drop
   const useQuickConnect = () => {
     return useMutation<QuickConnectResponse, Error, QuickConnectRequest>({
       mutationFn: async (request) => {
         console.log("Creating quick connect binding policy:", request);
-        const response = await api.post('/api/bp/quick-connect', request);
+        
+        // Check if we need to convert from legacy format
+        const formattedRequest = { ...request };
+        
+        // Convert workloadIds to workloadLabels if needed for backward compatibility
+        if (request.workloadIds && request.workloadIds.length > 0 && !request.workloadLabels) {
+          // For backward compatibility, assume app.kubernetes.io/name label
+          formattedRequest.workloadLabels = {
+            'app.kubernetes.io/name': request.workloadIds[0]
+          };
+        }
+        
+        // Convert clusterIds to clusterLabels if needed for backward compatibility
+        if (request.clusterIds && request.clusterIds.length > 0 && !request.clusterLabels) {
+          // Use 'name' as the key based on actual cluster label format
+          formattedRequest.clusterLabels = {
+            'name': request.clusterIds[0]
+          };
+        }
+        
+        // Validate and enhance resources if needed
+        if (!formattedRequest.resources || formattedRequest.resources.length === 0) {
+          console.warn("No resources provided, adding default resources");
+          formattedRequest.resources = [
+            { type: 'namespaces', createOnly: false },
+            { type: 'deployments', createOnly: false },
+            { type: 'services', createOnly: false }, 
+            { type: 'replicasets', createOnly: false }
+          ];
+        } else if (formattedRequest.resources.length === 1 && 
+                  formattedRequest.resources[0].type === 'namespaces') {
+          console.warn("Only namespaces resource provided, adding default workload resources");
+          formattedRequest.resources.push(
+            { type: 'deployments', createOnly: false },
+            { type: 'services', createOnly: false },
+            { type: 'replicasets', createOnly: false }
+          );
+        }
+        
+        // Ensure namespacesToSync is set if not provided
+        if (!formattedRequest.namespacesToSync || formattedRequest.namespacesToSync.length === 0) {
+          // Use the provided namespace or default to 'default'
+          formattedRequest.namespacesToSync = [formattedRequest.namespace || 'default'];
+        }
+        
+        console.log("Final formatted request:", JSON.stringify(formattedRequest, null, 2));
+        const response = await api.post('/api/bp/quick-connect', formattedRequest);
         console.log("Quick connect response:", response.data);
         return response.data;
       },
@@ -439,6 +483,66 @@ export const useBPQueries = () => {
       onError: (error: Error) => {
         console.error("Error creating quick connect binding policy:", error);
         toast.error('Failed to create binding policy');
+      }
+    });
+  };
+
+  // Generate YAML for binding policy - Updated for new format
+  const useGenerateBindingPolicyYaml = () => {
+    return useMutation<GenerateYamlResponse, Error, GenerateYamlRequest>({
+      mutationFn: async (request) => {
+        console.log("Generating YAML for binding policy:", request);
+        
+        // Handle both new and legacy formats
+        const formattedRequest = { ...request };
+        
+        // Convert workloadIds to workloadLabels if needed
+        if (request.workloadIds && request.workloadIds.length > 0 && !request.workloadLabels) {
+          formattedRequest.workloadLabels = {
+            'app.kubernetes.io/name': request.workloadIds[0]
+          };
+        }
+        
+        // Convert clusterIds to clusterLabels if needed
+        if (request.clusterIds && request.clusterIds.length > 0 && !request.clusterLabels) {
+          formattedRequest.clusterLabels = {
+            'name': request.clusterIds[0]
+          };
+        }
+        
+        // Validate and enhance resources if needed
+        if (!formattedRequest.resources || formattedRequest.resources.length === 0) {
+          console.warn("No resources provided for YAML generation, adding default resources");
+          formattedRequest.resources = [
+            { type: 'namespaces', createOnly: false },
+            { type: 'deployments', createOnly: false },
+            { type: 'services', createOnly: false }, 
+            { type: 'replicasets', createOnly: false }
+          ];
+        } else if (formattedRequest.resources.length === 1 && 
+                  formattedRequest.resources[0].type === 'namespaces') {
+          console.warn("Only namespaces resource provided for YAML generation, adding default workload resources");
+          formattedRequest.resources.push(
+            { type: 'deployments', createOnly: false },
+            { type: 'services', createOnly: false },
+            { type: 'replicasets', createOnly: false }
+          );
+        }
+        
+        // Ensure namespacesToSync is set if not provided
+        if (!formattedRequest.namespacesToSync || formattedRequest.namespacesToSync.length === 0) {
+          // Use the provided namespace or default to 'default'
+          formattedRequest.namespacesToSync = [formattedRequest.namespace || 'default'];
+        }
+        
+        console.log("Final YAML generation request:", JSON.stringify(formattedRequest, null, 2));
+        const response = await api.post('/api/bp/generate-yaml', formattedRequest);
+        console.log("Generated YAML response:", response.data);
+        return response.data;
+      },
+      onError: (error: Error) => {
+        console.error("Error generating binding policy YAML:", error);
+        toast.error('Failed to generate binding policy YAML');
       }
     });
   };

--- a/src/hooks/queries/useWDSQueries.ts
+++ b/src/hooks/queries/useWDSQueries.ts
@@ -9,7 +9,7 @@ interface Workload {
   namespace: string;
   creationTime: string;
   image: string;
-  label: string;
+  labels: Record<string, string>;
   replicas: number;
   status?: string;
 }

--- a/src/types/bindingPolicy.ts
+++ b/src/types/bindingPolicy.ts
@@ -43,15 +43,13 @@ export interface ManagedCluster {
 
 export interface Workload {
     name: string;
-    type: string;
+    kind: string;
     namespace: string;
     creationTime?: string;
-    labels: Record<string, string>;
-    status?: string;
+    image?: string;
+    labels?: Record<string, string>;
     replicas?: number;
-    selector?: Record<string, string>;
-    apiVersion?: string;
-    description?: string;
+    status?: string;
 }
 
 export interface BindingPolicyFilter {


### PR DESCRIPTION
### Description
Now the drag and drop binding policy is properly working targeting the cluster and workload using the default labels. 

### Related Issue
Fixes #485 

### Changes Made
- Updated the backend to correctly se the workload.
- Updated the frontend to match the required format needed by backend to create binding policy using quick create.
- Updated the binding policy canvas to get reset after creating a binding policy.
- Showing labels section when a workload is available in drag and drop

### Checklist
Please ensure the following before submitting your PR:
- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.
