### PR TITLE
fix: Remove white border in YAML tab of CreateBindingPolicyDialog.

### DIFF
--- a/src/components/BindingPolicy/CreateBindingPolicyDialog.tsx
+++ b/src/components/BindingPolicy/CreateBindingPolicyDialog.tsx
@@ -792,7 +792,8 @@ const CreateBindingPolicyDialog: React.FC<CreateBindingPolicyDialogProps> = ({
                   border: `1px solid ${theme === "dark" ? "rgba(255, 255, 255, 0.12)" : "rgba(0, 0, 0, 0.12)"}`,
                   borderRadius: '8px',
                   display: 'flex',
-                  flexDirection: 'column'
+                  flexDirection: 'column',
+                  bgcolor: theme === "dark" ? "#1e1e1e" : "#fff"
                 }}>
                   <Editor
                     height="100%"


### PR DESCRIPTION
Remove unwanted white border in YAML tab of CreateBindingPolicyDialog

Fixes: #521.

### Changes Made
<!-- Provide a detailed list of changes made in this PR. -->
- [ ] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

### Checklist
Please ensure the following before submitting your PR:
- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)
<img width="1710" alt="Screenshot 2025-04-12 at 1 55 19 AM" src="https://github.com/user-attachments/assets/8656056e-4b48-4996-abf1-c78c71a2815c" />

