### PR TITLE
feat: add label support in GitHub and Helm tab

### DIFF
--- a/src/components/CreateOptions.tsx
+++ b/src/components/CreateOptions.tsx
@@ -30,6 +30,7 @@ interface FormData {
   credentials: string;
   branchSpecifier: string;
   webhook: string;
+  workload_label: string;
 }
 
 interface HelmFormData {
@@ -39,6 +40,7 @@ interface HelmFormData {
   releaseName: string;
   version: string;
   namespace: string;
+  workload_label: string;
 }
 
 interface Workload {
@@ -127,6 +129,7 @@ spec:
     credentials: "none",
     branchSpecifier: "main",
     webhook: "none",
+    workload_label: "",
   };
   const [formData, setFormData] = useState<FormData>(initialFormData);
 
@@ -137,6 +140,7 @@ spec:
     releaseName: "",
     version: "", // Changed from "latest" to "" to make it empty by default
     namespace: "default",
+    workload_label: "",
   };
   const [helmFormData, setHelmFormData] = useState<HelmFormData>(initialHelmFormData);
 
@@ -415,6 +419,7 @@ spec:
         folder_path: formData.path,
         branch: formData.branchSpecifier || "main",
         webhook: formData.webhook !== "none" ? formData.webhook : undefined,
+        workload_label: formData.workload_label || undefined,
       };
 
       const queryParams: { [key: string]: string } = {};
@@ -445,6 +450,7 @@ spec:
           credentials: "none",
           branchSpecifier: "main",
           webhook: "none",
+          workload_label: "",
         });
         setTimeout(() => window.location.reload(), 4000);
       } else {
@@ -492,6 +498,11 @@ spec:
         requestBody.version = helmFormData.version;
       }
 
+      // Include the workload_label field if it's not empty
+      if (helmFormData.workload_label) {
+        requestBody.workloadLabel = helmFormData.workload_label;
+      }
+
       const response = await api.post(
         "/deploy/helm",
         requestBody,
@@ -513,6 +524,7 @@ spec:
           releaseName: "",
           version: "", // Reset to empty string
           namespace: "default",
+          workload_label: "",
         });
         setTimeout(() => window.location.reload(), 4000);
       } else {

--- a/src/components/Workloads/GitHubTab.tsx
+++ b/src/components/Workloads/GitHubTab.tsx
@@ -15,6 +15,7 @@ interface FormData {
   credentials: string;
   branchSpecifier: string;
   webhook: string;
+  workload_label: string;
 }
 
 interface Props {
@@ -182,6 +183,61 @@ const CreateFromYourGitHub = ({ formData, setFormData, error, credentialsList, h
         </span>
         <Typography variant="caption" sx={{ color: theme === "dark" ? "#858585" : "#666" }}>
           Specify the path to your YAML files in the repository
+        </Typography>
+      </Box>
+    </Box>
+
+    <Box>
+      <Typography
+        variant="subtitle1"
+        sx={{
+          fontWeight: 600,
+          fontSize: "13px",
+          color: theme === "dark" ? "#d4d4d4" : "#333",
+          mb: 1,
+        }}
+      >
+        Workload Label
+      </Typography>
+      <TextField
+        fullWidth
+        value={formData.workload_label}
+        onChange={(e) =>
+          setFormData({ ...formData, workload_label: e.target.value })
+        }
+        placeholder="e.g., my-app-workload"
+        sx={{
+          "& .MuiOutlinedInput-root": {
+            borderRadius: "8px",
+            "& fieldset": {
+              borderColor: theme === "dark" ? "#444" : "#e0e0e0",
+              borderWidth: "1px",
+            },
+            "&:hover fieldset": {
+              borderColor: "#1976d2",
+            },
+            "&.Mui-focused fieldset": {
+              borderColor: "#1976d2",
+              borderWidth: "1px",
+            },
+          },
+          "& .MuiInputBase-input": {
+            padding: "12px 14px",
+            fontSize: "0.875rem",
+            color: theme === "dark" ? "#d4d4d4" : "#666",
+          },
+          "& .MuiInputBase-input::placeholder": {
+            color: theme === "dark" ? "#858585" : "#666",
+            opacity: 1,
+          },
+        }}
+      />
+      <Box sx={{ display: "flex", alignItems: "center", mt: 1 }}>
+        <span role="img" aria-label="tip" style={{ fontSize: "0.8rem", marginRight: "8px" }}>
+          💡
+        </span>
+        <Typography variant="caption" sx={{ color: theme === "dark" ? "#858585" : "#666" }}>
+          Add a label to identify your workload (optional)
         </Typography>
       </Box>
     </Box>
@@ -465,7 +521,8 @@ export const GitHubTab = ({
         `/api/deploy?created_by_me=true&branch=${selectedRepoData.branch}`,
         {
           repo_url: selectedRepoData.repo_url,
-          folder_path: selectedRepoData.folder_path
+          folder_path: selectedRepoData.folder_path,
+          workload_label: formData.workload_label
         },
         {
           headers: {

--- a/src/components/Workloads/HelmTab/CreateOwnHelmForm.tsx
+++ b/src/components/Workloads/HelmTab/CreateOwnHelmForm.tsx
@@ -336,7 +336,7 @@ export const CreateOwnHelmForm = ({ formData, setFormData, error, theme }: Props
                       mb: 1,
                   }}
               >
-                  Namespace (default: default)
+                  Namespace *
               </Typography>
               <TextField
                   fullWidth
@@ -344,7 +344,66 @@ export const CreateOwnHelmForm = ({ formData, setFormData, error, theme }: Props
                   onChange={(e) =>
                       setFormData({ ...formData, namespace: e.target.value })
                   }
-                  placeholder="e.g., kube-system"
+                  error={!!error && !formData.namespace}
+                  placeholder="e.g., default, my-namespace"
+                  sx={{
+                      "& .MuiOutlinedInput-root": {
+                          borderRadius: "8px",
+                          "& fieldset": {
+                              borderColor: theme === "dark" ? "#444" : "#e0e0e0",
+                              borderWidth: "1px",
+                          },
+                          "&:hover fieldset": {
+                              borderColor: "#1976d2",
+                          },
+                          "&.Mui-focused fieldset": {
+                              borderColor: "#1976d2",
+                              borderWidth: "1px",
+                          },
+                          "&.Mui-error fieldset": {
+                              borderColor: "red",
+                          },
+                      },
+                      "& .MuiInputBase-input": {
+                          padding: "12px 14px",
+                          fontSize: "0.875rem",
+                          color: theme === "dark" ? "#d4d4d4" : "#666",
+                      },
+                      "& .MuiInputBase-input::placeholder": {
+                          color: theme === "dark" ? "#858585" : "#666",
+                          opacity: 1,
+                      },
+                  }}
+              />
+              <Box sx={{ display: "flex", alignItems: "center", mt: 1 }}>
+                  <span role="img" aria-label="tip" style={{ fontSize: "0.8rem", marginRight: "8px" }}>
+                      💡
+                  </span>
+                  <Typography variant="caption" sx={{ color: theme === "dark" ? "#858585" : "#666" }}>
+                      Specify the namespace for the Helm chart
+                  </Typography>
+              </Box>
+          </Box>
+
+          <Box>
+              <Typography
+                  variant="subtitle1"
+                  sx={{
+                      fontWeight: 600,
+                      fontSize: "13px",
+                      color: theme === "dark" ? "#d4d4d4" : "#333",
+                      mb: 1,
+                  }}
+              >
+                  Workload Label
+              </Typography>
+              <TextField
+                  fullWidth
+                  value={formData.workload_label}
+                  onChange={(e) =>
+                      setFormData({ ...formData, workload_label: e.target.value })
+                  }
+                  placeholder="e.g., my-helm-workload"
                   sx={{
                       "& .MuiOutlinedInput-root": {
                           borderRadius: "8px",
@@ -376,7 +435,7 @@ export const CreateOwnHelmForm = ({ formData, setFormData, error, theme }: Props
                       💡
                   </span>
                   <Typography variant="caption" sx={{ color: theme === "dark" ? "#858585" : "#666" }}>
-                      Specify the namespace for the Helm deployment
+                      Add a label to identify your workload (optional)
                   </Typography>
               </Box>
           </Box>

--- a/src/components/Workloads/HelmTab/HelmTab.tsx
+++ b/src/components/Workloads/HelmTab/HelmTab.tsx
@@ -16,6 +16,7 @@ export interface HelmFormData {
   releaseName: string;
   version: string;
   namespace: string;
+  workload_label: string;
 }
 
 interface Props {
@@ -116,6 +117,7 @@ export const HelmTab = ({
         chartName: selectedChart,
         releaseName: selectedChart,
         namespace: selectedChart,
+        workloadLabel: formData.workload_label || undefined
       };
 
       const response = await api.post(


### PR DESCRIPTION
### Description
This PR introduces label support functionality for both the GitHub and Helm tab sections. It allows users to assign and manage labels from now github and helm tab.


### Changes Made
<!-- Provide a detailed list of changes made in this PR. -->
- [x]  Added label UI and logic to the GitHub tab.
- [x]  Integrated label support in the Helm tab
- [x]  Handled label state and updates

### Checklist
Please ensure the following before submitting your PR:
- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.
