### PR TITLE
Fixed the issue of different yaml showing in binding policy

### DIFF
--- a/src/components/BindingPolicy/BPTable.tsx
+++ b/src/components/BindingPolicy/BPTable.tsx
@@ -15,7 +15,7 @@ import {
   TableContainer,
   Paper,
 } from "@mui/material";
-import { Info, Trash2,  CloudOff } from "lucide-react";
+import {  Trash2,  CloudOff } from "lucide-react";
 import { BindingPolicyInfo } from "../../types/bindingPolicy";
 import PolicyDetailDialog from "./Dialogs/PolicyDetailDialog";
 import useTheme from "../../stores/themeStore";
@@ -24,7 +24,6 @@ import { api } from "../../lib/api";
 
 interface BPTableProps {
   policies: BindingPolicyInfo[];
-  onPreviewMatches: (policy: BindingPolicyInfo) => void;
   onDeletePolicy: (policy: BindingPolicyInfo) => void;
   onEditPolicy: (policy: BindingPolicyInfo) => void;
   activeFilters: { status?: "Active" | "Inactive" | "Pending" };
@@ -34,7 +33,6 @@ interface BPTableProps {
 
 const BPTable: React.FC<BPTableProps> = ({
   policies,
-  onPreviewMatches,
   onDeletePolicy,
   onEditPolicy,
   activeFilters,
@@ -157,7 +155,16 @@ const BPTable: React.FC<BPTableProps> = ({
     
     console.log('Requesting details for policy:', policy.name);
     console.log('Policy namespace:', policy.namespace);
+    console.log('Policy YAML availability:', policy.yaml ? 'Available' : 'Not available');
+    
+    // Store both name and namespace for API request
     localStorage.setItem('selectedPolicyNamespace', policy.namespace || 'default');
+    
+    // If the policy already has YAML content, we can log it for debugging
+    if (policy.yaml) {
+      console.log('Policy has YAML content of length:', policy.yaml.length);
+      console.log('YAML content starts with:', policy.yaml.substring(0, 50));
+    }
     
     setSelectedPolicyName(policy.name);
   };
@@ -484,16 +491,6 @@ const BPTable: React.FC<BPTableProps> = ({
                     <Box
                       sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}
                     >
-                      <IconButton
-                        sx={{ 
-                          color: colors.textSecondary,
-                          "&:hover": { color: colors.primary }
-                        }}
-                        size="small"
-                        onClick={() => onPreviewMatches(policy)}
-                      >
-                        <Info size={18} />
-                      </IconButton>
                       <IconButton
                         size="small"
                         sx={{

--- a/src/components/CreateOptions.tsx
+++ b/src/components/CreateOptions.tsx
@@ -73,7 +73,7 @@ metadata:
   name: test-${randomStrings}
   namespace: test-${randomStrings}
   labels:
-    kubernetes.io/metadata.name: example-${randomStrings}
+    kubernetes.io/metadata.name: test-${randomStrings}
 spec:
   replicas: 2
   selector:

--- a/src/pages/BP.tsx
+++ b/src/pages/BP.tsx
@@ -573,10 +573,6 @@ const BP = () => {
     }
   }, [setBindingPolicies, setEditDialogOpen, setSelectedPolicy, setSuccessMessage]);
 
-  const handlePreviewPolicy = useCallback((policy: BindingPolicyInfo) => {
-    setSelectedPolicy(policy);
-    setPreviewDialogOpen(true);
-  }, []);
 
   // Create a memoized function for the policy assignment simulation used in the JSX
   const handleSimulatedPolicyAssign = useCallback((policyName: string, targetType: string, targetName: string) => {
@@ -696,7 +692,6 @@ const BP = () => {
               <>
                 <BPTable
                   policies={paginatedPolicies}
-                  onPreviewMatches={(policy) => handlePreviewPolicy(policy)}
                   onDeletePolicy={handleDeletePolicy}
                   onEditPolicy={handleEditPolicy}
                   activeFilters={activeFilters}

--- a/src/types/bindingPolicy.ts
+++ b/src/types/bindingPolicy.ts
@@ -55,3 +55,12 @@ export interface Workload {
 export interface BindingPolicyFilter {
     status?: "Active" | "Inactive" | "Pending";
 }
+
+export interface PolicyDetailDialogProps {
+    open: boolean;
+    onClose: () => void;
+    policy: BindingPolicyInfo;
+    onEdit?: (policy: BindingPolicyInfo) => void;
+    isLoading?: boolean;
+    error?: string;
+}


### PR DESCRIPTION
### Description
Fixed the issue of different yaml shown at the editor and the actual binding policy creator

### Related Issue
Fixes #500 

### Changes Made
- Fixed the issue was policy detail dialog was not taking the content from the correct api.
- updated the backed get all binding policy to send correct policy depend on the creation method.


### Checklist
Please ensure the following before submitting your PR:
- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.


