### PR TITLE
Refactor DeployHandler for improved GitHub repository handling

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -170,5 +170,5 @@ require (
 	k8s.io/utils v0.0.0-20241210054802-24370beab758 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.5.0 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
+	sigs.k8s.io/yaml v1.4.0
 )

--- a/backend/k8s/resources.go
+++ b/backend/k8s/resources.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gorilla/websocket"
 	"gopkg.in/yaml.v3"
 	"io"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -508,12 +507,11 @@ func LogWorkloads(c *gin.Context) {
 	}
 
 	// Create informer factory filtering by name if provided
-	tweakListOptions := func(options *metav1.ListOptions) {
+	tweakListOptions := func(options *v1.ListOptions) {
 		if name != "" {
 			options.FieldSelector = fmt.Sprintf("metadata.name=%s", name)
 		}
 	}
-
 	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, time.Minute, namespace, tweakListOptions)
 	informer := factory.ForResource(gvr).Informer()
 


### PR DESCRIPTION
Refactor the DeployHandler to clone GitHub repositories directly, enhancing error handling and managing workload labels more effectively. This change streamlines the deployment process and improves reliability.

Fixex #675