### PR TITLE
Upgrade Go base image to v1.24.2 to match go.mod requirements

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the backend
-FROM golang:1.23 AS backend-builder
+FROM golang:1.24 AS backend-builder
 
 # Set the working directory
 WORKDIR /app


### PR DESCRIPTION
This PR updates the golang base image in the Dockerfile from Go 1.23.x to Go 1.24.2 to resolve a build failure caused by a version mismatch. The go.mod file specifies go 1.24, but the current base image provides go 1.23.9.
Fixes #737