### PR TITLE
fix: removed the hardcoded container selection from exec-in-pods

### DIFF
--- a/backend/wecs/exec.go
+++ b/backend/wecs/exec.go
@@ -132,35 +132,16 @@ func GetAllPodContainersName(c *gin.Context) {
 	})
 }
 
-// need to remove when we add the tabs - till now keep it
-func getPodContainersName(c *gin.Context, clientSet *kubernetes.Clientset, ns string, podName string) string {
-	pod, err := clientSet.CoreV1().Pods(ns).Get(c, podName, metav1.GetOptions{})
-	if err != nil {
-		// handle error
-
-	}
-	containerName := ""
-	for _, container := range pod.Spec.Containers {
-		fmt.Println("Container Name:", container.Name)
-		fmt.Println("Image:", container.Image)
-		containerName = container.Name
-	}
-	return containerName
-}
 func startShellProcess(c *gin.Context, clientSet *kubernetes.Clientset, cfg *rest.Config, cmd []string, conn *websocket.Conn, namespace string) error {
-	//namespace := c.Param("namespace")
 	podName := c.Param("pod")
 	containerName := c.Param("container")
-	cN := getPodContainersName(c, clientSet, namespace, podName)
-	fmt.Println(containerName)
-	fmt.Println(cN)
 	req := clientSet.CoreV1().RESTClient().Post().Resource("pods").
 		Name(podName).
 		Namespace(namespace).
 		SubResource("exec")
 
 	req.VersionedParams(&v1.PodExecOptions{
-		Container: cN,
+		Container: containerName,
 		Command:   cmd,
 		Stdin:     true,
 		Stdout:    true,


### PR DESCRIPTION
### Description
We are selecting only one container always which is problematic for us, we need to go through some dynamic way to check first this pod in which containers running and then select the container and then we will do the execution to pods(container)

### Related Issue
<!-- Link the issue(s) this PR addresses. -->
Fixes #733

Part of #52 
### Changes Made
<!-- Provide a detailed list of changes made in this PR. -->
- [ ] Updated ...
- [ ] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

### Checklist
Please ensure the following before submitting your PR:
- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)
<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->


### Additional Notes
<!-- Add any other context, suggestions, or questions related to this PR. -->
