### PR TITLE
added individual delete button to the clusters and workload

### DIFF
--- a/src/components/BindingPolicy/PolicyCanvas.tsx
+++ b/src/components/BindingPolicy/PolicyCanvas.tsx
@@ -10,6 +10,7 @@ import {
   CircularProgress,
   Divider,
   Chip,
+  IconButton,
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
@@ -1122,9 +1123,13 @@ const PolicyCanvas: React.FC<PolicyCanvasProps> = ({
                                     backgroundColor: alpha(theme.palette.info.main, 0.1),
                                     transition: 'all 0.2s',
                                     cursor: 'pointer',
+                                    position: 'relative',
                                     '&:hover': { 
                                       transform: 'translateY(-2px)', 
                                       boxShadow: 3 
+                                    },
+                                    '&:hover .delete-button': {
+                                      opacity: 1,
                                     }
                                   }}
                                   data-item-type="cluster"
@@ -1203,6 +1208,29 @@ const PolicyCanvas: React.FC<PolicyCanvasProps> = ({
                                       </Box>
                                     </Box>
                                   )}
+                                  <IconButton
+                                    size="small"
+                                    className="delete-button"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      removeFromPolicyCanvas('cluster', clusterId);
+                                    }}
+                                    sx={{
+                                      position: 'absolute',
+                                      top: 4,
+                                      right: 4,
+                                      opacity: 0,
+                                      transition: 'opacity 0.2s',
+                                      bgcolor: alpha(theme.palette.error.main, 0.1),
+                                      color: theme.palette.error.main,
+                                      p: '2px',
+                                      '&:hover': {
+                                        bgcolor: alpha(theme.palette.error.main, 0.2),
+                                      }
+                                    }}
+                                  >
+                                    <DeleteIcon fontSize="small" />
+                                  </IconButton>
                                 </Paper>
                               );
                             })}
@@ -1281,9 +1309,13 @@ const PolicyCanvas: React.FC<PolicyCanvasProps> = ({
                                     backgroundColor: alpha(theme.palette.success.main, 0.1),
                                     transition: 'all 0.2s',
                                     cursor: 'pointer',
+                                    position: 'relative',
                                     '&:hover': { 
                                       transform: 'translateY(-2px)', 
                                       boxShadow: 3 
+                                    },
+                                    '&:hover .delete-button': { 
+                                      opacity: 1,
                                     }
                                   }}
                                   data-item-type="workload"
@@ -1382,6 +1414,29 @@ const PolicyCanvas: React.FC<PolicyCanvasProps> = ({
                                       )}
                                     </>
                                   )}
+                                  <IconButton
+                                    size="small"
+                                    className="delete-button"
+                                    onClick={(e) => {
+                                      e.stopPropagation(); 
+                                      removeFromPolicyCanvas('workload', workloadId);
+                                    }}
+                                    sx={{
+                                      position: 'absolute',
+                                      top: 4,
+                                      right: 4,
+                                      opacity: 0, // Hidden by default
+                                      transition: 'opacity 0.2s',
+                                      bgcolor: alpha(theme.palette.error.main, 0.1),
+                                      color: theme.palette.error.main,
+                                      p: '2px',
+                                      '&:hover': {
+                                        bgcolor: alpha(theme.palette.error.main, 0.2),
+                                      }
+                                    }}
+                                  >
+                                    <DeleteIcon fontSize="small" />
+                                  </IconButton>
                                 </Paper>
                               );
                             })}
@@ -1506,4 +1561,4 @@ const PolicyCanvas: React.FC<PolicyCanvasProps> = ({
   );
 };
 
-export default React.memo(PolicyCanvas); 
+export default React.memo(PolicyCanvas);


### PR DESCRIPTION
### Description
This PR enhances the binding policy canvas UI by adding individual delete buttons to cluster and workload items. Currently, users can only clear the entire canvas, which creates a poor user experience when they want to remove just one or a few items.

### Related Issue
Fixes #586  

### Changes Made
- [x] Added delete buttons to individual cluster and workload items in the binding policy canvas
- [x] Implemented hover effect to show delete buttons only when needed (cleaner UI)
- [x] Added proper event handling to prevent triggering parent click events
- [x] Styled buttons with error theme for clear user intent
- [x] Ensured dark mode compatibility for all UI elements

### Checklist
Please ensure the following before submitting your PR:
- [x] I have reviewed the project's contribution guidelines.
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.
- [x] The implementation maintains all existing functionality while adding new features.

### Screenshots or Logs
<!-- Screenshot of hover state showing delete button -->
[Screencast from 19-04-25 02:21:26 AM IST.webm](https://github.com/user-attachments/assets/e07d41bf-9619-4df9-94f5-55e3e3e96001)


### Additional Notes
This change improves user experience significantly by allowing selective removal of items from the canvas instead of requiring users to clear the entire canvas when they only need to remove one item.