### PR TITLE
docs: fixed alignment of 5th prerequisites in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Before you begin, ensure that your system meets the following requirements:
 
 - **Kubestellar guide**: [Guide](https://docs.kubestellar.io/release-0.25.1/direct/get-started/)
  
-- ### 5. Make and Air
+### 5. Make and Air
 
 - Make sure you have "make" installed to directly execute the backend script via makefile
 - Air helps in hot reloading of the backend


### PR DESCRIPTION
### Description
simple readme fix just to fix the visibity of 5th Prerequisites showed in readme.md

### Related Issue
<!-- Link the issue(s) this PR addresses. -->
Fixes #<issue_number>

### Changes Made
<!-- Provide a detailed list of changes made in this PR. -->
- [ ] Updated ...
- [ ] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

### Checklist
Please ensure the following before submitting your PR:
- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [x] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)
<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

## Before

![image](https://github.com/user-attachments/assets/a422bfbf-fee4-49cf-b210-ebd3196ca4cd)

## After

![image](https://github.com/user-attachments/assets/1a6fe453-bcfe-4664-9833-f0f683d81673)


### Additional Notes
<!-- Add any other context, suggestions, or questions related to this PR. -->

just a simple change to get started :slightly_smiling_face: 

Thank you :heart: 
