### PR TITLE
Fix: Improve icon visibility in dark mode for dropdown and view toggles

### DIFF
--- a/src/components/ContextDropdown.tsx
+++ b/src/components/ContextDropdown.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import { Box, MenuItem, Select } from "@mui/material";
 import { SelectChangeEvent } from "@mui/material/Select";
 import { toast } from "react-hot-toast";
-// import "react-toastify/dist/ReactToastify.css";
+import useTheme from "../stores/themeStore"; // Add this import
 
 interface ContextDropdownProps {
   onContextChange: (context: string) => void;
@@ -12,6 +12,7 @@ interface ContextDropdownProps {
 const ContextDropdown = ({ onContextChange }: ContextDropdownProps) => {
   const [contexts, setContexts] = useState<string[]>([]);
   const [currentContext, setCurrentContext] = useState<string>("wds1"); // Default from ui-wds-context
+  const theme = useTheme((state) => state.theme);
 
   useEffect(() => {
     fetch("http://localhost:4000/wds/get/context")
@@ -52,8 +53,40 @@ const ContextDropdown = ({ onContextChange }: ContextDropdownProps) => {
       <Select
         value={currentContext}
         onChange={handleContextChange}
-        sx={{ minWidth: 200, mr: 2, height: "50px", padding: "0 8px" , borderRadius:2}}
+        sx={{ 
+          minWidth: 200, 
+          mr: 2, 
+          height: "50px", 
+          padding: "0 8px",
+          borderRadius: 2,
+        
+          color: theme === "dark" ? "#FFFFFF" : "#121212",
+          borderColor: theme === "dark" ? "rgba(255, 255, 255, 0.23)" : "rgba(0, 0, 0, 0.23)",
+          backgroundColor: theme === "dark" ? "rgba(255, 255, 255, 0.05)" : "transparent",
+          "& .MuiSvgIcon-root": { 
+            color: theme === "dark" ? "#FFFFFF" : "inherit"
+          },
+          "& .MuiOutlinedInput-notchedOutline": {
+            borderColor: theme === "dark" ? "rgba(255, 255, 255, 0.23)" : "rgba(0, 0, 0, 0.23)"
+          },
+          "&:hover .MuiOutlinedInput-notchedOutline": {
+            borderColor: theme === "dark" ? "#FFFFFF" : "rgba(0, 0, 0, 0.87)"
+          },
+          "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+            borderColor: theme === "dark" ? "#90CAF9" : "#1976D2"
+          }
+        }}
         variant="outlined"
+        MenuProps={{
+          PaperProps: {
+            sx: {
+              backgroundColor: theme === "dark" ? "#333333" : "#FFFFFF",
+              "& .MuiMenuItem-root": {
+                color: theme === "dark" ? "#FFFFFF" : "inherit"
+              }
+            }
+          }
+        }}
       >
         {contexts.map((context) => (
           <MenuItem key={context} value={context} sx={{ height: "30px", padding: "0 8px" }}>

--- a/src/components/TreeViewComponent.tsx
+++ b/src/components/TreeViewComponent.tsx
@@ -1214,24 +1214,54 @@ const TreeViewComponent = () => {
               onClick={() => setViewMode('tiles')}
               sx={{ 
                   padding: 1,
-                  borderRadius: "50%", // Ensures a perfect circle
-                  width: 40,          // Optional: Fixed width for consistency
-                  height: 40,         // Optional: Fixed height for consistency
+                  borderRadius: "50%",
+                  width: 40,         
+                  height: 40,         
+                  
+                  bgcolor: theme === "dark" && viewMode === 'tiles' ? "rgba(144, 202, 249, 0.15)" : "transparent",
+                  "&:hover": {
+                    bgcolor: theme === "dark" ? "rgba(255, 255, 255, 0.1)" : "rgba(0, 0, 0, 0.05)",
+                  }
               }}
             >
-              <span><i className="fa fa-th menu_icon" title="Tiles"></i></span>
+              <span>
+                <i 
+                  className="fa fa-th menu_icon" 
+                  title="Tiles"
+                  style={{ 
+                    color: theme === "dark" 
+                      ? viewMode === 'tiles' ? "#90CAF9" : "#FFFFFF" 
+                      : undefined 
+                  }}
+                ></i>
+              </span>
             </IconButton>
             <IconButton
               color={viewMode === 'list' ? "primary" : "default"}
               onClick={() => setViewMode('list')}
               sx={{
                 padding: 1,
-                borderRadius: "50%", // Ensures a perfect circle
-                width: 40,          // Optional: Fixed width for consistency
-                height: 40,         // Optional: Fixed height for consistency
+                borderRadius: "50%", 
+                width: 40,         
+                height: 40,         
+                
+                bgcolor: theme === "dark" && viewMode === 'list' ? "rgba(144, 202, 249, 0.15)" : "transparent",
+                "&:hover": {
+                  bgcolor: theme === "dark" ? "rgba(255, 255, 255, 0.1)" : "rgba(0, 0, 0, 0.05)",
+                }
               }}
             >
-              <span><i className="fa fa-th-list selected menu_icon" title="List"></i></span>
+              <span>
+                <i 
+                  className="fa fa-th-list selected menu_icon" 
+                  title="List"
+                  style={{ 
+                    color: theme === "dark" 
+                      ? viewMode === 'list' ? "#90CAF9" : "#FFFFFF" 
+                      : undefined 
+                  }}
+                ></i>
+              </span>
             </IconButton>
             <Button
               variant="outlined"

--- a/src/components/WecsTopology.tsx
+++ b/src/components/WecsTopology.tsx
@@ -1124,24 +1124,53 @@ const WecsTreeview = () => {
               onClick={() => setViewMode('tiles')}
               sx={{ 
                 padding: 1,
-                borderRadius: "50%", // Ensures a perfect circle
-                width: 40,          // Optional: Fixed width for consistency
-                height: 40,         // Optional: Fixed height for consistency
+                borderRadius: "50%",
+                width: 40,
+                height: 40,
+                bgcolor: theme === "dark" && viewMode === 'tiles' ? "rgba(144, 202, 249, 0.15)" : "transparent",
+                "&:hover": {
+                  bgcolor: theme === "dark" ? "rgba(255, 255, 255, 0.1)" : "rgba(0, 0, 0, 0.05)",
+                }
               }}
             >
-              <span><i className="fa fa-th menu_icon" title="Tiles"></i></span>
+              <span>
+                <i 
+                  className="fa fa-th menu_icon" 
+                  title="Tiles"
+                  style={{ 
+                    color: theme === "dark" 
+                      ? viewMode === 'tiles' ? "#90CAF9" : "#FFFFFF" 
+                      : undefined 
+                  }}
+                ></i>
+              </span>
             </IconButton>
             <IconButton
               color={viewMode === 'list' ? "primary" : "default"}
               onClick={() => setViewMode('list')}
               sx={{ 
                 padding: 1,
-                borderRadius: "50%", // Ensures a perfect circle
-                width: 40,          // Optional: Fixed width for consistency
-                height: 40,         // Optional: Fixed height for consistency
+                borderRadius: "50%", 
+                width: 40,         
+                height: 40,         
+              
+                bgcolor: theme === "dark" && viewMode === 'list' ? "rgba(144, 202, 249, 0.15)" : "transparent",
+                "&:hover": {
+                  bgcolor: theme === "dark" ? "rgba(255, 255, 255, 0.1)" : "rgba(0, 0, 0, 0.05)",
+                }
               }}
             >
-              <span><i className="fa fa-th-list selected menu_icon" title="List"></i></span>
+              <span>
+                <i 
+                  className="fa fa-th-list menu_icon" 
+                  title="List"
+                  style={{ 
+                    color: theme === "dark" 
+                      ? viewMode === 'list' ? "#90CAF9" : "#FFFFFF" 
+                      : undefined 
+                  }}
+                ></i>
+              </span>
             </IconButton>
             <Button
               variant="outlined"


### PR DESCRIPTION
### Description
This PR improves the visibility of UI elements in dark mode by enhancing theme-aware styling for icons and buttons. Currently, several UI controls are difficult to see or nearly invisible when using dark mode, particularly the list/grid view toggle icons and dropdown selectors.

### Related Issue
Fixes UI visibility issues in dark mode

### Changes Made
- [x] Added theme-aware styling to list/grid toggle icons in the Manage Workloads page
- [x] Added theme-aware styling to list/grid toggle icons in the Remote Cluster page
- [x] Enhanced dropdown button visibility in dark mode with proper contrast
- [x] Applied consistent styling approach across components for better maintainability

### Checklist
Please ensure the following before submitting your PR:
- [x] I have reviewed the project's contribution guidelines.
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)
After:
[Image showing improved icon visibility in dark mode]
![image](https://github.com/user-attachments/assets/ed4deaf2-5d9e-4821-92cc-bbea7efb274d)
![Screenshot from 2025-04-16 03-27-05](https://github.com/user-attachments/assets/71ba28b9-1d6b-41e9-b310-91324087ab29)


### Additional Notes
These changes only affect the UI appearance in dark mode and do not alter any functional behavior. The approach used maintains current styling in light mode while enhancing visibility in dark mode through conditional theme-aware styling.