### PR TITLE
Added the search funcctionality for both clusters and workload labels

### DIFF
--- a/src/components/BindingPolicy/WorkloadPanel.tsx
+++ b/src/components/BindingPolicy/WorkloadPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import { 
   Box, 
   Typography, 
@@ -9,7 +9,9 @@ import {
   alpha,
   Button,
   Chip,
-  Tooltip
+  Tooltip,
+  InputBase,
+  IconButton
 } from '@mui/material';
 import { Draggable } from '@hello-pangea/dnd';
 import { Workload } from '../../types/bindingPolicy';
@@ -17,6 +19,9 @@ import StrictModeDroppable from './StrictModeDroppable';
 import KubernetesIcon from './KubernetesIcon';
 import AddIcon from '@mui/icons-material/Add';
 import { useNavigate } from 'react-router-dom';
+import CloseIcon from '@mui/icons-material/Close';
+import { SearchIcon } from 'lucide-react';
+
 
 interface WorkloadPanelProps {
   workloads: Workload[];
@@ -44,6 +49,8 @@ const WorkloadPanel: React.FC<WorkloadPanelProps> = ({
 }) => {
   const theme = useTheme();
   const navigate = useNavigate();
+  const [showSearch, setShowSearch] = useState(false);
+  const [searchTerm, setSearchTerm] = useState("");
 
   const handleCreateWorkload = () => {
     navigate('/workloads/manage');
@@ -82,6 +89,16 @@ const WorkloadPanel: React.FC<WorkloadPanelProps> = ({
     
     return Object.values(labelMap);
   }, [workloads]);
+  
+// Filter labels based on search term
+  const filteredLabels = React.useMemo(() => {
+    if (!searchTerm) return uniqueLabels;
+    
+    return uniqueLabels.filter(label => 
+      label.key.toLowerCase().includes(searchTerm.toLowerCase()) || 
+      label.value.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+  }, [uniqueLabels, searchTerm]);
 
   // Render a label item
   const renderLabelItem = (labelGroup: LabelGroup, index: number) => {
@@ -217,9 +234,56 @@ const WorkloadPanel: React.FC<WorkloadPanelProps> = ({
       }}
     >
       <Box sx={{ p: compact ? 1 : 2, backgroundColor: theme.palette.secondary.main, color: 'white', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', flexGrow: 1 }}>
           <KubernetesIcon type="workload" size={compact ? 20 : 24} sx={{ mr: 1, color: 'white' }} />
+          {showSearch ? (
+            <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              borderRadius: 1,
+              px:1,
+              mr:1,
+              bgcolor: alpha(theme.palette.common.white, 0.15),
+              flexGrow: 1,
+
+            }}
+            >
+              <InputBase
+              placeholder="Search labels"
+              value={searchTerm}
+              onChange={(e)=>setSearchTerm(e.target.value)}
+              sx={{
+                color: 'white',
+                flexGrow: 1,
+                '& .MuiInputBase-input': {
+                    py: 0.5,
+                  }
+              }}
+              autoFocus
+              />
+               <IconButton size="small" onClick={() => {
+                setSearchTerm("");
+                setShowSearch(false);
+              }} sx={{ color: 'white', p: 0.25 }}>
+                <CloseIcon fontSize="small" />
+              </IconButton>
+
+            </Box>
+          ):(
           <Typography variant={compact ? "subtitle1" : "h6"}>Workload Labels</Typography>
+        )}
+        {!showSearch && !compact && (
+          <IconButton 
+          size="small" 
+          sx={{ ml: 1, color: 'white' }}
+          onClick={() => setShowSearch(true)}
+        >
+          <SearchIcon fontSize="small" />
+        </IconButton>
+        )
+          
+        }
         </Box>
         {!compact && (
           <Button
@@ -273,12 +337,13 @@ const WorkloadPanel: React.FC<WorkloadPanelProps> = ({
                 data-rfd-droppable-context-id={provided.droppableProps['data-rfd-droppable-context-id']}
                 sx={{ minHeight: '100%' }}
               >
-                {uniqueLabels.length === 0 ? (
+
+                {filteredLabels.length === 0 ? (
                   <Typography sx={{ p: 2, color: 'text.secondary', textAlign: 'center' }}>
-                    No labels found in available workloads.
-                  </Typography>
+                    {searchTerm ? 'No labels match your search.' : 'No labels found in available clusters.'}
+                    </Typography>
                 ) : (
-                  uniqueLabels.map((labelGroup, index) => 
+                  filteredLabels.map((labelGroup, index) => 
                     renderLabelItem(labelGroup, index)
                   )
                 )}


### PR DESCRIPTION
### Description
Added the search funcctionality for both clusters and workload labels in the drag and drop binding policy

### Related Issue
Fixes #576 

### Changes Made
- Added a search button and search functionality at the top for both the cluster and workloads labels section.

### Checklist
Please ensure the following before submitting your PR:
- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

