### PR TITLE
Added cluster Scope objects in workload Panel

### DIFF
--- a/backend/wds/bp/handlers.go
+++ b/backend/wds/bp/handlers.go
@@ -1380,6 +1380,7 @@ func CreateQuickBindingPolicy(ctx *gin.Context) {
 	type ResourceConfig struct {
 		Type       string `json:"type"`       // Resource type (e.g., "deployments", "namespaces")
 		CreateOnly bool   `json:"createOnly"` // Whether to use createOnly mode for this resource
+		APIGroup   string `json:"apiGroup"`   // Optional API group for the resource (for CRDs)
 	}
 
 	type QuickBindingPolicyRequest struct {
@@ -1512,6 +1513,96 @@ func CreateQuickBindingPolicy(ctx *gin.Context) {
 
 	downsyncRules := []interface{}{namespaceRule}
 
+	// Track if we have CRDs to add
+	hasCRDs := false
+	crdAPIGroups := make(map[string]string)
+
+	// First check for custom resources that will need CRDs
+	for _, resourceCfg := range resourceConfigs {
+		resource := resourceCfg.Type
+
+		if isKubernetesBuiltInResource(resource) {
+			continue
+		}
+
+		// Found a custom resource, track its API group for CRD handling
+		apiGroup := ""
+		// Check if original request has apiGroup in the matching resource
+		for _, origRes := range request.Resources {
+			if origRes.Type == resource && origRes.APIGroup != "" {
+				apiGroup = origRes.APIGroup
+				break
+			}
+		}
+
+		// If no explicit apiGroup provided, use a heuristic to determine it
+		if apiGroup == "" {
+			singular := strings.TrimSuffix(resource, "s")
+
+			if strings.HasSuffix(resource, "cds") || strings.HasSuffix(resource, "eds") {
+				rootName := singular[:len(singular)-1]
+				apiGroup = fmt.Sprintf("%s.io", rootName)
+			} else {
+				apiGroup = fmt.Sprintf("%s.k8s.io", singular)
+			}
+		}
+
+		crdAPIGroups[resource] = apiGroup
+		hasCRDs = true
+	}
+
+	// If we have custom resources, add rule(s) for CustomResourceDefinitions
+	if hasCRDs {
+		fmt.Printf("Debug - Adding CustomResourceDefinitions to binding policy\n")
+
+		// Check if customresourcedefinitions is already in the resources list
+		hasExplicitCRDResource := false
+		for _, res := range resourceConfigs {
+			if res.Type == "customresourcedefinitions" {
+				hasExplicitCRDResource = true
+				break
+			}
+		}
+
+		if hasExplicitCRDResource {
+			fmt.Printf("Debug - User explicitly specified CustomResourceDefinitions resource, using workload labels\n")
+			crdRule := map[string]interface{}{
+				"apiGroup":  "apiextensions.k8s.io",
+				"resources": []string{"customresourcedefinitions"},
+				"objectSelectors": []interface{}{
+					map[string]interface{}{
+						"matchLabels": request.WorkloadLabels,
+					},
+				},
+			}
+			downsyncRules = append([]interface{}{crdRule}, downsyncRules...)
+		} else {
+			specificCRDNames := getCRDNamesFromResources(crdAPIGroups)
+
+			if len(specificCRDNames) > 0 {
+				fmt.Printf("Debug - Adding specific CRDs to binding policy: %v\n", specificCRDNames)
+
+				for _, crdName := range specificCRDNames {
+					fmt.Printf("Debug - Adding individual CRD rule for %s\n", crdName)
+
+					// Individual CRD rule with explicit name matching
+					crdRule := map[string]interface{}{
+						"apiGroup":  "apiextensions.k8s.io",
+						"resources": []string{"customresourcedefinitions"},
+						"objectSelectors": []interface{}{
+							map[string]interface{}{
+								"matchNames": []string{crdName},
+							},
+						},
+					}
+
+					// Add individual CRD rule (at the beginning, so CRDs are created first)
+					downsyncRules = append([]interface{}{crdRule}, downsyncRules...)
+				}
+			}
+		}
+	}
+
 	// Now add other resources
 	for _, resourceCfg := range resourceConfigs {
 		resource := resourceCfg.Type
@@ -1529,6 +1620,14 @@ func CreateQuickBindingPolicy(ctx *gin.Context) {
 					"matchLabels": request.WorkloadLabels,
 				},
 			},
+		}
+
+		// Handle custom resources by detecting non-standard resource types
+		if !isKubernetesBuiltInResource(resource) {
+			// For CRDs, we need to specify the apiGroup
+			apiGroup := crdAPIGroups[resource]
+			downsyncRule["apiGroup"] = apiGroup
+			fmt.Printf("Debug - Adding CRD resource %s with apiGroup %s\n", resource, apiGroup)
 		}
 
 		// Only add createOnly if it's true
@@ -1660,6 +1759,7 @@ func GenerateQuickBindingPolicyYAML(ctx *gin.Context) {
 	type ResourceConfig struct {
 		Type       string `json:"type"`       // Resource type (e.g., "deployments", "namespaces")
 		CreateOnly bool   `json:"createOnly"` // Whether to use createOnly mode for this resource
+		APIGroup   string `json:"apiGroup"`   // Optional API group for the resource (for CRDs)
 	}
 
 	type QuickBindingPolicyRequest struct {
@@ -1792,6 +1892,94 @@ func GenerateQuickBindingPolicyYAML(ctx *gin.Context) {
 
 	downsyncRules := []interface{}{namespaceRule}
 
+	// Track if we have CRDs to add
+	hasCRDs := false
+	crdAPIGroups := make(map[string]string)
+
+	// First check for custom resources that will need CRDs
+	for _, resourceCfg := range resourceConfigs {
+		resource := resourceCfg.Type
+
+		if isKubernetesBuiltInResource(resource) {
+			continue
+		}
+
+		apiGroup := ""
+		// Check if original request has apiGroup in the matching resource
+		for _, origRes := range request.Resources {
+			if origRes.Type == resource && origRes.APIGroup != "" {
+				apiGroup = origRes.APIGroup
+				break
+			}
+		}
+
+		if apiGroup == "" {
+			singular := strings.TrimSuffix(resource, "s")
+			if strings.HasSuffix(resource, "cds") || strings.HasSuffix(resource, "eds") {
+				rootName := singular[:len(singular)-1]
+				apiGroup = fmt.Sprintf("%s.io", rootName)
+			} else {
+				apiGroup = fmt.Sprintf("%s.k8s.io", singular)
+			}
+		}
+
+		crdAPIGroups[resource] = apiGroup
+		hasCRDs = true
+	}
+
+	// If we have custom resources, add rule(s) for CustomResourceDefinitions
+	if hasCRDs {
+		fmt.Printf("Debug - Adding CustomResourceDefinitions to binding policy\n")
+
+		// Check if customresourcedefinitions is already in the resources list
+		hasExplicitCRDResource := false
+		for _, res := range resourceConfigs {
+			if res.Type == "customresourcedefinitions" {
+				hasExplicitCRDResource = true
+				break
+			}
+		}
+
+		if hasExplicitCRDResource {
+			fmt.Printf("Debug - User explicitly specified CustomResourceDefinitions resource, using workload labels\n")
+
+			crdRule := map[string]interface{}{
+				"apiGroup":  "apiextensions.k8s.io",
+				"resources": []string{"customresourcedefinitions"},
+				"objectSelectors": []interface{}{
+					map[string]interface{}{
+						"matchLabels": request.WorkloadLabels,
+					},
+				},
+			}
+			downsyncRules = append([]interface{}{crdRule}, downsyncRules...)
+		} else {
+			specificCRDNames := getCRDNamesFromResources(crdAPIGroups)
+
+			if len(specificCRDNames) > 0 {
+				fmt.Printf("Debug - Adding specific CRDs to binding policy: %v\n", specificCRDNames)
+
+				for _, crdName := range specificCRDNames {
+					fmt.Printf("Debug - Adding individual CRD rule for %s\n", crdName)
+
+					// Individual CRD rule with explicit name matching
+					crdRule := map[string]interface{}{
+						"apiGroup":  "apiextensions.k8s.io",
+						"resources": []string{"customresourcedefinitions"},
+						"objectSelectors": []interface{}{
+							map[string]interface{}{
+								"matchNames": []string{crdName},
+							},
+						},
+					}
+
+					// Add individual CRD rule (at the beginning, so CRDs are created first)
+					downsyncRules = append([]interface{}{crdRule}, downsyncRules...)
+				}
+			}
+		}
+	}
+
 	// Now add other resources
 	for _, resourceCfg := range resourceConfigs {
 		resource := resourceCfg.Type
@@ -1809,6 +1997,13 @@ func GenerateQuickBindingPolicyYAML(ctx *gin.Context) {
 					"matchLabels": request.WorkloadLabels,
 				},
 			},
+		}
+
+		if !isKubernetesBuiltInResource(resource) {
+			// For CRDs, we need to specify the apiGroup
+			apiGroup := crdAPIGroups[resource]
+			downsyncRule["apiGroup"] = apiGroup
+			fmt.Printf("Debug - Adding CRD resource %s with apiGroup %s\n", resource, apiGroup)
 		}
 
 		// Only add createOnly if it's true
@@ -1947,4 +2142,38 @@ func CreateWecNamespace(ctx *gin.Context) {
 		"message":        fmt.Sprintf("Namespace %s created in WEC clusters: %v", namespace, wecContexts),
 		"cluster_labels": clusterLabels,
 	})
+}
+
+// Check if a resource is a built-in Kubernetes resource
+func isKubernetesBuiltInResource(resource string) bool {
+	// Common built-in Kubernetes resources
+	builtInResources := []string{
+		"pods", "services", "deployments", "statefulsets", "daemonsets",
+		"configmaps", "secrets", "namespaces", "persistentvolumes", "persistentvolumeclaims",
+		"serviceaccounts", "roles", "rolebindings", "clusterroles", "clusterrolebindings",
+		"ingresses", "jobs", "cronjobs", "events", "horizontalpodautoscalers",
+		"endpoints", "replicasets", "networkpolicies", "limitranges", "resourcequotas",
+		"customresourcedefinitions", "priorityclasses", "storageclasses",
+	}
+
+	for _, builtIn := range builtInResources {
+		if builtIn == resource {
+			return true
+		}
+	}
+	return false
+}
+
+// Helper function to get CRD full names from resource types and API groups
+func getCRDNamesFromResources(resourceAPIGroups map[string]string) []string {
+	crdNames := []string{}
+
+	for resource, apiGroup := range resourceAPIGroups {
+		crdName := fmt.Sprintf("%s.%s", resource, apiGroup)
+
+		fmt.Printf("Debug - Generated CRD name: %s for resource type %s\n", crdName, resource)
+		crdNames = append(crdNames, crdName)
+	}
+
+	return crdNames
 }

--- a/src/components/BindingPolicy/BPTable.tsx
+++ b/src/components/BindingPolicy/BPTable.tsx
@@ -77,20 +77,6 @@ const BPTable: React.FC<BPTableProps> = ({
     error: detailsError
   } = useBindingPolicyDetails(selectedPolicyName || undefined, { refetchInterval: 2000 });
 
-  const refetchPolicies = useCallback(() => {
-    console.log("Manually triggering policy data refetch");
-    queryClient.invalidateQueries({ queryKey: ['binding-policies'] });
-    fetchPolicyStatuses();
-  }, [queryClient]);
-
-  useEffect(() => {
-    const refreshInterval = setInterval(() => {
-      refetchPolicies();
-    }, 2000); 
-    
-    return () => clearInterval(refreshInterval);
-  }, [refetchPolicies]);
-
   // Fetch status for each policy
   const fetchPolicyStatuses = useCallback(async () => {
     // Create a map to store statuses
@@ -150,9 +136,20 @@ const BPTable: React.FC<BPTableProps> = ({
     // Update state with all fetched statuses
     setPolicyStatuses(newPolicyStatuses);
   }, [policies]);
-  useEffect(() => {
+
+  const refreshAllPolicyData = useCallback(() => {
+    console.log("Manually triggering policy data refetch");
+    queryClient.invalidateQueries({ queryKey: ['binding-policies'] });
     fetchPolicyStatuses();
-  }, [fetchPolicyStatuses]);
+  }, [queryClient, fetchPolicyStatuses]);
+
+  useEffect(() => {
+    const refreshInterval = setInterval(() => {
+      refreshAllPolicyData();
+    }, 2000); 
+    
+    return () => clearInterval(refreshInterval);
+  }, [refreshAllPolicyData]);
 
   // Add debugging for policy details
   useEffect(() => {

--- a/src/components/BindingPolicy/KubernetesIcon.tsx
+++ b/src/components/BindingPolicy/KubernetesIcon.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Box, Typography, SxProps, Theme } from '@mui/material';
 
-export type IconType = 'workload' | 'cluster' | 'policy';
+export type IconType = 'workload' | 'cluster' | 'policy' | 'namespace';
 
 interface KubernetesIconProps {
   type: IconType;
@@ -19,6 +19,8 @@ const KubernetesIcon: React.FC<KubernetesIconProps> = ({ type, size = 24, sx = {
         return '#2196f3'; // Material blue
       case 'policy':
         return '#9c27b0'; // Purple for policies
+      case 'namespace':
+        return '#00bcd4'; // Cyan for namespaces
       default:
         return '#326ce5';
     }
@@ -33,6 +35,8 @@ const KubernetesIcon: React.FC<KubernetesIconProps> = ({ type, size = 24, sx = {
         return 'CL';
       case 'policy':
         return 'BP';
+      case 'namespace':
+        return 'NS';
       default:
         return '';
     }

--- a/src/components/BindingPolicy/PolicyPanels.tsx
+++ b/src/components/BindingPolicy/PolicyPanels.tsx
@@ -4,12 +4,21 @@ import { ManagedCluster, Workload } from '../../types/bindingPolicy';
 import ClusterPanel from './ClusterPanel';
 import WorkloadPanel from './WorkloadPanel';
 
+// Import TreeItem type for the callback
+interface TreeItem {
+  id: string;
+  name?: string;
+  kind?: string;
+  namespace?: string;
+  [key: string]: unknown;
+}
+
 interface ClusterPanelContainerProps {
   clusters: ManagedCluster[];
   loading: boolean;
   error: string | undefined;
   compact?: boolean;
-  onItemClick?: (clusterId: string) => void; 
+  onItemClick?: (itemOrId: TreeItem | string) => void; 
 }
 
 interface WorkloadPanelContainerProps {
@@ -17,7 +26,7 @@ interface WorkloadPanelContainerProps {
   loading: boolean;
   error: string | undefined;
   compact?: boolean;
-  onItemClick?: (clusterId: string) => void; 
+  onItemClick?: (itemOrId: TreeItem | string) => void; 
 }
 
 export const ClusterPanelContainer: React.FC<ClusterPanelContainerProps> = ({

--- a/src/hooks/queries/useBPQueries.ts
+++ b/src/hooks/queries/useBPQueries.ts
@@ -1,7 +1,8 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '../../lib/api';
 import { toast } from 'react-hot-toast';
-import { BindingPolicyInfo } from '../../types/bindingPolicy';
+import { BindingPolicyInfo, Workload } from '../../types/bindingPolicy';
+import { useState, useCallback } from 'react';
 
 interface RawBindingPolicy {
   kind: string;
@@ -57,6 +58,8 @@ interface DownsyncItem {
 interface ResourceConfig {
   type: string;
   createOnly: boolean;
+  apiGroup?: string;
+  includeCRD?: boolean;
 }
 
 interface GenerateYamlRequest {
@@ -104,6 +107,34 @@ interface QuickConnectResponse {
     yaml: string;
   };
   message: string;
+}
+
+interface WorkloadSSEData {
+  namespaced: Record<string, Record<string, Array<{
+    createdAt: string;
+    kind: string;
+    labels: Record<string, string> | null;
+    name: string;
+    namespace: string;
+    uid: string;
+    version: string;
+  }>>>;
+  clusterScoped: Record<string, Array<{
+    createdAt: string;
+    kind: string;
+    labels: Record<string, string> | null;
+    name: string;
+    namespace: string;
+    uid: string;
+    version: string;
+  }>>;
+}
+
+interface WorkloadSSEState {
+  status: 'idle' | 'loading' | 'success' | 'error';
+  progress: number;
+  data: WorkloadSSEData | null;
+  error: Error | null;
 }
 
 export const useBPQueries = () => {
@@ -510,6 +541,68 @@ export const useBPQueries = () => {
           );
         }
         
+        // Check for custom resources and ensure they have apiGroup if possible
+        formattedRequest.resources = formattedRequest.resources.map(resource => {
+          const standardResources = [
+            'pods', 'services', 'deployments', 'statefulsets', 'daemonsets',
+            'configmaps', 'secrets', 'namespaces', 'persistentvolumes', 'persistentvolumeclaims',
+            'serviceaccounts', 'roles', 'rolebindings', 'clusterroles', 'clusterrolebindings',
+            'ingresses', 'jobs', 'cronjobs', 'events', 'horizontalpodautoscalers',
+            'endpoints', 'replicasets', 'networkpolicies', 'limitranges', 'resourcequotas',
+            'customresourcedefinitions',
+          ];
+          
+          if (!standardResources.includes(resource.type)) {
+            const newResource = { ...resource };
+            
+            // Explicitly set includeCRD to true for all custom resources
+            newResource.includeCRD = true;
+            
+            // If API group is already set, keep it
+            if (!newResource.apiGroup) {
+              const singular = resource.type.endsWith('s')
+                ? resource.type.slice(0, -1) 
+                : resource.type;
+              
+
+              if (/^argo/.test(resource.type)) {
+
+                newResource.apiGroup = 'argoproj.io';
+                console.log(`Assigning argoproj.io API group to ${resource.type} based on name pattern`);
+              } else if (/^istio/.test(resource.type) || /gateway|service|route/.test(resource.type)) {
+                newResource.apiGroup = 'networking.istio.io';
+                console.log(`Assigning networking.istio.io API group to ${resource.type} based on name pattern`);
+              } else {
+                let domain = 'k8s.io';
+                
+                const parts = singular.split('.');
+                if (parts.length > 1) {
+                  domain = parts.slice(1).join('.');
+                  newResource.apiGroup = domain;
+                } else {
+                  
+                  newResource.apiGroup = `${parts[0]}.${domain}`;
+                }
+              }
+            }
+            
+            console.log(`Determined API group for custom resource ${resource.type}: ${newResource.apiGroup}`);
+            return newResource;
+          }
+          
+          return resource;
+        });
+        
+        // Check if customresourcedefinitions is explicitly included by the user
+        const userExplicitlyIncludedCRDs = formattedRequest.resources.some(
+          res => res.type === 'customresourcedefinitions'
+        );
+        
+        
+        if (userExplicitlyIncludedCRDs) {
+          console.log("User explicitly included customresourcedefinitions in resources");
+        }
+        
         // Make sure the request has workloadLabels
         if (!formattedRequest.workloadLabels || Object.keys(formattedRequest.workloadLabels).length === 0) {
           console.warn("No workload labels provided");
@@ -612,6 +705,70 @@ export const useBPQueries = () => {
           );
         }
         
+        // Check for custom resources and ensure they have apiGroup if possible
+        formattedRequest.resources = formattedRequest.resources.map(resource => {
+          // Check if this looks like a CRD (not one of the standard k8s resources)
+          const standardResources = [
+            'pods', 'services', 'deployments', 'statefulsets', 'daemonsets',
+            'configmaps', 'secrets', 'namespaces', 'persistentvolumes', 'persistentvolumeclaims',
+            'serviceaccounts', 'roles', 'rolebindings', 'clusterroles', 'clusterrolebindings',
+            'ingresses', 'jobs', 'cronjobs', 'events', 'horizontalpodautoscalers',
+            'endpoints', 'replicasets', 'networkpolicies', 'limitranges', 'resourcequotas',
+            'customresourcedefinitions',
+          ];
+          
+          if (!standardResources.includes(resource.type)) {
+            const newResource = { ...resource };
+            
+            newResource.includeCRD = true;
+            
+            // If API group is already set, keep it
+            if (!newResource.apiGroup) {
+              // Get singular form
+              const singular = resource.type.endsWith('s')
+                ? resource.type.slice(0, -1) 
+                : resource.type;
+             
+              if (/^argo/.test(resource.type)) {
+               
+                newResource.apiGroup = 'argoproj.io';
+                console.log(`Assigning argoproj.io API group to ${resource.type} based on name pattern`);
+              } else if (/^istio/.test(resource.type) || /gateway|service|route/.test(resource.type)) {
+                newResource.apiGroup = 'networking.istio.io';
+                console.log(`Assigning networking.istio.io API group to ${resource.type} based on name pattern`);
+              } else {
+                let domain = 'k8s.io';
+                
+                // Extract resource name that might be part of a domain
+                const parts = singular.split('.');
+                if (parts.length > 1) {
+                  // If resource has dots, use everything after first dot as domain
+                  domain = parts.slice(1).join('.');
+                  newResource.apiGroup = domain;
+                } else {
+                  
+                  newResource.apiGroup = `${parts[0]}.${domain}`;
+                }
+              }
+            }
+            
+            console.log(`Determined API group for custom resource ${resource.type}: ${newResource.apiGroup}`);
+            return newResource;
+          }
+          
+          return resource;
+        });
+        
+        // Check if customresourcedefinitions is explicitly included by the user
+        const userExplicitlyIncludedCRDs = formattedRequest.resources.some(
+          res => res.type === 'customresourcedefinitions'
+        );
+        
+        
+        if (userExplicitlyIncludedCRDs) {
+          console.log("User explicitly included customresourcedefinitions in YAML generation");
+        }
+        
         // Ensure namespacesToSync is set if not provided
         if (!formattedRequest.namespacesToSync || formattedRequest.namespacesToSync.length === 0) {
           // Use the provided namespace or default to 'default'
@@ -649,6 +806,213 @@ export const useBPQueries = () => {
     });
   };
 
+  // Get workloads and their labels using SSE
+  const useWorkloadSSE = () => {
+    const [state, setState] = useState<WorkloadSSEState>({
+      status: 'idle',
+      progress: 0,
+      data: null,
+      error: null
+    });
+
+    const startSSEConnection = useCallback(() => {
+      setState({
+        status: 'loading',
+        progress: 0,
+        data: null,
+        error: null
+      });
+
+      // Get the base URL from the api client
+      const baseUrl = api.defaults.baseURL || '';
+      const url = `${baseUrl}/api/wds/list-sse`;
+      
+      console.log('Starting SSE connection to:', url);
+      
+      // Create EventSource connection with credentials enabled
+      const eventSource = new EventSource(url, { withCredentials: true });
+      
+      // Handle connection open
+      eventSource.onopen = () => {
+        console.log('SSE connection established');
+      };
+
+      // Handle progress events
+      eventSource.addEventListener('progress', (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          console.log('SSE progress event:', data);
+
+          setState(prevState => ({
+            ...prevState,
+            progress: Math.min(prevState.progress + 5, 95) // Cap at 95% until complete
+          }));
+        } catch (error) {
+          console.error('Error parsing progress event data:', error);
+          // Don't fail the whole connection for a single progress event parsing error
+        }
+      });
+
+      // Handle completed event (backend calls it 'complete', not 'completed')
+      eventSource.addEventListener('complete', (event) => {
+        try {
+          console.log('SSE complete event received, parsing data');
+          const parsedData = JSON.parse(event.data);
+          
+          setState({
+            status: 'success',
+            progress: 100,
+            data: parsedData,
+            error: null
+          });
+
+          console.log('SSE data successfully processed');
+          // Close the connection since we have the complete data
+          eventSource.close();
+        } catch (error) {
+          console.error('Error parsing complete event data:', error);
+          
+          setState(prevState => ({
+            ...prevState,
+            status: 'error',
+            error: new Error('Failed to parse complete event data')
+          }));
+          
+          eventSource.close();
+        }
+      });
+
+      eventSource.onmessage = (event) => {
+        console.log('SSE general message:', event.data);
+      };
+
+      eventSource.onerror = (error) => {
+        console.error('SSE connection error:', error);
+        
+        if (error instanceof Event && !error.target) {
+          console.error('Possible CORS error with EventSource');
+        }
+        
+        setState(prevState => ({
+          ...prevState,
+          status: 'error',
+          error: new Error('Failed to connect to SSE endpoint. Please ensure you have proper permissions and the server is running.')
+        }));
+        
+        // Close the connection on error
+        eventSource.close();
+      };
+
+      // Return cleanup function
+      return () => {
+        console.log('Closing SSE connection');
+        eventSource.close();
+      };
+    }, []);
+
+    // Extract workloads with their labels from the SSE data
+    const extractWorkloads = useCallback(() => {
+      if (!state.data) return [];
+
+      const workloads: Workload[] = [];
+      
+      const excludedTypes = new Set([
+        'Secret', 
+        'ConfigMap', 
+        'Endpoints', 
+        'EndpointSlice',
+        'ControllerRevision'
+      ]);
+      
+      const excludedNamespaces = new Set(['default']);
+      
+      Object.entries(state.data.namespaced).forEach(([namespace, resourceTypes]) => {
+        if (excludedNamespaces.has(namespace)) {
+          return;
+        }
+        
+        Object.entries(resourceTypes).forEach(([resourceType, resources]) => {
+          // Skip namespace metadata and excluded resource types
+          if (resourceType === '__namespaceMetaData' || excludedTypes.has(resourceType)) {
+            return;
+          }
+          
+          // Process workload resources
+          resources.forEach(resource => {
+            if (resource.labels) {
+              workloads.push({
+                name: resource.name,
+                namespace: namespace,
+                kind: resource.kind,
+                labels: resource.labels,
+                creationTime: resource.createdAt
+              });
+            }
+          });
+        });
+      });
+      
+      // Process cluster-scoped resources
+      if (state.data.clusterScoped) {
+        // Define which cluster-scoped resource types to include
+        const includeClusterResourceTypes = new Set([
+          'CustomResourceDefinition',
+          'Namespace'
+        ]);
+
+        Object.entries(state.data.clusterScoped).forEach(([resourceType, resources]) => {
+          if (excludedTypes.has(resourceType) || !includeClusterResourceTypes.has(resourceType)) {
+            return;
+          }
+          
+          // Process cluster-scoped resources
+          resources.forEach(resource => {
+            if (resource.labels) {
+              workloads.push({
+                name: resource.name,
+                namespace: resource.namespace || 'cluster-scoped',
+                kind: resource.kind,
+                labels: resource.labels,
+                creationTime: resource.createdAt
+              });
+            }
+          });
+        });
+      }
+
+      console.log(`Extracted ${workloads.length} workloads after filtering (default namespace excluded)`);
+      return workloads;
+    }, [state.data]);
+
+    // Provide a way to get unique label keys and values for filtering
+    const extractUniqueLabels = useCallback(() => {
+      const workloads = extractWorkloads();
+      const labelMap: Record<string, Set<string>> = {};
+      
+      workloads.forEach(workload => {
+        if (workload.labels) {
+          Object.entries(workload.labels).forEach(([key, value]) => {
+            if (!labelMap[key]) {
+              labelMap[key] = new Set();
+            }
+            labelMap[key].add(value);
+          });
+        }
+      });
+      
+      return Object.fromEntries(
+        Object.entries(labelMap).map(([key, values]) => [key, Array.from(values)])
+      );
+    }, [extractWorkloads]);
+
+    return {
+      state,
+      startSSEConnection,
+      extractWorkloads,
+      extractUniqueLabels
+    };
+  };
+
   return {
     useBindingPolicies,
     useBindingPolicyDetails,
@@ -660,5 +1024,6 @@ export const useBPQueries = () => {
     useGenerateBindingPolicyYaml,
     useQuickConnect,
     useCreateWecNamespace,
+    useWorkloadSSE,
   };
 };


### PR DESCRIPTION
### Description
Use the new api to show the cluster scope objects in the workload panel of the click and drop Binding Policy.

### Related Issue
Fixes #622 

### Changes Made
- Restructured everything in the workload panel.
- Integrated new api for the workloads which includes cluster scoped objects.
- Made changes in backend to deploy the CRD's  using click and drop method.

### Checklist
Please ensure the following before submitting your PR:
- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.


