### PR TITLE
fix: updated the list-view api to show all k8s workload resources

### DIFF
--- a/backend/routes/resources.go
+++ b/backend/routes/resources.go
@@ -17,7 +17,6 @@ func setupResourceRoutes(router *gin.Engine) {
 		api.GET("/wds/context", func(ctx *gin.Context) {
 			wds.CreateWDSContextUsingCommand(ctx.Writer, ctx.Request, ctx)
 		})
-		api.GET("/wds/list", wds.ListAllResourcesDetails)
 		api.GET("/wds/list-sse", wds.ListAllResourcesDetailsSSE)
 		api.GET("/wds/list/:namespace", wds.ListAllResourcesByNamespace)
 		api.GET("/:resourceKind/:namespace/log", k8s.LogWorkloads)

--- a/backend/wds/list.go
+++ b/backend/wds/list.go
@@ -17,29 +17,11 @@ import (
 	"time"
 )
 
-var popularKinds = map[string]bool{
-	"Deployment":               true,
-	"StatefulSet":              true,
-	"DaemonSet":                true,
-	"ReplicaSet":               true,
-	"Pod":                      true,
-	"Job":                      true,
-	"CronJob":                  true,
-	"Service":                  true,
-	"Endpoints":                true,
-	"Ingress":                  true,
-	"ConfigMap":                true,
-	"Secret":                   true,
-	"PersistentVolumeClaim":    true,
-	"Node":                     true,
-	"PersistentVolume":         true,
-	"StorageClass":             true,
+var includeClusterScopedKind = map[string]bool{
+	"ClusterRole":              true,
+	"ClusterRoleBinding":       true,
 	"CustomResourceDefinition": true,
-	//"ClusterRole":              true,
-	//"ClusterRoleBinding":       true,
-	"Namespace":          true,
-	"EndpointSlice":      true,
-	"ControllerRevision": true,
+	"Namespace":                true,
 }
 
 func getCacheKey(context, dataType string, parts ...string) string {
@@ -49,149 +31,9 @@ func getCacheKey(context, dataType string, parts ...string) string {
 var cachedResources []*metav1.APIResourceList
 var cachedResourcesKey = "preferredResources-list"
 
-// ListAllResourcesDetails api/wds/list
-const MaxConcurrentCalls = 20
-
 type ResourceListResponse struct {
 	Namespaced    map[string]map[string][]map[string]interface{} `json:"namespaced"`
 	ClusterScoped map[string][]map[string]interface{}            `json:"clusterScoped"`
-}
-
-func ListAllResourcesDetails(c *gin.Context) {
-	cookieContext, err := c.Cookie("ui-wds-context")
-	if err != nil {
-		cookieContext = "wds1"
-	}
-	cacheKey := getCacheKey(cookieContext, "list")
-
-	result := ResourceListResponse{
-		Namespaced:    make(map[string]map[string][]map[string]interface{}),
-		ClusterScoped: make(map[string][]map[string]interface{}),
-	}
-
-	found, err := redis.GetJSONValue(cacheKey, &result)
-	if err == nil && found && len(result.Namespaced) > 0 {
-		c.JSON(http.StatusOK, gin.H{"data": result})
-		return
-	}
-
-	clientset, dynamicClient, err := k8s.GetClientSetWithContext(cookieContext)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	discoveryClient := clientset.Discovery()
-
-	found, err = redis.GetJSONValue(cachedResourcesKey, &cachedResources)
-	if err != nil {
-		log.Printf("Error fetching API resource cache: %v", err)
-	}
-	if !found {
-		cachedResources, err = discoveryClient.ServerPreferredResources()
-		if err != nil {
-			log.Fatalf("Failed to fetch API resources: %v", err)
-		}
-		err = redis.SetJSONValue(cachedResourcesKey, cachedResources, 5*time.Minute)
-	}
-
-	resourceList := cachedResources
-
-	nsList, err := dynamicClient.Resource(schema.GroupVersionResource{
-		Group: "", Version: "v1", Resource: "namespaces",
-	}).List(c, metav1.ListOptions{})
-	if err != nil {
-		log.Fatalf("Failed to list namespaces: %v", err)
-	}
-
-	namespaceMeta := make(map[string]map[string]interface{})
-	var namespaces []string
-	for _, ns := range nsList.Items {
-		nsName := ns.GetName()
-		if strings.HasPrefix(nsName, "kube-") {
-			continue
-		}
-		namespaces = append(namespaces, nsName)
-		namespaceMeta[nsName] = extractNamespaceDetails(nsName, nsList.Items)
-	}
-
-	var wg sync.WaitGroup
-	var mutex sync.Mutex
-	sem := make(chan struct{}, MaxConcurrentCalls)
-
-	for _, resList := range resourceList {
-		gv, err := schema.ParseGroupVersion(resList.GroupVersion)
-		if err != nil {
-			continue
-		}
-		for _, res := range resList.APIResources {
-			if _, ok := popularKinds[res.Kind]; !ok || strings.Contains(res.Name, "/") || !contains(res.Verbs, "list") {
-				continue
-			}
-
-			gvr := schema.GroupVersionResource{Group: gv.Group, Version: gv.Version, Resource: res.Name}
-
-			if res.Namespaced {
-				for _, ns := range namespaces {
-					wg.Add(1)
-					sem <- struct{}{}
-					go func(ns string, gvr schema.GroupVersionResource, kind string) {
-						defer func() {
-							<-sem
-							wg.Done()
-						}()
-
-						ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-						defer cancel()
-
-						objs, err := dynamicClient.Resource(gvr).Namespace(ns).List(ctx, metav1.ListOptions{})
-						if err != nil || len(objs.Items) == 0 {
-							return
-						}
-						mutex.Lock()
-						defer mutex.Unlock()
-						nsMap := result.Namespaced
-						if nsMap[ns] == nil {
-							nsMap[ns] = map[string][]map[string]interface{}{
-								"__namespaceMetaData": {extractNamespaceDetails(ns, nsList.Items)},
-							}
-						}
-						for _, obj := range objs.Items {
-							nsMap[ns][res.Kind] = append(nsMap[ns][res.Kind], extractObjDetails(&obj))
-						}
-					}(ns, gvr, res.Kind)
-				}
-			} else {
-				wg.Add(1)
-				sem <- struct{}{}
-				go func(gvr schema.GroupVersionResource, kind string) {
-					defer func() {
-						<-sem
-						wg.Done()
-					}()
-
-					ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-					defer cancel()
-
-					objs, err := dynamicClient.Resource(gvr).List(ctx, metav1.ListOptions{})
-					if err != nil || len(objs.Items) == 0 {
-						return
-					}
-					mutex.Lock()
-					defer mutex.Unlock()
-					for _, obj := range objs.Items {
-						result.ClusterScoped[res.Kind] = append(result.ClusterScoped[res.Kind], extractObjDetails(&obj))
-					}
-				}(gvr, res.Kind)
-			}
-		}
-	}
-	wg.Wait()
-
-	err = redis.SetJSONValue(cacheKey, result, 2*time.Minute)
-	if err != nil {
-		log.Printf("Error caching list view details data: %v", err)
-	}
-	c.JSON(http.StatusOK, gin.H{"data": result})
 }
 
 // ListAllResourcesByNamespace api/wds/list/:namespace
@@ -251,7 +93,7 @@ func ListAllResourcesByNamespace(c *gin.Context) {
 			continue
 		}
 		for _, res := range resList.APIResources {
-			if _, ok := popularKinds[res.Kind]; !ok || strings.Contains(res.Name, "/") || !contains(res.Verbs, "list") {
+			if (!res.Namespaced && !includeClusterScopedKind[res.Kind]) || strings.Contains(res.Name, "/") || !contains(res.Verbs, "list") {
 				continue
 			}
 			gvr := schema.GroupVersionResource{Group: gv.Group, Version: gv.Version, Resource: res.Name}
@@ -346,10 +188,12 @@ func ListAllResourcesDetailsSSE(c *gin.Context) {
 	var namespaces []string
 	for _, ns := range nsList.Items {
 		nsName := ns.GetName()
-		if strings.HasPrefix(nsName, "kube-") {
+		// skip the "kube-" prefix namespace with the "default" namespaces
+		if strings.HasPrefix(nsName, "kube-") || strings.Contains(nsName, "default") || strings.Contains(nsName, "kubestellar-report") {
 			continue
 		}
 		namespaces = append(namespaces, nsName)
+		fmt.Println(namespaces)
 		namespaceMeta[nsName] = extractNamespaceDetails(nsName, nsList.Items)
 	}
 
@@ -365,7 +209,7 @@ func ListAllResourcesDetailsSSE(c *gin.Context) {
 			continue
 		}
 		for _, res := range resList.APIResources {
-			if _, ok := popularKinds[res.Kind]; !ok || strings.Contains(res.Name, "/") || !contains(res.Verbs, "list") {
+			if (!res.Namespaced && !includeClusterScopedKind[res.Kind]) || strings.Contains(res.Name, "/") || !contains(res.Verbs, "list") {
 				continue
 			}
 			gvr := schema.GroupVersionResource{Group: gv.Group, Version: gv.Version, Resource: res.Name}
@@ -430,6 +274,19 @@ func ListAllResourcesDetailsSSE(c *gin.Context) {
 					}
 					newItems := []map[string]interface{}{}
 					for _, obj := range objs.Items {
+						objName := obj.GetName()
+						objKind := obj.GetKind()
+						// Skip system/kube namespaces
+						if strings.EqualFold(objKind, "Namespace") &&
+							(strings.HasPrefix(objName, "kube-") || strings.Contains(objName, "default") || strings.Contains(objName, "kubestellar-report")) {
+							continue
+						}
+
+						// Skip system/kube clusterroles & bindings
+						if (objKind == "ClusterRole" || objKind == "ClusterRoleBinding") &&
+							(strings.HasPrefix(objName, "system:") || strings.HasPrefix(objName, "kube-")) {
+							continue
+						}
 						newItems = append(newItems, extractObjDetails(&obj))
 					}
 					mutex.Lock()


### PR DESCRIPTION
### Description
Updated to show all k8s workloads with the cluster-scoped object and I removed the ListAllResourcesDetails reason we are using the sse way to get all objects

### Related Issue
<!-- Link the issue(s) this PR addresses. -->
Fixes #743

Under #52
### Changes Made
<!-- Provide a detailed list of changes made in this PR. -->
- [ ] Updated ...
- [ ] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

### Checklist
Please ensure the following before submitting your PR:
- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)


<img width="477" alt="Screenshot 2025-05-12 at 10 58 38 PM" src="https://github.com/user-attachments/assets/11c646c8-2646-48c7-9c75-13289765edb8" />

### Additional Notes
<!-- Add any other context, suggestions, or questions related to this PR. -->
