### PR TITLE
Add delete endpoints for Helm and GitHub deployments

### DIFF
--- a/backend/routes/gitops.go
+++ b/backend/routes/gitops.go
@@ -9,34 +9,38 @@ import (
 	"github.com/kubestellar/ui/k8s"
 )
 
+
+// setupGitopsRoutes registers general GitOps deployment routes
 func setupGitopsRoutes(router *gin.Engine) {
 	router.POST("api/deploy", api.DeployHandler)
 }
 
-func helmDeploy(router *gin.Engine) {
+// setupHelmRoutes registers all Helm chart related routes
+func setupHelmRoutes(router *gin.Engine) {
 	// Route for deploying Helm charts
 	router.POST("/deploy/helm", k8s.HelmDeployHandler)
 
-	// Routes for listing and retrieving Helm deployments
-
-	// List all Helm deployments
+	// Routes for retrieving Helm deployments
 	router.GET("/api/deployments/helm/list", k8s.ListHelmDeploymentsHandler)
-
-	// List all Helm deployments for a specific namespace
-	router.GET("/api/deployments/github/list", k8s.ListGithubDeployments)
-
-	// Get a specific Helm deployment by ID
 	router.GET("/api/deployments/helm/:id", k8s.GetHelmDeploymentHandler)
-
-	// List all Helm deployments for a specific namespace
 	router.GET("/api/deployments/helm/namespace/:namespace", k8s.ListHelmDeploymentsByNamespaceHandler)
-
-	// List all Helm deployments for a specific release
 	router.GET("/api/deployments/helm/release/:release", k8s.ListHelmDeploymentsByReleaseHandler)
+	
+	// Route for deleting Helm deployments
+	router.DELETE("/api/deployments/helm/:id", k8s.DeleteHelmDeploymentHandler)
 }
 
-func GetDeploymentHistory(router *gin.Engine) {
+// setupGitHubRoutes registers all GitHub related routes
+func setupGitHubRoutes(router *gin.Engine) {
+	// Route for listing GitHub deployments
+	router.GET("/api/deployments/github/list", k8s.ListGithubDeployments)
+	
+	// Route for deleting GitHub deployments
+	router.DELETE("/api/deployments/github/:id", k8s.DeleteGitHubDeploymentHandler)
+}
 
+// setupDeploymentHistoryRoutes registers routes for deployment history
+func setupDeploymentHistoryRoutes(router *gin.Engine) {
 	// GitHub config routes - for viewing stored deployment data
 	router.GET("/api/deployments/github", func(c *gin.Context) {
 		config, err := k8s.GetConfigMapData("its1", k8s.GitHubConfigMapName)
@@ -66,5 +70,4 @@ func GetDeploymentHistory(router *gin.Engine) {
 		}
 		c.JSON(http.StatusOK, config)
 	})
-
 }

--- a/backend/routes/setup.go
+++ b/backend/routes/setup.go
@@ -13,8 +13,10 @@ func SetupRoutes(router *gin.Engine) {
 	setupBindingPolicyRoutes(router)
 	setupResourceRoutes(router)
 	getWecsResources(router)
-	helmDeploy(router)
-	GetDeploymentHistory(router)
 	setupInstallerRoutes(router)
 	setupWdsCookiesRoute(router)
+	setupGitopsRoutes(router)
+	setupHelmRoutes(router)
+	setupGitHubRoutes(router)
+	setupDeploymentHistoryRoutes(router)
 }


### PR DESCRIPTION
## Overview
This PR adds functionality to delete individual Helm chart deployments and GitHub deployments by their ID, allowing for more granular management of stored deployments.

## Changes
- Added functions to delete specific Helm and GitHub deployments by ID
- Implemented HTTP handlers for the deletion operations
- Created DELETE API endpoints with proper routing
- Fixed route registration to prevent conflicts with existing endpoints
- Separated Helm and GitHub route handlers for better code organization

## API Endpoints Added
- `DELETE /api/deployments/helm/:id` - Delete a Helm deployment by ID
- `DELETE /api/deployments/github/:id` - Delete a GitHub deployment by ID

## Testing
Verified route registration works properly without conflicts.
Tested deletion operations for both Helm and GitHub deployments.

## Related Issues
Closes #491