### PR TITLE
Added Bulk edit Mode

### DIFF
--- a/src/components/BindingPolicy/ClusterDialogs.tsx
+++ b/src/components/BindingPolicy/ClusterDialogs.tsx
@@ -1,0 +1,909 @@
+import React, { useState, useRef, useEffect, KeyboardEvent as ReactKeyboardEvent } from 'react';
+import { 
+  Box, 
+  Typography, 
+  CircularProgress, 
+  Divider,
+  alpha,
+  Chip,
+  Tooltip,
+  Button,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Zoom,
+  InputAdornment,
+  List,
+  ListItemText,
+  ListItemButton,
+  Checkbox,
+  FormControlLabel,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import SearchIcon from '@mui/icons-material/Search';
+import EditIcon from '@mui/icons-material/Edit';
+import SaveIcon from '@mui/icons-material/Save';
+import DeleteIcon from '@mui/icons-material/Delete';
+import LabelIcon from '@mui/icons-material/Label';
+import AddIcon from '@mui/icons-material/Add';
+import { Tag, Tags } from 'lucide-react';
+import { ManagedCluster } from '../../types/bindingPolicy';
+import { toast } from 'react-hot-toast';
+
+interface ColorTheme {
+  primary: string;
+  primaryLight: string;
+  primaryDark: string;
+  secondary: string;
+  white: string;
+  background: string;
+  paper: string;
+  text: string;
+  textSecondary: string;
+  border: string;
+  success: string;
+  warning: string;
+  error: string;
+  disabled: string;
+}
+
+interface LabelEditDialogProps {
+  open: boolean;
+  onClose: () => void;
+  cluster: ManagedCluster | null;
+  clusters: ManagedCluster[];
+  isBulkEdit: boolean;
+  onSave: (clusterName: string, contextName: string, labels: { [key: string]: string }) => void;
+  onBulkSave: (clusters: ManagedCluster[], labels: { [key: string]: string }) => void;
+  isDark: boolean;
+  colors: ColorTheme;
+}
+
+interface SelectClusterDialogProps {
+  open: boolean;
+  onClose: () => void;
+  clusters: ManagedCluster[];
+  onSelectCluster: (cluster: ManagedCluster) => void;
+  onSelectClusters: (clusters: ManagedCluster[]) => void;
+  isDark: boolean;
+  colors: ColorTheme;
+}
+
+export const LabelEditDialog: React.FC<LabelEditDialogProps> = ({ 
+  open, 
+  onClose, 
+  cluster, 
+  clusters,
+  isBulkEdit,
+  onSave,
+  onBulkSave,
+  isDark,
+  colors
+}) => {
+  const [labels, setLabels] = useState<Array<{ key: string; value: string }>>([]);
+  const [newKey, setNewKey] = useState("");
+  const [newValue, setNewValue] = useState("");
+  const [labelSearch, setLabelSearch] = useState("");
+  const [isSearching, setIsSearching] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [selectedLabelIndex, setSelectedLabelIndex] = useState<number | null>(null);
+  const [appendLabels, setAppendLabels] = useState(true);
+  const keyInputRef = useRef<HTMLInputElement>(null);
+  const valueInputRef = useRef<HTMLInputElement>(null);
+
+  // Filter labels based on search
+  const filteredLabels = labelSearch.trim() === "" 
+    ? labels 
+    : labels.filter(label => 
+        label.key.toLowerCase().includes(labelSearch.toLowerCase()) || 
+        label.value.toLowerCase().includes(labelSearch.toLowerCase())
+      );
+
+  useEffect(() => {
+    if (open) {
+      if (isBulkEdit) {
+        console.log("LabelEditDialog opened for bulk edit with clusters:", clusters.length);
+        
+        // For bulk edit, start with empty labels
+        setLabels([]);
+      } else if (cluster) {
+        const labelArray = Object.entries(cluster.labels || {}).map(([key, value]) => ({
+          key,
+          value,
+        }));
+        setLabels(labelArray);
+      }
+      
+      // Reset 
+      setNewKey("");
+      setNewValue("");
+      setLabelSearch("");
+      setIsSearching(false);
+      setSelectedLabelIndex(null);
+      setAppendLabels(true);
+      
+
+      setTimeout(() => {
+        if (keyInputRef.current) {
+          keyInputRef.current.focus();
+        }
+      }, 100);
+    }
+  }, [cluster, clusters, isBulkEdit, open]);
+
+  const handleAddLabel = () => {
+    if (newKey.trim() && newValue.trim()) {
+      // Check for duplicates
+      const isDuplicate = labels.some(label => label.key === newKey.trim());
+      
+      if (isDuplicate) {
+        // Update existing label with same key
+        setLabels(labels.map(label => 
+          label.key === newKey.trim() 
+            ? { ...label, value: newValue.trim() } 
+            : label
+        ));
+        toast.success(`Updated existing label: ${newKey}`);
+      } else {
+        // Add new label with animation effect
+        setLabels(prev => [...prev, { key: newKey.trim(), value: newValue.trim() }]);
+        toast.success(`Added new label: ${newKey}`);
+      }
+      
+      
+      setNewKey("");
+      setNewValue("");
+      if (keyInputRef.current) {
+        keyInputRef.current.focus();
+      }
+    }
+  };
+
+  const handleKeyDown = (e: ReactKeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      
+      if (newKey && !newValue && valueInputRef.current) {
+        
+        valueInputRef.current.focus();
+      } else if (newKey && newValue) {
+        
+        handleAddLabel();
+      }
+    } else if (e.key === 'Escape') {
+
+      setNewKey("");
+      setNewValue("");
+      if (keyInputRef.current) {
+        keyInputRef.current.focus();
+      }
+    }
+  };
+
+  const handleRemoveLabel = (index: number) => {
+    const labelToRemove = labels[index];
+    setLabels(labels.filter((_, i) => i !== index));
+    toast.success(`Removed label: ${labelToRemove.key}`);
+  };
+
+  const handleSave = () => {
+    if (isBulkEdit) {
+      if (clusters.length === 0) return;
+      
+      setSaving(true);
+      
+      
+      const labelObject: { [key: string]: string } = {};
+      labels.forEach(({ key, value }) => {
+        labelObject[key] = value;
+      });
+
+    //   console.log("===== BULK LABEL SAVE DEBUG =====");
+    //   console.log("Clusters being saved:", clusters.length);
+    //   console.log("Labels being saved:", JSON.stringify(labelObject, null, 2));
+    //   console.log("Append mode:", appendLabels);
+      
+      // Add a slight delay to show loading state
+      setTimeout(() => {
+        onBulkSave(clusters, labelObject);
+        setSaving(false);
+        onClose();
+      }, 300);
+    } else if (cluster) {
+      setSaving(true);
+      
+      
+      const labelObject: { [key: string]: string } = {};
+      labels.forEach(({ key, value }) => {
+        labelObject[key] = value;
+      });
+      
+      // Add a slight delay to show loading state
+      setTimeout(() => {
+        onSave(cluster.name, cluster.context || 'default', labelObject);
+        setSaving(false);
+        onClose();
+      }, 300);
+    }
+  };
+
+  const toggleSearchMode = () => {
+    setIsSearching(!isSearching);
+    if (!isSearching) {
+      setTimeout(() => {
+        const searchInput = document.getElementById('label-search-input');
+        if (searchInput) {
+          searchInput.focus();
+        }
+      }, 100);
+    } else {
+      setLabelSearch("");
+    }
+  };
+
+  return (
+    <Dialog 
+      open={open} 
+      onClose={onClose}
+      fullWidth
+      maxWidth="sm"
+      TransitionComponent={Zoom}
+      transitionDuration={300}
+      PaperProps={{
+        style: {
+          backgroundColor: colors.paper,
+          color: colors.text,
+          border: `1px solid ${colors.border}`,
+          borderRadius: '12px',
+          overflow: 'hidden',
+          boxShadow: isDark 
+            ? '0 10px 25px -5px rgba(0, 0, 0, 0.5), 0 8px 10px -6px rgba(0, 0, 0, 0.4)' 
+            : '0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.05)',
+        }
+      }}
+    >
+      <DialogTitle 
+        style={{ 
+          color: colors.primary,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '20px 24px',
+          borderBottom: `1px solid ${colors.border}`,
+        }}
+      >
+        <div className="flex items-center gap-2">
+          <LabelIcon style={{ color: colors.primary }} />
+          <Typography variant="h6" component="span">
+            {isBulkEdit 
+              ? `Edit Labels for ${clusters.length} Clusters` 
+              : `Edit Labels for ${cluster?.name}`}
+          </Typography>
+        </div>
+        <IconButton onClick={onClose} size="small" style={{ color: colors.textSecondary }}>
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </DialogTitle>
+      
+      <DialogContent style={{ padding: '20px 24px' }}>
+        {isBulkEdit && (
+          <Box mb={2} pb={2} borderBottom={`1px solid ${colors.border}`}>
+            <Typography variant="subtitle2" style={{ marginBottom: '8px', color: colors.textSecondary }}>
+              Bulk Edit Mode
+            </Typography>
+            <Typography variant="body2" style={{ marginBottom: '12px', color: colors.textSecondary }}>
+              You are editing labels for {clusters.length} clusters. The changes will be applied to all selected clusters.
+            </Typography>
+            
+            <FormControlLabel
+              control={
+                <Checkbox 
+                  checked={appendLabels} 
+                  onChange={(e) => setAppendLabels(e.target.checked)}
+                  sx={{
+                    color: colors.primary,
+                    '&.Mui-checked': {
+                      color: colors.primary,
+                    },
+                  }}
+                />
+              }
+              label={
+                <Typography variant="body2">
+                  Append to existing labels (unchecking will replace all existing labels)
+                </Typography>
+              }
+            />
+          </Box>
+        )}
+        
+        <div className="mb-6">
+          <div className="flex items-center justify-between mb-4">
+            <Typography variant="body2" style={{ color: colors.textSecondary }}>
+              Add or remove labels to organize and categorize your cluster.
+            </Typography>
+            
+            <div className="flex gap-2">
+              <Tooltip title={isSearching ? "Exit search" : "Search labels"}>
+                <IconButton 
+                  size="small" 
+                  onClick={toggleSearchMode}
+                  style={{ 
+                    color: isSearching ? colors.primary : colors.textSecondary,
+                    backgroundColor: isSearching ? (isDark ? 'rgba(47, 134, 255, 0.15)' : 'rgba(47, 134, 255, 0.1)') : 'transparent',
+                  }}
+                >
+                  <SearchIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+              {labels.length > 0 && (
+                <Chip 
+                  size="small" 
+                  label={`${labels.length} label${labels.length !== 1 ? 's' : ''}`}
+                  style={{
+                    backgroundColor: isDark ? 'rgba(47, 134, 255, 0.15)' : 'rgba(47, 134, 255, 0.1)',
+                    color: colors.primary,
+                    fontSize: '0.75rem',
+                  }}
+                />
+              )}
+            </div>
+          </div>
+          
+          <Zoom in={isSearching} mountOnEnter unmountOnExit>
+            <div className="mb-4">
+              <TextField
+                id="label-search-input"
+                placeholder="Search labels..."
+                value={labelSearch}
+                onChange={(e) => setLabelSearch(e.target.value)}
+                fullWidth
+                variant="outlined"
+                size="small"
+                autoFocus
+                InputProps={{
+                  style: { color: colors.text },
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <SearchIcon style={{ color: colors.primary, fontSize: '1.2rem' }} />
+                    </InputAdornment>
+                  ),
+                  endAdornment: labelSearch && (
+                    <InputAdornment position="end">
+                      <IconButton 
+                        size="small" 
+                        onClick={() => setLabelSearch('')}
+                        style={{ color: colors.textSecondary }}
+                      >
+                        <CloseIcon fontSize="small" />
+                      </IconButton>
+                    </InputAdornment>
+                  ),
+                }}
+                sx={{
+                  "& .MuiOutlinedInput-root": {
+                    backgroundColor: isDark ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.02)',
+                    "& fieldset": { borderColor: colors.border },
+                    "&:hover fieldset": { borderColor: colors.primaryLight },
+                    "&.Mui-focused fieldset": { borderColor: colors.primary },
+                  },
+                }}
+              />
+            </div>
+          </Zoom>
+          
+          <Zoom in={!isSearching}>
+            <div className="mb-5">
+              <div className="flex flex-col sm:flex-row gap-2 mb-2">
+                <TextField
+                  label="Label Key"
+                  placeholder="e.g. environment"
+                  value={newKey}
+                  onChange={(e) => setNewKey(e.target.value)}
+                  inputRef={keyInputRef}
+                  onKeyDown={handleKeyDown}
+                  fullWidth
+                  variant="outlined"
+                  size="small"
+                  autoComplete="off"
+                  InputProps={{
+                    style: { color: colors.text }
+                  }}
+                  InputLabelProps={{
+                    style: { color: colors.textSecondary },
+                    shrink: true,
+                  }}
+                  sx={{
+                    "& .MuiOutlinedInput-root": {
+                      "& fieldset": { borderColor: colors.border },
+                      "&:hover fieldset": { borderColor: colors.primaryLight },
+                      "&.Mui-focused fieldset": { borderColor: colors.primary },
+                    },
+                  }}
+                />
+                <TextField
+                  label="Label Value"
+                  placeholder="e.g. production"
+                  value={newValue}
+                  onChange={(e) => setNewValue(e.target.value)}
+                  inputRef={valueInputRef}
+                  onKeyDown={handleKeyDown}
+                  fullWidth
+                  variant="outlined"
+                  size="small"
+                  autoComplete="off"
+                  InputProps={{
+                    style: { color: colors.text }
+                  }}
+                  InputLabelProps={{
+                    style: { color: colors.textSecondary },
+                    shrink: true,
+                  }}
+                  sx={{
+                    "& .MuiOutlinedInput-root": {
+                      "& fieldset": { borderColor: colors.border },
+                      "&:hover fieldset": { borderColor: colors.primaryLight },
+                      "&.Mui-focused fieldset": { borderColor: colors.primary },
+                    },
+                  }}
+                />
+                <Button 
+                  onClick={handleAddLabel}
+                  variant="contained"
+                  disabled={!newKey.trim() || !newValue.trim()}
+                  startIcon={<AddIcon />}
+                  style={{ 
+                    backgroundColor: (!newKey.trim() || !newValue.trim()) ? colors.disabled : colors.primary,
+                    color: colors.white,
+                    minWidth: '100px',
+                    transition: 'all 0.2s ease',
+                  }}
+                >
+                  Add
+                </Button>
+              </div>
+              <Typography variant="caption" style={{ color: colors.textSecondary }}>
+                Tip: Press <span style={{ fontFamily: 'monospace', backgroundColor: isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)', padding: '1px 4px', borderRadius: '2px' }}>Enter</span> to move between fields or add a label
+              </Typography>
+            </div>
+          </Zoom>
+
+          <Divider style={{ backgroundColor: colors.border, margin: '16px 0' }} />
+          
+          <div className="max-h-60 overflow-y-auto pr-1">
+            {filteredLabels.length > 0 ? (
+              <div className="space-y-2">
+                {filteredLabels.map((label, index) => (
+                  <Zoom in={true} style={{ transitionDelay: `${index * 25}ms` }} key={`${label.key}-${index}`}>
+                    <div 
+                      className={`flex items-center justify-between gap-2 p-2 rounded transition-all duration-200 ${selectedLabelIndex === index ? 'ring-1' : ''}`} 
+                      style={{ 
+                        backgroundColor: selectedLabelIndex === index 
+                          ? (isDark ? 'rgba(47, 134, 255, 0.2)' : 'rgba(47, 134, 255, 0.1)') 
+                          : (isDark ? 'rgba(47, 134, 255, 0.1)' : 'rgba(47, 134, 255, 0.05)'),
+                        border: `1px solid ${selectedLabelIndex === index ? colors.primary : colors.border}`,
+                        boxShadow: selectedLabelIndex === index 
+                          ? (isDark ? '0 0 0 1px rgba(47, 134, 255, 0.4)' : '0 0 0 1px rgba(47, 134, 255, 0.2)')
+                          : 'none',
+                        cursor: 'default',
+                      }} 
+                      onClick={() => setSelectedLabelIndex(selectedLabelIndex === index ? null : index)}
+                    >
+                      <div className="flex items-center gap-2">
+                        <Tag size={16} style={{ color: colors.primary }} />
+                        <span style={{ color: colors.text }}>
+                          <span style={{ fontWeight: 500 }}>{label.key}</span>
+                          <span style={{ color: colors.textSecondary }}> = </span>
+                          <span>{label.value}</span>
+                        </span>
+                      </div>
+                      <Tooltip title="Remove Label">
+                        <IconButton 
+                          size="small" 
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleRemoveLabel(labels.findIndex(l => l.key === label.key && l.value === label.value));
+                          }}
+                          style={{ 
+                            color: selectedLabelIndex === index ? colors.primary : colors.textSecondary,
+                            opacity: 0.8,
+                            transition: 'all 0.2s ease',
+                          }}
+                          className="hover:opacity-100"
+                        >
+                          <DeleteIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                    </div>
+                  </Zoom>
+                ))}
+              </div>
+            ) : (
+              <div className="flex flex-col items-center justify-center text-center p-6 mt-2">
+                <Tags size={28} style={{ color: colors.textSecondary, marginBottom: '12px' }} />
+                <Typography variant="body2" style={{ color: colors.text, fontWeight: 500, marginBottom: '4px' }}>
+                  {labelSearch ? "No matching labels found" : "No labels added yet"}
+                </Typography>
+                <Typography variant="caption" style={{ color: colors.textSecondary, maxWidth: '300px', margin: '0 auto' }}>
+                  {labelSearch 
+                    ? "Try a different search term or clear the search"
+                    : "Add your first label using the fields above to help organize this cluster."
+                  }
+                </Typography>
+                
+                {labelSearch && (
+                  <Button
+                    size="small"
+                    variant="text"
+                    style={{ color: colors.primary, marginTop: '12px' }}
+                    onClick={() => setLabelSearch('')}
+                  >
+                    Clear Search
+                  </Button>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+      
+      <DialogActions 
+        style={{ 
+          padding: '16px 24px',
+          borderTop: `1px solid ${colors.border}`,
+        }}
+      >
+        <Button 
+          onClick={onClose}
+          variant="outlined"
+          style={{ 
+            borderColor: colors.border,
+            color: colors.textSecondary,
+          }}
+        >
+          Cancel
+        </Button>
+        
+        <Button 
+          onClick={handleSave}
+          variant="contained"
+          disabled={saving}
+          startIcon={saving ? <CircularProgress size={16} color="inherit" /> : <SaveIcon />}
+          style={{ 
+            backgroundColor: colors.primary,
+            color: colors.white,
+            minWidth: '120px',
+          }}
+        >
+          {saving ? 'Saving...' : 'Save Changes'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+// Select Cluster Dialog Component
+export const SelectClusterDialog: React.FC<SelectClusterDialogProps> = ({
+  open,
+  onClose,
+  clusters,
+  onSelectCluster,
+  onSelectClusters,
+  isDark,
+  colors
+}) => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedItems, setSelectedItems] = useState<Record<string, boolean>>({});
+  const [bulkSelectMode, setBulkSelectMode] = useState(false);
+  
+  // Reset selections when dialog opens
+  useEffect(() => {
+    if (open) {
+      setSelectedItems({});
+      setBulkSelectMode(false);
+      setSearchTerm('');
+    }
+  }, [open]);
+  
+  const filteredClusters = searchTerm 
+    ? clusters.filter(cluster => 
+        cluster.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        Object.entries(cluster.labels || {}).some(
+          ([key, value]) => 
+            key.toLowerCase().includes(searchTerm.toLowerCase()) || 
+            value.toLowerCase().includes(searchTerm.toLowerCase())
+        )
+      )
+    : clusters;
+    
+  const toggleItemSelection = (cluster: ManagedCluster) => {
+    setSelectedItems(prev => ({
+      ...prev,
+      [cluster.name]: !prev[cluster.name]
+    }));
+  };
+  
+  const toggleBulkSelectMode = () => {
+    setBulkSelectMode(!bulkSelectMode);
+    if (!bulkSelectMode) {
+      // When entering bulk mode, clear any existing selections
+      setSelectedItems({});
+    }
+  };
+  
+  const getSelectedClusters = () => {
+    return clusters.filter(cluster => selectedItems[cluster.name]);
+  };
+  
+  const selectedCount = Object.values(selectedItems).filter(Boolean).length;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="sm"
+      PaperProps={{
+        style: {
+          backgroundColor: colors.paper,
+          color: colors.text,
+          border: `1px solid ${colors.border}`,
+          borderRadius: '12px',
+          overflow: 'hidden',
+          boxShadow: isDark 
+            ? '0 10px 25px -5px rgba(0, 0, 0, 0.5), 0 8px 10px -6px rgba(0, 0, 0, 0.4)' 
+            : '0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.05)',
+        }
+      }}
+    >
+      <DialogTitle 
+        style={{ 
+          color: colors.primary,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '20px 24px',
+          borderBottom: `1px solid ${colors.border}`,
+        }}
+      >
+        <div className="flex items-center gap-2">
+          <Typography variant="h6" component="span">
+            {bulkSelectMode ? "Select Multiple Clusters" : "Select Cluster to Edit"}
+          </Typography>
+        </div>
+        <IconButton onClick={onClose} size="small" style={{ color: colors.textSecondary }}>
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </DialogTitle>
+      
+      <DialogContent style={{ padding: '16px 24px' }}>
+        <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
+          <FormControlLabel
+            control={
+              <Checkbox 
+                checked={bulkSelectMode} 
+                onChange={toggleBulkSelectMode}
+                sx={{
+                  color: colors.primary,
+                  '&.Mui-checked': {
+                    color: colors.primary,
+                  },
+                }}
+              />
+            }
+            label="Bulk Edit Mode"
+          />
+          
+          {bulkSelectMode && selectedCount > 0 && (
+            <Chip 
+              label={`${selectedCount} selected`}
+              color="primary"
+              size="small"
+            />
+          )}
+        </Box>
+        
+        <TextField
+          placeholder="Search clusters..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          fullWidth
+          variant="outlined"
+          size="small"
+          autoFocus
+          margin="normal"
+          InputProps={{
+            style: { color: colors.text },
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon style={{ color: colors.primary, fontSize: '1.2rem' }} />
+              </InputAdornment>
+            ),
+            endAdornment: searchTerm && (
+              <InputAdornment position="end">
+                <IconButton 
+                  size="small" 
+                  onClick={() => setSearchTerm('')}
+                  style={{ color: colors.textSecondary }}
+                >
+                  <CloseIcon fontSize="small" />
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+          sx={{
+            "& .MuiOutlinedInput-root": {
+              backgroundColor: isDark ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.02)',
+              "& fieldset": { borderColor: colors.border },
+              "&:hover fieldset": { borderColor: colors.primaryLight },
+              "&.Mui-focused fieldset": { borderColor: colors.primary },
+            },
+            mb: 2,
+          }}
+        />
+        
+        <List
+          sx={{
+            maxHeight: '400px',
+            overflow: 'auto',
+            '&::-webkit-scrollbar': {
+              width: '8px',
+            },
+            '&::-webkit-scrollbar-track': {
+              background: isDark ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.05)',
+              borderRadius: '4px',
+            },
+            '&::-webkit-scrollbar-thumb': {
+              background: isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.1)',
+              borderRadius: '4px',
+              '&:hover': {
+                background: isDark ? 'rgba(255, 255, 255, 0.2)' : 'rgba(0, 0, 0, 0.2)',
+              },
+            },
+          }}
+        >
+          {filteredClusters.length > 0 ? (
+            filteredClusters.map((cluster) => {
+              const isSelected = !!selectedItems[cluster.name];
+              
+              return (
+                <ListItemButton
+                  key={cluster.name}
+                  onClick={() => {
+                    if (bulkSelectMode) {
+                      toggleItemSelection(cluster);
+                    } else {
+                      onSelectCluster(cluster);
+                    }
+                  }}
+                  sx={{
+                    borderRadius: '8px',
+                    mb: 1,
+                    border: `1px solid ${colors.border}`,
+                    backgroundColor: isSelected
+                      ? (isDark ? 'rgba(47, 134, 255, 0.2)' : 'rgba(47, 134, 255, 0.1)')
+                      : (isDark ? 'rgba(47, 134, 255, 0.08)' : 'rgba(47, 134, 255, 0.04)'),
+                    '&:hover': {
+                      backgroundColor: isSelected 
+                        ? (isDark ? 'rgba(47, 134, 255, 0.25)' : 'rgba(47, 134, 255, 0.15)')
+                        : (isDark ? 'rgba(47, 134, 255, 0.15)' : 'rgba(47, 134, 255, 0.08)'),
+                    },
+                    transition: 'all 0.2s ease',
+                  }}
+                >
+                  {bulkSelectMode && (
+                    <Checkbox 
+                      checked={isSelected}
+                      onChange={() => toggleItemSelection(cluster)}
+                      onClick={(e) => e.stopPropagation()}
+                      sx={{
+                        color: colors.primary,
+                        '&.Mui-checked': {
+                          color: colors.primary,
+                        },
+                        marginRight: 1,
+                        padding: 0,
+                      }}
+                    />
+                  )}
+                  
+                  <ListItemText 
+                    primary={cluster.name} 
+                    secondary={
+                      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }}>
+                        {Object.entries(cluster.labels || {}).slice(0, 3).map(([key, value]) => (
+                          <Chip
+                            key={`${key}-${value}`}
+                            size="small"
+                            label={`${key}=${value}`}
+                            sx={{ 
+                              height: 20,
+                              fontSize: '0.7rem',
+                              bgcolor: alpha(colors.primary, 0.1),
+                              color: colors.primary,
+                            }}
+                          />
+                        ))}
+                        {Object.keys(cluster.labels || {}).length > 3 && (
+                          <Chip
+                            size="small"
+                            label={`+${Object.keys(cluster.labels || {}).length - 3} more`}
+                            sx={{ 
+                              height: 20,
+                              fontSize: '0.7rem',
+                              bgcolor: alpha(colors.secondary, 0.1),
+                              color: colors.secondary,
+                            }}
+                          />
+                        )}
+                      </Box>
+                    }
+                    primaryTypographyProps={{
+                      style: { 
+                        color: colors.text,
+                        fontWeight: 500,
+                      }
+                    }}
+                    secondaryTypographyProps={{
+                      style: { 
+                        color: colors.textSecondary,
+                      },
+                      component: 'div'
+                    }}
+                  />
+                  {!bulkSelectMode && (
+                    <EditIcon fontSize="small" sx={{ color: colors.primary, opacity: 0.7 }} />
+                  )}
+                </ListItemButton>
+              );
+            })
+          ) : (
+            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', py: 4 }}>
+              <Typography variant="body1" sx={{ color: colors.text, fontWeight: 500, mb: 1 }}>
+                No clusters found
+              </Typography>
+              <Typography variant="body2" sx={{ color: colors.textSecondary }}>
+                {searchTerm ? 'Try a different search term' : 'No clusters available to edit'}
+              </Typography>
+            </Box>
+          )}
+        </List>
+      </DialogContent>
+      
+      <DialogActions
+        style={{ 
+          padding: '16px 24px',
+          borderTop: `1px solid ${colors.border}`,
+        }}
+      >
+        <Button 
+          onClick={onClose}
+          variant="outlined"
+          style={{ 
+            borderColor: colors.border,
+            color: colors.textSecondary,
+          }}
+        >
+          Cancel
+        </Button>
+        
+        {bulkSelectMode && (
+          <Button 
+            onClick={() => onSelectClusters(getSelectedClusters())}
+            variant="contained"
+            disabled={selectedCount === 0}
+            style={{ 
+              backgroundColor: colors.primary,
+              color: colors.white,
+            }}
+          >
+            Edit {selectedCount} Clusters
+          </Button>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
+}; 

--- a/src/components/BindingPolicy/ClusterLabelsList.tsx
+++ b/src/components/BindingPolicy/ClusterLabelsList.tsx
@@ -1,0 +1,340 @@
+import React from 'react';
+import { 
+  Box, 
+  Typography, 
+  CircularProgress, 
+  Chip,
+  Tooltip,
+  IconButton,
+  alpha,
+  List,
+  ListItem,
+  ListItemText,
+  useTheme as useMuiTheme,
+} from '@mui/material';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import EditIcon from '@mui/icons-material/Edit';
+import { ManagedCluster } from '../../types/bindingPolicy';
+import { usePolicyDragDropStore } from '../../stores/policyDragDropStore';
+import useTheme from "../../stores/themeStore";
+
+// Group representing a unique label key+value with clusters that share it
+interface LabelGroup {
+  key: string;
+  value: string;
+  clusters: Array<{
+    name: string;
+  }>;
+}
+
+interface ClusterLabelsListProps {
+  clusters: ManagedCluster[];
+  filteredLabels: LabelGroup[];
+  loading: boolean;
+  error?: string;
+  compact?: boolean;
+  searchTerm: string;
+  onItemClick?: (clusterId: string) => void;
+  onEditCluster: (cluster: ManagedCluster) => void;
+}
+
+const ClusterLabelsList: React.FC<ClusterLabelsListProps> = ({
+  clusters,
+  filteredLabels,
+  loading,
+  error,
+  compact = false,
+  searchTerm,
+  onItemClick,
+  onEditCluster
+}) => {
+  const muiTheme = useMuiTheme();
+  const theme = useTheme((state) => state.theme);
+  const isDarkTheme = theme === "dark";
+
+  const renderLabelItem = (labelGroup: LabelGroup) => {
+    const firstCluster = labelGroup.clusters[0];
+    
+    // Format: label-{key}-{value} or label-{key}:{value} if it's a simple label
+    let itemId = '';
+    
+    // Special handling for common labels we know are important
+    if (labelGroup.key === 'location-group' && labelGroup.value === 'edge') {
+      itemId = 'label-location-group:edge';
+    } else if (labelGroup.key.includes('/')) {
+      itemId = `label-${labelGroup.key}-${labelGroup.value}`;
+    } else {
+      itemId = `label-${labelGroup.key}:${labelGroup.value}`;
+    }
+    
+    // Check if this item is in the canvas
+    const { canvasEntities } = usePolicyDragDropStore.getState();
+    const isInCanvas = canvasEntities.clusters.includes(itemId);
+
+    // Find the full cluster objects for each cluster in this label group
+    const clusterObjects = labelGroup.clusters.map(c => 
+      clusters.find(cluster => cluster.name === c.name)
+    ).filter((c): c is ManagedCluster => c !== undefined);
+    
+    return (
+      <Box
+        key={`${labelGroup.key}:${labelGroup.value}`}
+        onClick={() => {
+          if (onItemClick) {
+            if (isInCanvas) {
+              console.log(`⚠️ Cluster ${itemId} is already in the canvas`);
+              return;
+            }
+            
+            onItemClick(itemId);
+          }
+        }}
+        sx={{
+          p: 1,
+          m: compact ? 0.5 : 1,
+          borderRadius: 1,
+          backgroundColor: isDarkTheme ? 'rgba(30, 41, 59, 0.8)' : muiTheme.palette.background.paper,
+          border: `1px solid ${isDarkTheme ? 'rgba(255, 255, 255, 0.12)' : muiTheme.palette.divider}`,
+          boxShadow: 0,
+          cursor: 'pointer',
+          position: 'relative',
+          transition: 'all 0.2s ease',
+          "&:hover": {
+            backgroundColor: isDarkTheme 
+              ? 'rgba(30, 41, 59, 0.95)' 
+              : alpha(muiTheme.palette.primary.main, 0.1),
+            boxShadow: 2,
+            transform: 'translateY(-2px)',
+          },
+        }}
+      >
+       {/* Position cluster count chip and edit button  */}
+       <Box sx={{ position: 'absolute', top: 4, right: 4, display: 'flex', gap: 0.5 }}>
+          <Tooltip title="Edit clusters with this label">
+            <IconButton 
+              size="small" 
+              onClick={(e) => {
+                e.stopPropagation(); 
+                
+                if (clusterObjects.length === 1) {
+                  // If only one cluster, edit it directly
+                  onEditCluster(clusterObjects[0]);
+                }
+              }}
+              sx={{ 
+                p: 0.5, 
+                bgcolor: isDarkTheme
+                  ? alpha(muiTheme.palette.primary.main, 0.2)
+                  : alpha(muiTheme.palette.primary.main, 0.1),
+                color: isDarkTheme
+                  ? muiTheme.palette.primary.light
+                  : muiTheme.palette.primary.main,
+                '&:hover': {
+                  bgcolor: isDarkTheme
+                    ? alpha(muiTheme.palette.primary.main, 0.3)
+                    : alpha(muiTheme.palette.primary.main, 0.2),
+                } 
+              }}
+            >
+              <EditIcon sx={{ fontSize: '0.9rem' }} />
+            </IconButton>
+          </Tooltip>
+          
+          <Tooltip title={`${labelGroup.clusters.length} cluster(s)`}>
+            <Chip 
+              size="small" 
+              label={`${labelGroup.clusters.length}`}
+              sx={{ 
+                fontSize: '0.8rem',
+                height: 16,
+                '& .MuiChip-label': { px: 0.5 },
+                bgcolor: isDarkTheme
+                  ? alpha(muiTheme.palette.info.main, 0.2)
+                  : alpha(muiTheme.palette.info.main, 0.1),
+                color: isDarkTheme
+                  ? muiTheme.palette.info.light
+                  : muiTheme.palette.info.main,
+              }}
+            />
+          </Tooltip>
+        </Box>
+        
+         {/* Label value */}
+         <Box sx={{ mt: 0.5 }}>
+          <Chip
+            size="small"
+            label={`${labelGroup.key} = ${labelGroup.value}`}
+            sx={{ 
+              fontSize: '1rem',
+              height: 20,
+              '& .MuiChip-label': { 
+                px: 0.75,
+                textOverflow: 'ellipsis',
+                overflow: 'hidden',
+              },
+              bgcolor: isDarkTheme
+                ? alpha(muiTheme.palette.primary.main, 0.2)
+                : alpha(muiTheme.palette.primary.main, 0.1),
+              color: isDarkTheme
+                ? muiTheme.palette.primary.light
+                : muiTheme.palette.primary.main,
+            }}
+          />
+        </Box>
+     {/* Cluster summary with edit buttons */}
+     <Box sx={{ mt: 0.5 }}>
+          <Tooltip 
+            title={
+              <React.Fragment>
+                <Typography variant="caption" sx={{ fontWeight: 'bold' }} component="div">Clusters:</Typography>
+                <List 
+                  dense 
+                  sx={{ 
+                    m: 0, 
+                    p: 0, 
+                    pl: 1, 
+                    maxHeight: '150px', 
+                    overflow: 'auto',
+                    '&::-webkit-scrollbar': { width: '4px' },
+                    '&::-webkit-scrollbar-thumb': { 
+                      background: isDarkTheme 
+                        ? alpha('#ffffff', 0.2)
+                        : alpha('#000000', 0.2),
+                      borderRadius: '4px' 
+                    }
+                  }}
+                >
+                  {clusterObjects.map(cluster => (
+                    <ListItem 
+                      key={cluster.name} 
+                      disablePadding
+                      secondaryAction={
+                        <IconButton 
+                          edge="end"
+                          size="small"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            e.preventDefault();
+                            onEditCluster(cluster);
+                          }}
+                          sx={{ p: 0.5 }}
+                        >
+                          <EditIcon fontSize="inherit" />
+                        </IconButton>
+                      }
+                    >
+                      <ListItemText 
+                        primary={cluster.name} 
+                        sx={{ m: 0 }}
+                        primaryTypographyProps={{ 
+                          variant: 'caption',
+                          component: 'div',
+                          style: { 
+                            display: 'block',
+                            maxWidth: '180px',
+                            whiteSpace: 'nowrap',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis'
+                          }
+                        }} 
+                      />
+                    </ListItem>
+                  ))}
+                </List>
+              </React.Fragment>
+            } 
+            arrow 
+            placement="top"
+          >
+            <Typography 
+              variant="caption" 
+              sx={{ 
+                color: isDarkTheme 
+                  ? "rgba(255, 255, 255, 0.7)" 
+                  : "text.secondary" 
+              }}
+            >
+              {labelGroup.clusters.length === 1 
+                ? firstCluster.name
+                : labelGroup.clusters.length <= 2
+                  ? labelGroup.clusters.map(c => c.name).join(', ')
+                  : `${labelGroup.clusters.slice(0, 2).map(c => c.name).join(', ')} +${labelGroup.clusters.length - 2} more`}
+            </Typography>
+          </Tooltip>
+        </Box>
+        
+        {isInCanvas && (
+          <CheckCircleIcon 
+            sx={{ 
+              position: 'absolute',
+              bottom: 4,
+              right: 4,
+              fontSize: '1.2rem',
+              color: muiTheme.palette.success.main,
+              backgroundColor: isDarkTheme 
+                ? 'rgba(17, 25, 40, 0.8)'
+                : alpha(muiTheme.palette.background.paper, 0.7),
+              borderRadius: '50%'
+            }}
+          />
+        )}
+      </Box>
+    );
+  };
+
+  return (
+    <Box sx={{ 
+      p: compact ? 0.5 : 1, 
+      overflow: 'auto', 
+      flexGrow: 1,
+      '&::-webkit-scrollbar': {
+        display: 'none'
+      },
+      scrollbarWidth: 'none',  
+      '-ms-overflow-style': 'none',
+      backgroundColor: isDarkTheme 
+        ? 'rgba(17, 25, 40, 0.8)' 
+        : 'transparent',
+    }}>
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
+          <CircularProgress size={30} sx={{
+            color: isDarkTheme ? '#60a5fa' : undefined
+          }} />
+        </Box>
+      ) : error ? (
+        <Typography color="error" sx={{ p: 2 }}>
+          {error}
+        </Typography>
+      ) : clusters.length === 0 ? (
+        <Typography
+          sx={{ 
+            p: 2, 
+            color: isDarkTheme ? "rgba(255, 255, 255, 0.7)" : "text.secondary", 
+            textAlign: 'center' 
+          }}
+        >
+          No cluster labels available. Please add clusters with labels to use in binding policies.
+        </Typography>
+      ) : (
+        <Box sx={{ minHeight: '100%' }}>
+          {filteredLabels.length === 0 ? (
+            <Typography sx={{ 
+              p: 2, 
+              color: isDarkTheme ? "rgba(255, 255, 255, 0.7)" : "text.secondary", 
+              textAlign: 'center' 
+            }}>
+              {searchTerm ? 'No labels match your search.' : 'No labels found in available clusters.'}
+            </Typography>
+          ) : (
+            filteredLabels.map((labelGroup) => 
+              renderLabelItem(labelGroup)
+            )
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default ClusterLabelsList; 

--- a/src/components/BindingPolicy/ClusterPanel.tsx
+++ b/src/components/BindingPolicy/ClusterPanel.tsx
@@ -67,7 +67,7 @@ const ClusterPanel: React.FC<ClusterPanelProps> = ({
   const updateLabelsMutation = useUpdateClusterLabels();
 
   const handleImportClusters = () => {
-    navigate('/its');
+    navigate('/its?import=true');
   };
 
   const handleAddLabels = () => {

--- a/src/components/BindingPolicy/ClusterPanel.tsx
+++ b/src/components/BindingPolicy/ClusterPanel.tsx
@@ -1,45 +1,16 @@
-import React, { useState, useRef, useEffect, KeyboardEvent as ReactKeyboardEvent } from 'react';
+import React, { useState } from 'react';
 import { 
-  Box, 
-  Typography, 
-  CircularProgress, 
   Paper, 
-  Divider,
-  alpha,
-  Chip,
-  Tooltip,
-  Button,
-  InputBase,
-  IconButton,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  TextField,
-  Zoom,
-  InputAdornment,
-  List,
-  ListItem,
-  ListItemText,
-  ListItemButton,
   useTheme as useMuiTheme,
 } from '@mui/material';
-import AddIcon from '@mui/icons-material/Add';
-import CloseIcon from '@mui/icons-material/Close';
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import SearchIcon from '@mui/icons-material/Search';
-import EditIcon from '@mui/icons-material/Edit';
-import SaveIcon from '@mui/icons-material/Save';
-import DeleteIcon from '@mui/icons-material/Delete';
-import LabelIcon from '@mui/icons-material/Label';
-import { Tag, Tags } from 'lucide-react';
 import { ManagedCluster } from '../../types/bindingPolicy';
 import { useNavigate } from 'react-router-dom';
-import { usePolicyDragDropStore } from '../../stores/policyDragDropStore';
 import { useClusterQueries } from '../../hooks/queries/useClusterQueries';
 import { toast } from 'react-hot-toast';
-import { BsTagFill } from "react-icons/bs";
 import useTheme from "../../stores/themeStore";
+import ClusterPanelHeader from './ClusterPanelHeader';
+import ClusterLabelsList from './ClusterLabelsList';
+import { LabelEditDialog, SelectClusterDialog } from './ClusterDialogs';
 
 interface ClusterPanelProps {
   clusters: ManagedCluster[];
@@ -59,713 +30,16 @@ interface LabelGroup {
   }>;
 }
 
-interface ColorTheme {
-  primary: string;
-  primaryLight: string;
-  primaryDark: string;
-  secondary: string;
-  white: string;
-  background: string;
-  paper: string;
-  text: string;
-  textSecondary: string;
-  border: string;
-  success: string;
-  warning: string;
-  error: string;
-  disabled: string;
-}
 
-interface LabelEditDialogProps {
-  open: boolean;
-  onClose: () => void;
-  cluster: ManagedCluster | null;
-  onSave: (clusterName: string, contextName: string, labels: { [key: string]: string }) => void;
-  isDark: boolean;
-  colors: ColorTheme;
-}
 
-interface SelectClusterDialogProps {
-  open: boolean;
-  onClose: () => void;
-  clusters: ManagedCluster[];
-  onSelectCluster: (cluster: ManagedCluster) => void;
-  isDark: boolean;
-  colors: ColorTheme;
-}
+
+
 
 const DEFAULT_FILTERED_LABEL_KEYS = [
   'open-cluster-management',
   'kubernetes.io',
   'k8s.io'
 ];
-
-// LabelEditDialog component adapted from ClustersTable.tsx
-const LabelEditDialog: React.FC<LabelEditDialogProps> = ({ 
-  open, 
-  onClose, 
-  cluster, 
-  onSave,
-  isDark,
-  colors
-}) => {
-  const [labels, setLabels] = useState<Array<{ key: string; value: string }>>([]);
-  const [newKey, setNewKey] = useState("");
-  const [newValue, setNewValue] = useState("");
-  const [labelSearch, setLabelSearch] = useState("");
-  const [isSearching, setIsSearching] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const [selectedLabelIndex, setSelectedLabelIndex] = useState<number | null>(null);
-  const keyInputRef = useRef<HTMLInputElement>(null);
-  const valueInputRef = useRef<HTMLInputElement>(null);
-
-  // Filter labels based on search
-  const filteredLabels = labelSearch.trim() === "" 
-    ? labels 
-    : labels.filter(label => 
-        label.key.toLowerCase().includes(labelSearch.toLowerCase()) || 
-        label.value.toLowerCase().includes(labelSearch.toLowerCase())
-      );
-
-  useEffect(() => {
-    if (cluster && open) {
-      // Convert labels object to array format for editing
-      const labelArray = Object.entries(cluster.labels || {}).map(([key, value]) => ({
-        key,
-        value,
-      }));
-      setLabels(labelArray);
-      
-      // Reset other states
-      setNewKey("");
-      setNewValue("");
-      setLabelSearch("");
-      setIsSearching(false);
-      setSelectedLabelIndex(null);
-      
-      // Focus key input after a short delay
-      setTimeout(() => {
-        if (keyInputRef.current) {
-          keyInputRef.current.focus();
-        }
-      }, 100);
-    }
-  }, [cluster, open]);
-
-  const handleAddLabel = () => {
-    if (newKey.trim() && newValue.trim()) {
-      // Check for duplicates
-      const isDuplicate = labels.some(label => label.key === newKey.trim());
-      
-      if (isDuplicate) {
-        // Update existing label with same key
-        setLabels(labels.map(label => 
-          label.key === newKey.trim() 
-            ? { ...label, value: newValue.trim() } 
-            : label
-        ));
-        toast.success(`Updated existing label: ${newKey}`);
-      } else {
-        // Add new label with animation effect
-        setLabels(prev => [...prev, { key: newKey.trim(), value: newValue.trim() }]);
-        toast.success(`Added new label: ${newKey}`);
-      }
-      
-      // Clear inputs and refocus key input
-      setNewKey("");
-      setNewValue("");
-      if (keyInputRef.current) {
-        keyInputRef.current.focus();
-      }
-    }
-  };
-
-  const handleKeyDown = (e: ReactKeyboardEvent) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      
-      if (newKey && !newValue && valueInputRef.current) {
-        // If key is entered but value is empty, move focus to value input
-        valueInputRef.current.focus();
-      } else if (newKey && newValue) {
-        // If both fields are filled, add the label
-        handleAddLabel();
-      }
-    } else if (e.key === 'Escape') {
-      // Clear both inputs on Escape
-      setNewKey("");
-      setNewValue("");
-      if (keyInputRef.current) {
-        keyInputRef.current.focus();
-      }
-    }
-  };
-
-  const handleRemoveLabel = (index: number) => {
-    const labelToRemove = labels[index];
-    setLabels(labels.filter((_, i) => i !== index));
-    toast.success(`Removed label: ${labelToRemove.key}`);
-  };
-
-  const handleSave = () => {
-    if (!cluster) return;
-    
-    setSaving(true);
-    
-    // Convert array back to object format
-    const labelObject: { [key: string]: string } = {};
-    labels.forEach(({ key, value }) => {
-      labelObject[key] = value;
-    });
-    
-    // Add a slight delay to show loading state
-    setTimeout(() => {
-      onSave(cluster.name, cluster.context || 'default', labelObject);
-      setSaving(false);
-      onClose();
-    }, 300);
-  };
-
-  const toggleSearchMode = () => {
-    setIsSearching(!isSearching);
-    if (!isSearching) {
-      setTimeout(() => {
-        const searchInput = document.getElementById('label-search-input');
-        if (searchInput) {
-          searchInput.focus();
-        }
-      }, 100);
-    } else {
-      setLabelSearch("");
-    }
-  };
-
-  return (
-    <Dialog 
-      open={open} 
-      onClose={onClose}
-      fullWidth
-      maxWidth="sm"
-      TransitionComponent={Zoom}
-      transitionDuration={300}
-      PaperProps={{
-        style: {
-          backgroundColor: colors.paper,
-          color: colors.text,
-          border: `1px solid ${colors.border}`,
-          borderRadius: '12px',
-          overflow: 'hidden',
-          boxShadow: isDark 
-            ? '0 10px 25px -5px rgba(0, 0, 0, 0.5), 0 8px 10px -6px rgba(0, 0, 0, 0.4)' 
-            : '0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.05)',
-        }
-      }}
-    >
-      <DialogTitle 
-        style={{ 
-          color: colors.primary,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          padding: '20px 24px',
-          borderBottom: `1px solid ${colors.border}`,
-        }}
-      >
-        <div className="flex items-center gap-2">
-          <LabelIcon style={{ color: colors.primary }} />
-          <Typography variant="h6" component="span">
-            Edit Labels for <span style={{ fontWeight: 'bold' }}>{cluster?.name}</span>
-          </Typography>
-        </div>
-        <IconButton onClick={onClose} size="small" style={{ color: colors.textSecondary }}>
-          <CloseIcon fontSize="small" />
-        </IconButton>
-      </DialogTitle>
-      
-      <DialogContent style={{ padding: '24px' }}>
-        <div className="mb-6">
-          <div className="flex items-center justify-between mb-4">
-            <Typography variant="body2" style={{ color: colors.textSecondary }}>
-              Add or remove labels to organize and categorize your cluster.
-            </Typography>
-            
-            <div className="flex gap-2">
-              <Tooltip title={isSearching ? "Exit search" : "Search labels"}>
-                <IconButton 
-                  size="small" 
-                  onClick={toggleSearchMode}
-                  style={{ 
-                    color: isSearching ? colors.primary : colors.textSecondary,
-                    backgroundColor: isSearching ? (isDark ? 'rgba(47, 134, 255, 0.15)' : 'rgba(47, 134, 255, 0.1)') : 'transparent',
-                  }}
-                >
-                  <SearchIcon fontSize="small" />
-                </IconButton>
-              </Tooltip>
-              {labels.length > 0 && (
-                <Chip 
-                  size="small" 
-                  label={`${labels.length} label${labels.length !== 1 ? 's' : ''}`}
-                  style={{
-                    backgroundColor: isDark ? 'rgba(47, 134, 255, 0.15)' : 'rgba(47, 134, 255, 0.1)',
-                    color: colors.primary,
-                    fontSize: '0.75rem',
-                  }}
-                />
-              )}
-            </div>
-          </div>
-          
-          <Zoom in={isSearching} mountOnEnter unmountOnExit>
-            <div className="mb-4">
-              <TextField
-                id="label-search-input"
-                placeholder="Search labels..."
-                value={labelSearch}
-                onChange={(e) => setLabelSearch(e.target.value)}
-                fullWidth
-                variant="outlined"
-                size="small"
-                autoFocus
-                InputProps={{
-                  style: { color: colors.text },
-                  startAdornment: (
-                    <InputAdornment position="start">
-                      <SearchIcon style={{ color: colors.primary, fontSize: '1.2rem' }} />
-                    </InputAdornment>
-                  ),
-                  endAdornment: labelSearch && (
-                    <InputAdornment position="end">
-                      <IconButton 
-                        size="small" 
-                        onClick={() => setLabelSearch('')}
-                        style={{ color: colors.textSecondary }}
-                      >
-                        <CloseIcon fontSize="small" />
-                      </IconButton>
-                    </InputAdornment>
-                  ),
-                }}
-                sx={{
-                  "& .MuiOutlinedInput-root": {
-                    backgroundColor: isDark ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.02)',
-                    "& fieldset": { borderColor: colors.border },
-                    "&:hover fieldset": { borderColor: colors.primaryLight },
-                    "&.Mui-focused fieldset": { borderColor: colors.primary },
-                  },
-                }}
-              />
-            </div>
-          </Zoom>
-          
-          <Zoom in={!isSearching}>
-            <div className="mb-5">
-              <div className="flex flex-col sm:flex-row gap-2 mb-2">
-                <TextField
-                  label="Label Key"
-                  placeholder="e.g. environment"
-                  value={newKey}
-                  onChange={(e) => setNewKey(e.target.value)}
-                  inputRef={keyInputRef}
-                  onKeyDown={handleKeyDown}
-                  fullWidth
-                  variant="outlined"
-                  size="small"
-                  autoComplete="off"
-                  InputProps={{
-                    style: { color: colors.text }
-                  }}
-                  InputLabelProps={{
-                    style: { color: colors.textSecondary },
-                    shrink: true,
-                  }}
-                  sx={{
-                    "& .MuiOutlinedInput-root": {
-                      "& fieldset": { borderColor: colors.border },
-                      "&:hover fieldset": { borderColor: colors.primaryLight },
-                      "&.Mui-focused fieldset": { borderColor: colors.primary },
-                    },
-                  }}
-                />
-                <TextField
-                  label="Label Value"
-                  placeholder="e.g. production"
-                  value={newValue}
-                  onChange={(e) => setNewValue(e.target.value)}
-                  inputRef={valueInputRef}
-                  onKeyDown={handleKeyDown}
-                  fullWidth
-                  variant="outlined"
-                  size="small"
-                  autoComplete="off"
-                  InputProps={{
-                    style: { color: colors.text }
-                  }}
-                  InputLabelProps={{
-                    style: { color: colors.textSecondary },
-                    shrink: true,
-                  }}
-                  sx={{
-                    "& .MuiOutlinedInput-root": {
-                      "& fieldset": { borderColor: colors.border },
-                      "&:hover fieldset": { borderColor: colors.primaryLight },
-                      "&.Mui-focused fieldset": { borderColor: colors.primary },
-                    },
-                  }}
-                />
-                <Button 
-                  onClick={handleAddLabel}
-                  variant="contained"
-                  disabled={!newKey.trim() || !newValue.trim()}
-                  startIcon={<AddIcon />}
-                  style={{ 
-                    backgroundColor: (!newKey.trim() || !newValue.trim()) ? colors.disabled : colors.primary,
-                    color: colors.white,
-                    minWidth: '100px',
-                    transition: 'all 0.2s ease',
-                  }}
-                >
-                  Add
-                </Button>
-              </div>
-              <Typography variant="caption" style={{ color: colors.textSecondary }}>
-                Tip: Press <span style={{ fontFamily: 'monospace', backgroundColor: isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)', padding: '1px 4px', borderRadius: '2px' }}>Enter</span> to move between fields or add a label
-              </Typography>
-            </div>
-          </Zoom>
-
-          <Divider style={{ backgroundColor: colors.border, margin: '16px 0' }} />
-          
-          <div className="max-h-60 overflow-y-auto pr-1">
-            {filteredLabels.length > 0 ? (
-              <div className="space-y-2">
-                {filteredLabels.map((label, index) => (
-                  <Zoom in={true} style={{ transitionDelay: `${index * 25}ms` }} key={`${label.key}-${index}`}>
-                    <div 
-                      className={`flex items-center justify-between gap-2 p-2 rounded transition-all duration-200 ${selectedLabelIndex === index ? 'ring-1' : ''}`} 
-                      style={{ 
-                        backgroundColor: selectedLabelIndex === index 
-                          ? (isDark ? 'rgba(47, 134, 255, 0.2)' : 'rgba(47, 134, 255, 0.1)') 
-                          : (isDark ? 'rgba(47, 134, 255, 0.1)' : 'rgba(47, 134, 255, 0.05)'),
-                        border: `1px solid ${selectedLabelIndex === index ? colors.primary : colors.border}`,
-                        boxShadow: selectedLabelIndex === index 
-                          ? (isDark ? '0 0 0 1px rgba(47, 134, 255, 0.4)' : '0 0 0 1px rgba(47, 134, 255, 0.2)')
-                          : 'none',
-                        cursor: 'default',
-                      }} 
-                      onClick={() => setSelectedLabelIndex(selectedLabelIndex === index ? null : index)}
-                    >
-                      <div className="flex items-center gap-2">
-                        <Tag size={16} style={{ color: colors.primary }} />
-                        <span style={{ color: colors.text }}>
-                          <span style={{ fontWeight: 500 }}>{label.key}</span>
-                          <span style={{ color: colors.textSecondary }}> = </span>
-                          <span>{label.value}</span>
-                        </span>
-                      </div>
-                      <Tooltip title="Remove Label">
-                        <IconButton 
-                          size="small" 
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleRemoveLabel(labels.findIndex(l => l.key === label.key && l.value === label.value));
-                          }}
-                          style={{ 
-                            color: selectedLabelIndex === index ? colors.primary : colors.textSecondary,
-                            opacity: 0.8,
-                            transition: 'all 0.2s ease',
-                          }}
-                          className="hover:opacity-100"
-                        >
-                          <DeleteIcon fontSize="small" />
-                        </IconButton>
-                      </Tooltip>
-                    </div>
-                  </Zoom>
-                ))}
-              </div>
-            ) : (
-              <div className="flex flex-col items-center justify-center text-center p-6 mt-2">
-                <Tags size={28} style={{ color: colors.textSecondary, marginBottom: '12px' }} />
-                <Typography variant="body2" style={{ color: colors.text, fontWeight: 500, marginBottom: '4px' }}>
-                  {labelSearch ? "No matching labels found" : "No labels added yet"}
-                </Typography>
-                <Typography variant="caption" style={{ color: colors.textSecondary, maxWidth: '300px', margin: '0 auto' }}>
-                  {labelSearch 
-                    ? "Try a different search term or clear the search"
-                    : "Add your first label using the fields above to help organize this cluster."
-                  }
-                </Typography>
-                
-                {labelSearch && (
-                  <Button
-                    size="small"
-                    variant="text"
-                    style={{ color: colors.primary, marginTop: '12px' }}
-                    onClick={() => setLabelSearch('')}
-                  >
-                    Clear Search
-                  </Button>
-                )}
-              </div>
-            )}
-          </div>
-        </div>
-      </DialogContent>
-      
-      <DialogActions 
-        style={{ 
-          padding: '16px 24px',
-          borderTop: `1px solid ${colors.border}`,
-          justifyContent: 'space-between',
-        }}
-      >
-        <Button 
-          onClick={onClose}
-          style={{ 
-            color: colors.textSecondary,
-          }}
-          variant="text"
-          startIcon={<CloseIcon />}
-          disabled={saving}
-        >
-          Cancel
-        </Button>
-        
-        <Button 
-          onClick={handleSave}
-          variant="contained"
-          disabled={saving}
-          startIcon={saving ? <CircularProgress size={16} color="inherit" /> : <SaveIcon />}
-          style={{ 
-            backgroundColor: colors.primary,
-            color: colors.white,
-            minWidth: '120px',
-          }}
-        >
-          {saving ? 'Saving...' : 'Save Changes'}
-        </Button>
-      </DialogActions>
-    </Dialog>
-  );
-};
-
-// Select Cluster Dialog Component
-const SelectClusterDialog: React.FC<SelectClusterDialogProps> = ({
-  open,
-  onClose,
-  clusters,
-  onSelectCluster,
-  isDark,
-  colors
-}) => {
-  const [searchTerm, setSearchTerm] = useState('');
-  
-  const filteredClusters = searchTerm 
-    ? clusters.filter(cluster => 
-        cluster.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        Object.entries(cluster.labels || {}).some(
-          ([key, value]) => 
-            key.toLowerCase().includes(searchTerm.toLowerCase()) || 
-            value.toLowerCase().includes(searchTerm.toLowerCase())
-        )
-      )
-    : clusters;
-
-  return (
-    <Dialog
-      open={open}
-      onClose={onClose}
-      fullWidth
-      maxWidth="sm"
-      PaperProps={{
-        style: {
-          backgroundColor: colors.paper,
-          color: colors.text,
-          border: `1px solid ${colors.border}`,
-          borderRadius: '12px',
-          overflow: 'hidden',
-          boxShadow: isDark 
-            ? '0 10px 25px -5px rgba(0, 0, 0, 0.5), 0 8px 10px -6px rgba(0, 0, 0, 0.4)' 
-            : '0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.05)',
-        }
-      }}
-    >
-      <DialogTitle 
-        style={{ 
-          color: colors.primary,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          padding: '20px 24px',
-          borderBottom: `1px solid ${colors.border}`,
-        }}
-      >
-        <div className="flex items-center gap-2">
-          <Typography variant="h6" component="span">
-            Select Cluster to Edit
-          </Typography>
-        </div>
-        <IconButton onClick={onClose} size="small" style={{ color: colors.textSecondary }}>
-          <CloseIcon fontSize="small" />
-        </IconButton>
-      </DialogTitle>
-      
-      <DialogContent style={{ padding: '16px 24px' }}>
-        <TextField
-          placeholder="Search clusters..."
-          value={searchTerm}
-          onChange={(e) => setSearchTerm(e.target.value)}
-          fullWidth
-          variant="outlined"
-          size="small"
-          autoFocus
-          margin="normal"
-          InputProps={{
-            style: { color: colors.text },
-            startAdornment: (
-              <InputAdornment position="start">
-                <SearchIcon style={{ color: colors.primary, fontSize: '1.2rem' }} />
-              </InputAdornment>
-            ),
-            endAdornment: searchTerm && (
-              <InputAdornment position="end">
-                <IconButton 
-                  size="small" 
-                  onClick={() => setSearchTerm('')}
-                  style={{ color: colors.textSecondary }}
-                >
-                  <CloseIcon fontSize="small" />
-                </IconButton>
-              </InputAdornment>
-            ),
-          }}
-          sx={{
-            "& .MuiOutlinedInput-root": {
-              backgroundColor: isDark ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.02)',
-              "& fieldset": { borderColor: colors.border },
-              "&:hover fieldset": { borderColor: colors.primaryLight },
-              "&.Mui-focused fieldset": { borderColor: colors.primary },
-            },
-            mb: 2,
-          }}
-        />
-        
-        <List
-          sx={{
-            maxHeight: '400px',
-            overflow: 'auto',
-            '&::-webkit-scrollbar': {
-              width: '8px',
-            },
-            '&::-webkit-scrollbar-track': {
-              background: isDark ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.05)',
-              borderRadius: '4px',
-            },
-            '&::-webkit-scrollbar-thumb': {
-              background: isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.1)',
-              borderRadius: '4px',
-              '&:hover': {
-                background: isDark ? 'rgba(255, 255, 255, 0.2)' : 'rgba(0, 0, 0, 0.2)',
-              },
-            },
-          }}
-        >
-          {filteredClusters.length > 0 ? (
-            filteredClusters.map((cluster) => (
-              <ListItemButton
-                key={cluster.name}
-                onClick={() => onSelectCluster(cluster)}
-                sx={{
-                  borderRadius: '8px',
-                  mb: 1,
-                  border: `1px solid ${colors.border}`,
-                  backgroundColor: isDark ? 'rgba(47, 134, 255, 0.08)' : 'rgba(47, 134, 255, 0.04)',
-                  '&:hover': {
-                    backgroundColor: isDark ? 'rgba(47, 134, 255, 0.15)' : 'rgba(47, 134, 255, 0.08)',
-                  },
-                  transition: 'all 0.2s ease',
-                }}
-              >
-                <ListItemText 
-                  primary={cluster.name} 
-                  secondary={
-                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }}>
-                      {Object.entries(cluster.labels || {}).slice(0, 3).map(([key, value]) => (
-                        <Chip
-                          key={`${key}-${value}`}
-                          size="small"
-                          label={`${key}=${value}`}
-                          sx={{ 
-                            height: 20,
-                            fontSize: '0.7rem',
-                            bgcolor: alpha(colors.primary, 0.1),
-                            color: colors.primary,
-                          }}
-                        />
-                      ))}
-                      {Object.keys(cluster.labels || {}).length > 3 && (
-                        <Chip
-                          size="small"
-                          label={`+${Object.keys(cluster.labels || {}).length - 3} more`}
-                          sx={{ 
-                            height: 20,
-                            fontSize: '0.7rem',
-                            bgcolor: alpha(colors.secondary, 0.1),
-                            color: colors.secondary,
-                          }}
-                        />
-                      )}
-                    </Box>
-                  }
-                  primaryTypographyProps={{
-                    style: { 
-                      color: colors.text,
-                      fontWeight: 500,
-                    }
-                  }}
-                  secondaryTypographyProps={{
-                    style: { 
-                      color: colors.textSecondary,
-                    },
-                    component: 'div'
-                  }}
-                />
-                <EditIcon fontSize="small" sx={{ color: colors.primary, opacity: 0.7 }} />
-              </ListItemButton>
-            ))
-          ) : (
-            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', py: 4 }}>
-              <Typography variant="body1" sx={{ color: colors.text, fontWeight: 500, mb: 1 }}>
-                No clusters found
-              </Typography>
-              <Typography variant="body2" sx={{ color: colors.textSecondary }}>
-                {searchTerm ? 'Try a different search term' : 'No clusters available to edit'}
-              </Typography>
-            </Box>
-          )}
-        </List>
-      </DialogContent>
-      
-      <DialogActions
-        style={{ 
-          padding: '16px 24px',
-          borderTop: `1px solid ${colors.border}`,
-        }}
-      >
-        <Button 
-          onClick={onClose}
-          style={{ 
-            color: colors.textSecondary,
-          }}
-          variant="text"
-        >
-          Cancel
-        </Button>
-      </DialogActions>
-    </Dialog>
-  );
-};
 
 const ClusterPanel: React.FC<ClusterPanelProps> = ({
   clusters,
@@ -775,13 +49,14 @@ const ClusterPanel: React.FC<ClusterPanelProps> = ({
   filteredLabelKeys = DEFAULT_FILTERED_LABEL_KEYS,
   onItemClick
 }) => {
-  const muiTheme = useMuiTheme(); // Keep MUI theme for certain MUI component props
-  const theme = useTheme((state) => state.theme); // Get custom theme state (dark/light)
+  const muiTheme = useMuiTheme(); 
+  const theme = useTheme((state) => state.theme); 
   const navigate = useNavigate();
-  const [showSearch, setShowSearch] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [selectedCluster, setSelectedCluster] = useState<ManagedCluster | null>(null);
+  const [selectedClusters, setSelectedClusters] = useState<ManagedCluster[]>([]);
+  const [isBulkEdit, setIsBulkEdit] = useState(false);
   const [loadingClusterEdit, setLoadingClusterEdit] = useState<string | null>(null);
   const [selectClusterDialogOpen, setSelectClusterDialogOpen] = useState(false);
   
@@ -799,6 +74,8 @@ const ClusterPanel: React.FC<ClusterPanelProps> = ({
     if (clusters.length > 0) {
       // Open the select cluster dialog instead of auto-selecting the first cluster
       setSelectClusterDialogOpen(true);
+      setIsBulkEdit(false);
+      setSelectedClusters([]);
     } else {
       toast.error('No clusters available to edit');
     }
@@ -821,6 +98,27 @@ const ClusterPanel: React.FC<ClusterPanelProps> = ({
     setSelectedCluster(clusterWithContext);
     setEditDialogOpen(true);
     setSelectClusterDialogOpen(false);
+    setIsBulkEdit(false);
+  };
+
+  const handleEditMultipleClusters = (clusters: ManagedCluster[]) => {
+    console.log("handleEditMultipleClusters called with:", JSON.stringify(clusters.map(c => c.name), null, 2));
+    
+    if (clusters.length === 0) {
+      toast.error('No clusters selected');
+      return;
+    }
+    
+    // Ensure all clusters have valid contexts
+    const clustersWithContext = clusters.map(cluster => ({
+      ...cluster,
+      context: cluster.context || DEFAULT_CONTEXT
+    }));
+    
+    setSelectedClusters(clustersWithContext);
+    setEditDialogOpen(true);
+    setSelectClusterDialogOpen(false);
+    setIsBulkEdit(true);
   };
 
   // Debug function to log all cluster contexts
@@ -858,7 +156,7 @@ const ClusterPanel: React.FC<ClusterPanelProps> = ({
           });
           setLoadingClusterEdit(null);
         },
-          onError: (error: Error) => {
+        onError: (error: Error) => {
           toast.error("Failed to update labels", {
             icon: '❌',
             style: {
@@ -873,6 +171,80 @@ const ClusterPanel: React.FC<ClusterPanelProps> = ({
         }
       }
     );
+  };
+
+  const handleBulkSaveLabels = async (clusters: ManagedCluster[], labels: { [key: string]: string }) => {
+    if (clusters.length === 0) return;
+    
+    let successCount = 0;
+    let failureCount = 0;
+    
+    setLoadingClusterEdit("bulk-edit");
+    
+
+    for (const cluster of clusters) {
+      try {
+        // Get context from cluster or use default
+        const contextName = cluster.context || DEFAULT_CONTEXT;
+        
+        await new Promise<void>((resolve, reject) => {
+          updateLabelsMutation.mutate(
+            { 
+              contextName,
+              clusterName: cluster.name, 
+              labels
+            },
+            {
+              onSuccess: () => {
+                successCount++;
+                resolve();
+              },
+              onError: (error: Error) => {
+                console.error(`Error updating cluster ${cluster.name}:`, error);
+                failureCount++;
+                reject(error);
+              }
+            }
+          );
+        });
+      } catch (error) {
+        console.error(`Error processing cluster ${cluster.name}:`, error);
+      }
+    }
+    
+    if (successCount > 0 && failureCount === 0) {
+      toast.success(`Labels updated for all ${successCount} clusters`, {
+        icon: '🏷️',
+        style: {
+          borderRadius: '10px',
+          background: isDarkTheme ? '#1e293b' : '#ffffff',
+          color: isDarkTheme ? '#f1f5f9' : '#1e293b',
+          border: `1px solid ${isDarkTheme ? '#334155' : '#e2e8f0'}`,
+        },
+      });
+    } else if (successCount > 0 && failureCount > 0) {
+      toast(`Labels updated for ${successCount} clusters, failed for ${failureCount} clusters`, {
+        icon: '⚠️',
+        style: {
+          borderRadius: '10px',
+          background: isDarkTheme ? '#1e293b' : '#ffffff',
+          color: isDarkTheme ? '#f1f5f9' : '#1e293b',
+          border: `1px solid ${isDarkTheme ? '#334155' : '#e2e8f0'}`,
+        },
+      });
+    } else {
+      toast.error(`Failed to update labels for all ${failureCount} clusters`, {
+        icon: '❌',
+        style: {
+          borderRadius: '10px',
+          background: isDarkTheme ? '#1e293b' : '#ffffff',
+          color: isDarkTheme ? '#f1f5f9' : '#1e293b',
+          border: `1px solid ${isDarkTheme ? '#334155' : '#e2e8f0'}`,
+        },
+      });
+    }
+    
+    setLoadingClusterEdit(null);
   };
 
   // Colors for theming the LabelEditDialog
@@ -934,239 +306,6 @@ const ClusterPanel: React.FC<ClusterPanelProps> = ({
     );
   }, [uniqueLabels, searchTerm]);
 
-  const renderLabelItem = (labelGroup: LabelGroup) => {
-    const firstCluster = labelGroup.clusters[0];
-    
-    // Format: label-{key}-{value} or label-{key}:{value} if it's a simple label
-    let itemId = '';
-    
-    // Special handling for common labels we know are important
-    if (labelGroup.key === 'location-group' && labelGroup.value === 'edge') {
-      itemId = 'label-location-group:edge';
-    } else if (labelGroup.key.includes('/')) {
-      itemId = `label-${labelGroup.key}-${labelGroup.value}`;
-    } else {
-      itemId = `label-${labelGroup.key}:${labelGroup.value}`;
-    }
-    
-    // Check if this item is in the canvas
-    const { canvasEntities } = usePolicyDragDropStore.getState();
-    const isInCanvas = canvasEntities.clusters.includes(itemId);
-
-    // Find the full cluster objects for each cluster in this label group
-    const clusterObjects = labelGroup.clusters.map(c => 
-      clusters.find(cluster => cluster.name === c.name)
-    ).filter((c): c is ManagedCluster => c !== undefined);
-    
-    return (
-      <Box
-        key={`${labelGroup.key}:${labelGroup.value}`}
-        onClick={() => {
-          if (onItemClick) {
-            if (isInCanvas) {
-              console.log(`⚠️ Cluster ${itemId} is already in the canvas`);
-              return;
-            }
-            
-            onItemClick(itemId);
-          }
-        }}
-        sx={{
-          p: 1,
-          m: compact ? 0.5 : 1,
-          borderRadius: 1,
-          backgroundColor: isDarkTheme ? 'rgba(30, 41, 59, 0.8)' : muiTheme.palette.background.paper,
-          border: `1px solid ${isDarkTheme ? 'rgba(255, 255, 255, 0.12)' : muiTheme.palette.divider}`,
-          boxShadow: 0,
-          cursor: 'pointer',
-          position: 'relative',
-          transition: 'all 0.2s ease',
-          "&:hover": {
-            backgroundColor: isDarkTheme 
-              ? 'rgba(30, 41, 59, 0.95)' 
-              : alpha(muiTheme.palette.primary.main, 0.1),
-            boxShadow: 2,
-            transform: 'translateY(-2px)',
-          },
-        }}
-      >
-       {/* Position cluster count chip and edit button in absolute position */}
-       <Box sx={{ position: 'absolute', top: 4, right: 4, display: 'flex', gap: 0.5 }}>
-          <Tooltip title="Edit clusters with this label">
-            <IconButton 
-              size="small" 
-              onClick={(e) => {
-                e.stopPropagation(); // Prevent triggering the box click
-                
-                if (clusterObjects.length === 1) {
-                  // If only one cluster, edit it directly
-                  handleEditSpecificCluster(clusterObjects[0]);
-                } else if (clusterObjects.length > 0) {
-                  // If multiple clusters, open the select dialog with filtered clusters
-                  setSelectClusterDialogOpen(true);
-                }
-              }}
-              sx={{ 
-                p: 0.5, 
-                bgcolor: isDarkTheme
-                  ? alpha(muiTheme.palette.primary.main, 0.2)
-                  : alpha(muiTheme.palette.primary.main, 0.1),
-                color: isDarkTheme
-                  ? muiTheme.palette.primary.light
-                  : muiTheme.palette.primary.main,
-                '&:hover': {
-                  bgcolor: isDarkTheme
-                    ? alpha(muiTheme.palette.primary.main, 0.3)
-                    : alpha(muiTheme.palette.primary.main, 0.2),
-                } 
-              }}
-            >
-              <EditIcon sx={{ fontSize: '0.9rem' }} />
-            </IconButton>
-          </Tooltip>
-          
-          <Tooltip title={`${labelGroup.clusters.length} cluster(s)`}>
-            <Chip 
-              size="small" 
-              label={`${labelGroup.clusters.length}`}
-              sx={{ 
-                fontSize: '0.8rem',
-                height: 16,
-                '& .MuiChip-label': { px: 0.5 },
-                bgcolor: isDarkTheme
-                  ? alpha(muiTheme.palette.info.main, 0.2)
-                  : alpha(muiTheme.palette.info.main, 0.1),
-                color: isDarkTheme
-                  ? muiTheme.palette.info.light
-                  : muiTheme.palette.info.main,
-              }}
-            />
-          </Tooltip>
-        </Box>
-        
-         {/* Label value */}
-         <Box sx={{ mt: 0.5 }}>
-          <Chip
-            size="small"
-            label={`${labelGroup.key} = ${labelGroup.value}`}
-            sx={{ 
-              fontSize: '1rem',
-              height: 20,
-              '& .MuiChip-label': { 
-                px: 0.75,
-                textOverflow: 'ellipsis',
-                overflow: 'hidden',
-              },
-              bgcolor: isDarkTheme
-                ? alpha(muiTheme.palette.primary.main, 0.2)
-                : alpha(muiTheme.palette.primary.main, 0.1),
-              color: isDarkTheme
-                ? muiTheme.palette.primary.light
-                : muiTheme.palette.primary.main,
-            }}
-          />
-        </Box>
-     {/* Cluster summary with edit buttons */}
-     <Box sx={{ mt: 0.5 }}>
-          <Tooltip 
-            title={
-              <React.Fragment>
-                <Typography variant="caption" sx={{ fontWeight: 'bold' }} component="div">Clusters:</Typography>
-                <List 
-                  dense 
-                  sx={{ 
-                    m: 0, 
-                    p: 0, 
-                    pl: 1, 
-                    maxHeight: '150px', 
-                    overflow: 'auto',
-                    '&::-webkit-scrollbar': { width: '4px' },
-                    '&::-webkit-scrollbar-thumb': { 
-                      background: isDarkTheme 
-                        ? alpha('#ffffff', 0.2)
-                        : alpha('#000000', 0.2),
-                      borderRadius: '4px' 
-                    }
-                  }}
-                >
-                  {clusterObjects.map(cluster => (
-                    <ListItem 
-                      key={cluster.name} 
-                      disablePadding
-                      secondaryAction={
-                        <IconButton 
-                          edge="end"
-                          size="small"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            e.preventDefault();
-                            handleEditSpecificCluster(cluster);
-                          }}
-                          sx={{ p: 0.5 }}
-                        >
-                          <EditIcon fontSize="inherit" />
-                        </IconButton>
-                      }
-                    >
-                      <ListItemText 
-                        primary={cluster.name} 
-                        sx={{ m: 0 }}
-                        primaryTypographyProps={{ 
-                          variant: 'caption',
-                          component: 'div',
-                          style: { 
-                            display: 'block',
-                            maxWidth: '180px',
-                            whiteSpace: 'nowrap',
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis'
-                          }
-                        }} 
-                      />
-                    </ListItem>
-                  ))}
-                </List>
-              </React.Fragment>
-            } 
-            arrow 
-            placement="top"
-          >
-            <Typography 
-              variant="caption" 
-              sx={{ 
-                color: isDarkTheme 
-                  ? "rgba(255, 255, 255, 0.7)" 
-                  : "text.secondary" 
-              }}
-            >
-              {labelGroup.clusters.length === 1 
-                ? firstCluster.name
-                : labelGroup.clusters.length <= 2
-                  ? labelGroup.clusters.map(c => c.name).join(', ')
-                  : `${labelGroup.clusters.slice(0, 2).map(c => c.name).join(', ')} +${labelGroup.clusters.length - 2} more`}
-            </Typography>
-          </Tooltip>
-        </Box>
-        
-        {isInCanvas && (
-          <CheckCircleIcon 
-            sx={{ 
-              position: 'absolute',
-              bottom: 4,
-              right: 4,
-              fontSize: '1.2rem',
-              color: muiTheme.palette.success.main,
-              backgroundColor: isDarkTheme 
-                ? 'rgba(17, 25, 40, 0.8)'
-                : alpha(muiTheme.palette.background.paper, 0.7),
-              borderRadius: '50%'
-            }}
-          />
-        )}
-      </Box>
-    );
-  };
-
   return (
     <Paper 
       elevation={2}
@@ -1181,216 +320,38 @@ const ClusterPanel: React.FC<ClusterPanelProps> = ({
         backdropFilter: 'blur(10px)',
       }}
     >
-      <Box 
-        sx={{ 
-          p: compact ? 1 : 2, 
-          backgroundColor: isDarkTheme 
-            ? "rgba(37, 99, 235, 0.9)" 
-            : muiTheme.palette.primary.main, 
-          color: 'white', 
-          display: 'flex', 
-          justifyContent: 'space-between', 
-          alignItems: 'center',
-          borderBottom: isDarkTheme 
-            ? '1px solid rgba(255, 255, 255, 0.15)' 
-            : 'none',
-        }}
-      >
-        <Box sx={{ display: 'flex', alignItems: 'center', flexGrow: 1 }}>
-          {showSearch ? (
-            <Box 
-              sx={{ 
-                display: 'flex', 
-                alignItems: 'center', 
-                bgcolor: alpha(muiTheme.palette.common.white, 0.15),
-                borderRadius: 1,
-                px: 1,
-                flexGrow: 1,
-                mr: 1
-              }}
-            >
-              <InputBase
-                placeholder="Search labels..."
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                sx={{ 
-                  color: 'white', 
-                  flexGrow: 1,
-                  '& .MuiInputBase-input': {
-                    py: 0.5,
-                  }
-                }}
-                autoFocus
-              />
-              <IconButton 
-                size="small" 
-                onClick={() => {
-                  setSearchTerm("");
-                  setShowSearch(false);
-                }} 
-                sx={{ 
-                  color: 'white', 
-                  p: 0.25,
-                  '&:hover': {
-                    backgroundColor: isDarkTheme 
-                      ? 'rgba(255, 255, 255, 0.15)' 
-                      : 'rgba(255, 255, 255, 0.25)'
-                  }
-                }}
-              >
-                <CloseIcon fontSize="small" />
-              </IconButton>
-            </Box>
-          ) : (
-            <Typography variant={compact ? "subtitle1" : "h6"}>
-              Clusters 
-            </Typography>
-          )}
-          {!showSearch && !compact && (
-            <IconButton 
-              size="small" 
-              sx={{ 
-                ml: 1, 
-                color: 'white',
-                '&:hover': {
-                  backgroundColor: isDarkTheme 
-                    ? 'rgba(255, 255, 255, 0.15)' 
-                    : 'rgba(255, 255, 255, 0.25)'
-                }
-              }}
-              onClick={() => setShowSearch(true)}
-            >
-              <SearchIcon fontSize="small" />
-            </IconButton>
-          )}
-        </Box>
-        {!compact && (
-          <Box sx={{ display: 'flex', gap: 1 }}>
-           <Button
-           variant="contained"
-           endIcon={<BsTagFill />}
-           onClick={handleAddLabels}
-           size="small"
-           sx={{ 
-             bgcolor: isDarkTheme 
-               ? alpha(muiTheme.palette.common.white, 0.15)  
-               : muiTheme.palette.common.white,
-             color: isDarkTheme 
-               ? muiTheme.palette.common.white
-               : muiTheme.palette.secondary.main,
-             borderColor: isDarkTheme ? 'rgba(255, 255, 255, 0.3)' : undefined,
-             transition: 'all 0.2s ease',
-             fontWeight: 500,
-             "&:hover": {
-               bgcolor: isDarkTheme 
-                 ? alpha(muiTheme.palette.common.white, 0.25)
-                 : alpha(muiTheme.palette.common.white, 0.9),
-               transform: 'translateY(-2px)',
-               boxShadow: isDarkTheme
-                 ? '0 4px 12px rgba(0,0,0,0.4)'
-                 : '0 4px 8px rgba(0,0,0,0.2)'
-             },
-           }}
-         >
-  Labels
-</Button>
-<Button
-  variant="contained"
-  startIcon={<AddIcon />}
-  onClick={handleImportClusters}
-  size="small"
-  sx={{
-    bgcolor: isDarkTheme 
-      ? alpha(muiTheme.palette.common.white, 0.15)
-      : muiTheme.palette.common.white,
-    color: isDarkTheme 
-      ? muiTheme.palette.common.white
-      : muiTheme.palette.secondary.main,
-    borderColor: isDarkTheme ? 'rgba(255, 255, 255, 0.3)' : undefined,
-    transition: 'all 0.2s ease',
-    fontWeight: 500,
-    "&:hover": {
-      bgcolor: isDarkTheme 
-        ? alpha(muiTheme.palette.common.white, 0.25)
-        : alpha(muiTheme.palette.common.white, 0.9),
-      transform: 'translateY(-2px)',
-      boxShadow: isDarkTheme
-        ? '0 4px 12px rgba(0,0,0,0.4)'
-        : '0 4px 8px rgba(0,0,0,0.2)'
-    },
-  }}
->
-  Import
-</Button>
-          </Box>
-        )}
-      </Box>
-  
+      <ClusterPanelHeader
+        compact={compact}
+        onSearch={setSearchTerm}
+        onAddLabels={handleAddLabels}
+        onImportClusters={handleImportClusters}
+      />
       
-      <Box sx={{ 
-        p: compact ? 0.5 : 1, 
-        overflow: 'auto', 
-        flexGrow: 1,
-        '&::-webkit-scrollbar': {
-          display: 'none'
-        },
-        scrollbarWidth: 'none',  
-        '-ms-overflow-style': 'none',
-        backgroundColor: isDarkTheme 
-          ? 'rgba(17, 25, 40, 0.8)' 
-          : 'transparent',
-      }}>
-        {loading ? (
-          <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
-            <CircularProgress size={30} sx={{
-              color: isDarkTheme ? '#60a5fa' : undefined
-            }} />
-          </Box>
-        ) : error ? (
-          <Typography color="error" sx={{ p: 2 }}>
-            {error}
-          </Typography>
-        ) : clusters.length === 0 ? (
-          <Typography
-            sx={{ 
-              p: 2, 
-              color: isDarkTheme ? "rgba(255, 255, 255, 0.7)" : "text.secondary", 
-              textAlign: 'center' 
-            }}
-          >
-            No cluster labels available. Please add clusters with labels to use in binding policies.
-          </Typography>
-        ) : (
-          <Box sx={{ minHeight: '100%' }}>
-            {filteredLabels.length === 0 ? (
-              <Typography sx={{ 
-                p: 2, 
-                color: isDarkTheme ? "rgba(255, 255, 255, 0.7)" : "text.secondary", 
-                textAlign: 'center' 
-              }}>
-                {searchTerm ? 'No labels match your search.' : 'No labels found in available clusters.'}
-              </Typography>
-            ) : (
-              filteredLabels.map((labelGroup) => 
-                renderLabelItem(labelGroup)
-              )
-            )}
-          </Box>
-        )}
-      </Box>
-
+      <ClusterLabelsList
+        clusters={clusters}
+        filteredLabels={filteredLabels}
+        loading={loading}
+        error={error}
+        compact={compact}
+        searchTerm={searchTerm}
+        onItemClick={onItemClick}
+        onEditCluster={handleEditSpecificCluster}
+      />
 
       {/* Label Edit Dialog */}
       <LabelEditDialog
         open={editDialogOpen}
         onClose={() => {
           setEditDialogOpen(false);
-          if (loadingClusterEdit && selectedCluster) {
+          if (loadingClusterEdit && (selectedCluster || isBulkEdit)) {
             setLoadingClusterEdit(null);
           }
         }}
         cluster={selectedCluster}
+        clusters={selectedClusters || []}
+        isBulkEdit={isBulkEdit}
         onSave={handleSaveLabels}
+        onBulkSave={handleBulkSaveLabels}
         isDark={isDarkTheme}
         colors={colors}
       />
@@ -1404,6 +365,7 @@ const ClusterPanel: React.FC<ClusterPanelProps> = ({
           context: cluster.context || DEFAULT_CONTEXT 
         }))}
         onSelectCluster={handleEditSpecificCluster}
+        onSelectClusters={handleEditMultipleClusters}
         isDark={isDarkTheme}
         colors={colors}
       />

--- a/src/components/BindingPolicy/ClusterPanelHeader.tsx
+++ b/src/components/BindingPolicy/ClusterPanelHeader.tsx
@@ -1,0 +1,173 @@
+import React, { useState } from 'react';
+import { 
+  Box, 
+  Typography, 
+  Button,
+  InputBase,
+  IconButton,
+  alpha,
+  useTheme as useMuiTheme,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import CloseIcon from '@mui/icons-material/Close';
+import SearchIcon from '@mui/icons-material/Search';
+import { BsTagFill } from "react-icons/bs";
+import useTheme from "../../stores/themeStore";
+
+interface ClusterPanelHeaderProps {
+  compact?: boolean;
+  onSearch: (term: string) => void;
+  onAddLabels: () => void;
+  onImportClusters: () => void;
+}
+
+const ClusterPanelHeader: React.FC<ClusterPanelHeaderProps> = ({
+  compact = false,
+  onSearch,
+  onAddLabels,
+  onImportClusters
+}) => {
+  const muiTheme = useMuiTheme();
+  const theme = useTheme((state) => state.theme);
+  const isDarkTheme = theme === "dark";
+  const [showSearch, setShowSearch] = useState(false);
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const handleSearchChange = (value: string) => {
+    setSearchTerm(value);
+    onSearch(value);
+  };
+
+  return (
+    <Box 
+      sx={{ 
+        p: compact ? 1 : 2, 
+        backgroundColor: isDarkTheme 
+          ? "rgba(37, 99, 235, 0.9)" 
+          : muiTheme.palette.primary.main, 
+        color: 'white', 
+        display: 'flex', 
+        justifyContent: 'space-between', 
+        alignItems: 'center',
+        borderBottom: isDarkTheme 
+          ? '1px solid rgba(255, 255, 255, 0.15)' 
+          : 'none',
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', flexGrow: 1 }}>
+        {showSearch ? (
+          <Box 
+            sx={{ 
+              display: 'flex', 
+              alignItems: 'center', 
+              bgcolor: alpha(muiTheme.palette.common.white, 0.15),
+              borderRadius: 1,
+              px: 1,
+              flexGrow: 1,
+              mr: 1
+            }}
+          >
+            <InputBase
+              placeholder="Search labels..."
+              value={searchTerm}
+              onChange={(e) => handleSearchChange(e.target.value)}
+              sx={{ 
+                color: 'white', 
+                flexGrow: 1,
+                '& .MuiInputBase-input': {
+                  py: 0.5,
+                }
+              }}
+              autoFocus
+            />
+            <IconButton 
+              size="small" 
+              onClick={() => {
+                handleSearchChange("");
+                setShowSearch(false);
+              }} 
+              sx={{ 
+                color: 'white', 
+                p: 0.25,
+                '&:hover': {
+                  backgroundColor: isDarkTheme 
+                    ? 'rgba(255, 255, 255, 0.15)' 
+                    : 'rgba(255, 255, 255, 0.25)'
+                }
+              }}
+            >
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </Box>
+        ) : (
+          <Typography variant={compact ? "subtitle1" : "h6"}>
+            Clusters 
+          </Typography>
+        )}
+        {!showSearch && !compact && (
+          <IconButton 
+            size="small" 
+            sx={{ 
+              ml: 1, 
+              color: 'white',
+              '&:hover': {
+                backgroundColor: isDarkTheme 
+                  ? 'rgba(255, 255, 255, 0.15)' 
+                  : 'rgba(255, 255, 255, 0.25)'
+              }
+            }}
+            onClick={() => setShowSearch(true)}
+          >
+            <SearchIcon fontSize="small" />
+          </IconButton>
+        )}
+      </Box>
+      {!compact && (
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Button
+            variant="contained"
+            endIcon={<BsTagFill />}
+            onClick={onAddLabels}
+            size="small"
+            sx={{ 
+              bgcolor: 'white', 
+              color: isDarkTheme 
+                ? "rgba(37, 99, 235, 0.9)"
+                : muiTheme.palette.primary.main,
+              transition: 'all 0.2s ease',
+              "&:hover": {
+                bgcolor: alpha(muiTheme.palette.common.white, 0.9),
+                transform: 'translateY(-2px)',
+                boxShadow: '0 4px 8px rgba(0,0,0,0.2)'
+              },
+            }}
+          >
+            labels
+          </Button>
+          <Button
+            variant="contained"
+            startIcon={<AddIcon />}
+            onClick={onImportClusters}
+            size="small"
+            sx={{ 
+              bgcolor: 'white', 
+              color: isDarkTheme 
+                ? "rgba(37, 99, 235, 0.9)"
+                : muiTheme.palette.primary.main,
+              transition: 'all 0.2s ease',
+              "&:hover": {
+                bgcolor: alpha(muiTheme.palette.common.white, 0.9),
+                transform: 'translateY(-2px)',
+                boxShadow: '0 4px 8px rgba(0,0,0,0.2)'
+              },
+            }}
+          >
+            Import
+          </Button>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default ClusterPanelHeader; 

--- a/src/components/BindingPolicy/CreateBindingPolicyDialog.tsx
+++ b/src/components/BindingPolicy/CreateBindingPolicyDialog.tsx
@@ -546,7 +546,7 @@ const CreateBindingPolicyDialog: React.FC<CreateBindingPolicyDialogProps> = ({
           workloadLabels[labelInfo.key] = labelInfo.value;
         }
       } else {
-        workloadLabels['kubernetes.io/kubestellar.workload.name'] = workloadObj.name;
+        workloadLabels['kubestellar.io/workload'] = workloadObj.name;
       }
       
       if (clusterId.startsWith('label-')) {
@@ -795,7 +795,7 @@ const CreateBindingPolicyDialog: React.FC<CreateBindingPolicyDialogProps> = ({
           workloadLabels[labelInfo.key] = labelInfo.value;
         }
       } else {
-        workloadLabels['kubernetes.io/kubestellar.workload.name'] = workloadObj.name;
+        workloadLabels['kubestellar.io/workload'] = workloadObj.name;
       }
       
       if (clusterId.startsWith('label-')) {

--- a/src/components/BindingPolicy/PolicyDragDropContainer.tsx
+++ b/src/components/BindingPolicy/PolicyDragDropContainer.tsx
@@ -940,7 +940,7 @@ const PolicyDragDropContainer: React.FC<PolicyDragDropContainerProps> = ({
           "Workload info not in expected label format:",
           workloadInfo
         );
-        workloadLabels["kubernetes.io/kubestellar.workload.name"] =
+        workloadLabels["kubestellar.io/workload"] =
           workloadInfo;
       }
 

--- a/src/components/BindingPolicy/WorkloadPanel.tsx
+++ b/src/components/BindingPolicy/WorkloadPanel.tsx
@@ -130,7 +130,7 @@ const WorkloadPanel: React.FC<WorkloadPanelProps> = ({
   const { state, startSSEConnection, extractWorkloads } = useWorkloadSSE();
 
   // Use SSE or prop workloads based on SSE connection status
-  const workloads = state.data ? extractWorkloads() : propWorkloads;
+  const workloads = state.data ? extractWorkloads() || [] : propWorkloads || [];
   const loading = (state.status === 'loading' || state.status === 'idle') && propLoading;
   const error = state.error?.message || propError;
 
@@ -147,7 +147,7 @@ const WorkloadPanel: React.FC<WorkloadPanelProps> = ({
   }, []);
 
   const handleCreateWorkload = () => {
-    navigate("/workloads/manage");
+    navigate("/workloads/manage?create=true");
   };
 
   const handleAddLabels = () => {

--- a/src/components/BindingPolicy/WorkloadPanel.tsx
+++ b/src/components/BindingPolicy/WorkloadPanel.tsx
@@ -22,7 +22,9 @@ import {
   List,
   ListItemText,
   ListItemButton,
-  Divider
+  Divider,
+  Checkbox,
+  FormControlLabel
 } from '@mui/material';
 import { Workload } from '../../types/bindingPolicy';
 import AddIcon from '@mui/icons-material/Add';
@@ -66,7 +68,10 @@ interface LabelEditDialogProps {
   open: boolean;
   onClose: () => void;
   workload: Workload | null;
+  workloads: Workload[];
+  isBulkEdit: boolean;
   onSave: (workloadName: string, namespace: string, kind: string, labels: { [key: string]: string }) => void;
+  onBulkSave: (workloads: Workload[], labels: { [key: string]: string }) => void;
   isDark: boolean;
   colors: ColorTheme;
 }
@@ -76,6 +81,7 @@ interface SelectWorkloadDialogProps {
   onClose: () => void;
   workloads: Workload[];
   onSelectWorkload: (workload: Workload) => void;
+  onSelectWorkloads: (workloads: Workload[]) => void;
   isDark: boolean;
   colors: ColorTheme;
 }
@@ -111,6 +117,8 @@ const WorkloadPanel: React.FC<WorkloadPanelProps> = ({
   const [searchTerm, setSearchTerm] = useState("");
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [selectedWorkload, setSelectedWorkload] = useState<Workload | null>(null);
+  const [selectedWorkloads, setSelectedWorkloads] = useState<Workload[]>([]);
+  const [isBulkEdit, setIsBulkEdit] = useState(false);
   const [loadingWorkloadEdit, setLoadingWorkloadEdit] = useState<string | null>(null);
   const [selectWorkloadDialogOpen, setSelectWorkloadDialogOpen] = useState(false);
   const [refreshTrigger, setRefreshTrigger] = useState(0); // Add refresh trigger state
@@ -145,6 +153,8 @@ const WorkloadPanel: React.FC<WorkloadPanelProps> = ({
   const handleAddLabels = () => {
     if (workloads.length > 0) {
       setSelectWorkloadDialogOpen(true);
+      setIsBulkEdit(false);
+      setSelectedWorkloads([]);
     } else {
       toast.error('No workloads available to edit');
     }
@@ -172,6 +182,21 @@ const WorkloadPanel: React.FC<WorkloadPanelProps> = ({
     }
     setEditDialogOpen(true);
     setSelectWorkloadDialogOpen(false);
+    setIsBulkEdit(false);
+  };
+
+  const handleEditMultipleWorkloads = (workloads: Workload[]) => {
+    console.log("handleEditMultipleWorkloads called with:", JSON.stringify(workloads, null, 2));
+    
+    if (workloads.length === 0) {
+      toast.error('No workloads selected');
+      return;
+    }
+    
+    setSelectedWorkloads(workloads);
+    setEditDialogOpen(true);
+    setSelectWorkloadDialogOpen(false);
+    setIsBulkEdit(true);
   };
 
   const handleSaveLabels = async (
@@ -361,6 +386,129 @@ const WorkloadPanel: React.FC<WorkloadPanelProps> = ({
     } finally {
       setLoadingWorkloadEdit(null);
     }
+  };
+
+  const handleBulkSaveLabels = async (workloads: Workload[], labels: { [key: string]: string }) => {
+    if (workloads.length === 0) return;
+    
+    let successCount = 0;
+    let failureCount = 0;
+    
+    setLoadingWorkloadEdit("bulk-edit");
+    
+    for (const workload of workloads) {
+      try {
+        // Special handling for Namespace resources
+        if (workload.kind === "Namespace") {
+          // Get the current namespace details
+          const getUrl = `/api/namespaces/${workload.name}`;
+          const getResponse = await api.get(getUrl);
+          const currentResource = getResponse.data;
+          
+          if (!currentResource) {
+            console.error(`No namespace data returned for ${workload.name}`);
+            failureCount++;
+            continue;
+          }
+          
+          const updatedResource = {
+            ...currentResource,
+            labels: {
+              ...currentResource.labels,
+              ...labels // Only add/update the new labels, keep existing ones
+            }
+          };
+          
+          const updateUrl = `/api/namespaces/update/${workload.name}`;
+          await api.put(updateUrl, updatedResource);
+          successCount++;
+        } else {
+          const kindToPluralMap: Record<string, string> = {
+            Deployment: "deployments",
+            StatefulSet: "statefulsets",
+            DaemonSet: "daemonsets",
+            Pod: "pods",
+            Service: "services",
+            ConfigMap: "configmaps",
+            Secret: "secrets",
+            // need to add more mappings here
+          };
+          
+          const pluralForm = kindToPluralMap[workload.kind] || `${workload.kind.toLowerCase()}s`;
+          const namespace = workload.namespace || "default";
+          
+          // Get the current resource
+          const getUrl = `/api/${pluralForm}/${namespace}/${workload.name}`;
+          const getResponse = await api.get(getUrl);
+          const currentResource = getResponse.data;
+          
+          if (!currentResource) {
+            console.error(`Resource ${workload.kind}/${namespace}/${workload.name} not found`);
+            failureCount++;
+            continue;
+          }
+          
+          // Update the resource with new labels
+          const updatedResource = {
+            ...currentResource,
+            metadata: {
+              ...currentResource.metadata,
+              labels: {
+                ...(currentResource.metadata.labels || {}),
+                ...labels // Only add/update the new labels, keep existing ones
+              }
+            }
+          };
+          
+          // Update the resource
+          const updateUrl = `/api/${pluralForm}/${namespace}/${workload.name}`;
+          await api.put(updateUrl, updatedResource);
+          successCount++;
+        }
+      } catch (error) {
+        console.error(`Error updating workload ${workload.kind}/${workload.name}:`, error);
+        failureCount++;
+      }
+    }
+    
+    if (successCount > 0 && failureCount === 0) {
+      toast.success(`Labels updated for all ${successCount} resources`, {
+        icon: '🏷️',
+        style: {
+          borderRadius: '10px',
+          background: isDarkTheme ? '#1e293b' : '#ffffff',
+          color: isDarkTheme ? '#f1f5f9' : '#1e293b',
+          border: `1px solid ${isDarkTheme ? '#334155' : '#e2e8f0'}`,
+        },
+      });
+    } else if (successCount > 0 && failureCount > 0) {
+      toast(`Labels updated for ${successCount} resources, failed for ${failureCount} resources`, {
+        icon: '⚠️',
+        style: {
+          borderRadius: '10px',
+          background: isDarkTheme ? '#1e293b' : '#ffffff',
+          color: isDarkTheme ? '#f1f5f9' : '#1e293b',
+          border: `1px solid ${isDarkTheme ? '#334155' : '#e2e8f0'}`,
+        },
+      });
+    } else {
+      toast.error(`Failed to update labels for all ${failureCount} resources`, {
+        icon: '❌',
+        style: {
+          borderRadius: '10px',
+          background: isDarkTheme ? '#1e293b' : '#ffffff',
+          color: isDarkTheme ? '#f1f5f9' : '#1e293b',
+          border: `1px solid ${isDarkTheme ? '#334155' : '#e2e8f0'}`,
+        },
+      });
+    }
+    
+    setLoadingWorkloadEdit(null);
+    
+    // Schedule a refresh after the save is complete
+    setTimeout(() => {
+      refreshWorkloads();
+    }, 1000);
   };
 
   // Colors for theming the dialogs
@@ -589,7 +737,7 @@ const WorkloadPanel: React.FC<WorkloadPanelProps> = ({
                     handleEditSpecificWorkload(workloadObjects[0]);
                   } else if (workloadObjects.length > 0) {
                     // If multiple workloads, open the select dialog
-                    setSelectWorkloadDialogOpen(true);
+                    handleEditMultipleWorkloads(workloadObjects);
                   }
                 }}
                 sx={{ 
@@ -845,61 +993,45 @@ const WorkloadPanel: React.FC<WorkloadPanelProps> = ({
           <Box sx={{ display: 'flex', gap: 1 }}>
             {/* "Add Labels" button */}
             <Button
-  variant="contained"
-  endIcon={<BsTagFill />}
-  onClick={handleAddLabels}
-  size="small"
-  sx={{ 
-    bgcolor: isDarkTheme 
-      ? alpha(muiTheme.palette.common.white, 0.15)  
-      : muiTheme.palette.common.white,
-    color: isDarkTheme 
-      ? muiTheme.palette.common.white
-      : muiTheme.palette.secondary.main,
-    borderColor: isDarkTheme ? 'rgba(255, 255, 255, 0.3)' : undefined,
-    transition: 'all 0.2s ease',
-    fontWeight: 500,
-    "&:hover": {
-      bgcolor: isDarkTheme 
-        ? alpha(muiTheme.palette.common.white, 0.25)
-        : alpha(muiTheme.palette.common.white, 0.9),
-      transform: 'translateY(-2px)',
-      boxShadow: isDarkTheme
-        ? '0 4px 12px rgba(0,0,0,0.4)'
-        : '0 4px 8px rgba(0,0,0,0.2)'
-    },
-  }}
->
-  Labels
-</Button>
-<Button
-  variant="contained"
-  startIcon={<AddIcon />}
-  onClick={handleCreateWorkload}
-  size="small"
-  sx={{
-    bgcolor: isDarkTheme 
-      ? alpha(muiTheme.palette.common.white, 0.15)
-      : muiTheme.palette.common.white,
-    color: isDarkTheme 
-      ? muiTheme.palette.common.white
-      : muiTheme.palette.secondary.main,
-    borderColor: isDarkTheme ? 'rgba(255, 255, 255, 0.3)' : undefined,
-    transition: 'all 0.2s ease',
-    fontWeight: 500,
-    "&:hover": {
-      bgcolor: isDarkTheme 
-        ? alpha(muiTheme.palette.common.white, 0.25)
-        : alpha(muiTheme.palette.common.white, 0.9),
-      transform: 'translateY(-2px)',
-      boxShadow: isDarkTheme
-        ? '0 4px 12px rgba(0,0,0,0.4)'
-        : '0 4px 8px rgba(0,0,0,0.2)'
-    },
-  }}
->
-  Create
-</Button>
+              variant="contained"
+              endIcon={<BsTagFill />}
+              onClick={handleAddLabels}
+              size="small"
+              sx={{ 
+                bgcolor: 'white', 
+                color: isDarkTheme 
+                  ? "rgba(37, 99, 235, 0.9)"
+                  : muiTheme.palette.secondary.main,
+                transition: 'all 0.2s ease',
+                "&:hover": {
+                  bgcolor: alpha(muiTheme.palette.common.white, 0.9),
+                  transform: 'translateY(-2px)',
+                  boxShadow: '0 4px 8px rgba(0,0,0,0.2)'
+                },
+              }}
+            >
+              Labels
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={<AddIcon />}
+              onClick={handleCreateWorkload}
+              size="small"
+              sx={{
+                bgcolor: "white",
+                color: isDarkTheme 
+                  ? "rgba(37, 99, 235, 0.9)"
+                  : muiTheme.palette.secondary.main,
+                transition: 'all 0.2s ease',
+                "&:hover": {
+                  bgcolor: alpha(muiTheme.palette.common.white, 0.9),
+                  transform: 'translateY(-2px)',
+                  boxShadow: '0 4px 8px rgba(0,0,0,0.2)'
+                },
+              }}
+            >
+              Create
+            </Button>
           </Box>
         )}
       </Box>
@@ -1005,7 +1137,10 @@ const WorkloadPanel: React.FC<WorkloadPanelProps> = ({
           }
         }}
         workload={selectedWorkload}
+        workloads={selectedWorkloads}
+        isBulkEdit={isBulkEdit}
         onSave={handleSaveLabels}
+        onBulkSave={handleBulkSaveLabels}
         isDark={isDarkTheme}
         colors={colors}
       />
@@ -1016,6 +1151,7 @@ const WorkloadPanel: React.FC<WorkloadPanelProps> = ({
         onClose={() => setSelectWorkloadDialogOpen(false)}
         workloads={workloads}
         onSelectWorkload={handleEditSpecificWorkload}
+        onSelectWorkloads={handleEditMultipleWorkloads}
         isDark={isDarkTheme}
         colors={colors}
       />
@@ -1028,7 +1164,10 @@ const LabelEditDialog: React.FC<LabelEditDialogProps> = ({
   open, 
   onClose, 
   workload, 
+  workloads,
+  isBulkEdit,
   onSave,
+  onBulkSave,
   isDark,
   colors
 }) => {
@@ -1039,6 +1178,7 @@ const LabelEditDialog: React.FC<LabelEditDialogProps> = ({
   const [isSearching, setIsSearching] = useState(false);
   const [saving, setSaving] = useState(false);
   const [selectedLabelIndex, setSelectedLabelIndex] = useState<number | null>(null);
+  const [appendLabels, setAppendLabels] = useState(true);
   const keyInputRef = useRef<HTMLInputElement>(null);
   const valueInputRef = useRef<HTMLInputElement>(null);
 
@@ -1051,22 +1191,30 @@ const LabelEditDialog: React.FC<LabelEditDialogProps> = ({
       );
 
   useEffect(() => {
-    if (workload && open) {
-      console.log("LabelEditDialog opened with workload:", JSON.stringify(workload, null, 2));
-      
-      const labelArray = Object.entries(workload.labels || {}).map(([key, value]) => ({
-        key,
-        value,
-      }));
-      console.log("Initial labels array:", JSON.stringify(labelArray, null, 2));
-      
-      setLabels(labelArray);
+    if (open) {
+      if (isBulkEdit) {
+        console.log("LabelEditDialog opened for bulk edit with workloads:", workloads.length);
+        
+        // For bulk edit, start with empty labels
+        setLabels([]);
+      } else if (workload) {
+        console.log("LabelEditDialog opened with workload:", JSON.stringify(workload, null, 2));
+        
+        const labelArray = Object.entries(workload.labels || {}).map(([key, value]) => ({
+          key,
+          value,
+        }));
+        console.log("Initial labels array:", JSON.stringify(labelArray, null, 2));
+        
+        setLabels(labelArray);
+      }
       
       setNewKey("");
       setNewValue("");
       setLabelSearch("");
       setIsSearching(false);
       setSelectedLabelIndex(null);
+      setAppendLabels(true);
       
       setTimeout(() => {
         if (keyInputRef.current) {
@@ -1074,7 +1222,7 @@ const LabelEditDialog: React.FC<LabelEditDialogProps> = ({
         }
       }, 100);
     }
-  }, [workload, open]);
+  }, [workload, workloads, isBulkEdit, open]);
 
   const handleAddLabel = () => {
     if (newKey.trim() && newValue.trim()) {
@@ -1128,32 +1276,52 @@ const LabelEditDialog: React.FC<LabelEditDialogProps> = ({
   };
 
   const handleSave = () => {
-    if (!workload) return;
-    
-    setSaving(true);
-    
-    // Convert array back to object format
-    const labelObject: { [key: string]: string } = {};
-    labels.forEach(({ key, value }) => {
-      labelObject[key] = value;
-    });
+    if (isBulkEdit) {
+      if (workloads.length === 0) return;
+      
+      setSaving(true);
+      
+      // Convert array back to object format
+      const labelObject: { [key: string]: string } = {};
+      labels.forEach(({ key, value }) => {
+        labelObject[key] = value;
+      });
+      
+      console.log("===== BULK LABEL SAVE DEBUG =====");
+      console.log("Workloads being saved:", workloads.length);
+      console.log("Labels being saved:", JSON.stringify(labelObject, null, 2));
+      console.log("Append mode:", appendLabels);
+      
+      // Add a slight delay to show loading state
+      setTimeout(() => {
+        onBulkSave(workloads, labelObject);
+        setSaving(false);
+        onClose();
+      }, 300);
+    } else if (workload) {
+      setSaving(true);
+      
+      const labelObject: { [key: string]: string } = {};
+      labels.forEach(({ key, value }) => {
+        labelObject[key] = value;
+      });
 
-    console.log("===== LABEL SAVE DEBUG =====");
-    console.log("Workload being saved:", JSON.stringify(workload, null, 2));
-    console.log("Labels being saved:", JSON.stringify(labelObject, null, 2));
-    
-    
-    // Add a slight delay to show loading state
-    setTimeout(() => {
-      onSave(
-        workload.name, 
-        workload.namespace || "default", 
-        workload.kind, 
-        labelObject
-      );
-      setSaving(false);
-      onClose();
-    }, 300);
+      console.log("===== LABEL SAVE DEBUG =====");
+      console.log("Workload being saved:", JSON.stringify(workload, null, 2));
+      console.log("Labels being saved:", JSON.stringify(labelObject, null, 2));
+      
+      // Add a slight delay to show loading state
+      setTimeout(() => {
+        onSave(
+          workload.name, 
+          workload.namespace || "default", 
+          workload.kind, 
+          labelObject
+        );
+        setSaving(false);
+        onClose();
+      }, 300);
+    }
   };
 
   const toggleSearchMode = () => {
@@ -1204,10 +1372,15 @@ const LabelEditDialog: React.FC<LabelEditDialogProps> = ({
         <div className="flex items-center gap-2">
           <LabelIcon style={{ color: colors.primary }} />
           <Typography variant="h6" component="span">
-            Edit Labels for <span style={{ fontWeight: 'bold' }}>{workload?.name}</span> 
-            <Typography component="span" style={{ fontSize: '0.8rem', marginLeft: '8px', color: colors.textSecondary }}>
-              ({workload?.kind})
-            </Typography>
+            {isBulkEdit 
+              ? `Edit Labels for ${workloads.length} Resources` 
+              : `Edit Labels for ${workload?.name}`}
+            
+            {!isBulkEdit && workload && (
+              <Typography component="span" style={{ fontSize: '0.8rem', marginLeft: '8px', color: colors.textSecondary }}>
+                ({workload.kind})
+              </Typography>
+            )}
           </Typography>
         </div>
         <IconButton onClick={onClose} size="small" style={{ color: colors.textSecondary }}>
@@ -1215,7 +1388,38 @@ const LabelEditDialog: React.FC<LabelEditDialogProps> = ({
         </IconButton>
       </DialogTitle>
       
-      <DialogContent style={{ padding: '24px' }}>
+      <DialogContent style={{ padding: '20px 24px' }}>
+        {isBulkEdit && (
+          <Box mb={2} pb={2} borderBottom={`1px solid ${colors.border}`}>
+            <Typography variant="subtitle2" style={{ marginBottom: '8px', color: colors.textSecondary }}>
+              Bulk Edit Mode
+            </Typography>
+            <Typography variant="body2" style={{ marginBottom: '12px', color: colors.textSecondary }}>
+              You are editing labels for {workloads.length} resources. The changes will be applied to all selected resources.
+            </Typography>
+            
+            <FormControlLabel
+              control={
+                <Checkbox 
+                  checked={appendLabels} 
+                  onChange={(e) => setAppendLabels(e.target.checked)}
+                  sx={{
+                    color: colors.primary,
+                    '&.Mui-checked': {
+                      color: colors.primary,
+                    },
+                  }}
+                />
+              }
+              label={
+                <Typography variant="body2">
+                  Append to existing labels (unchecking will replace all existing labels)
+                </Typography>
+              }
+            />
+          </Box>
+        )}
+        
         <div className="mb-6">
           <div className="flex items-center justify-between mb-4">
             <Typography variant="body2" style={{ color: colors.textSecondary }}>
@@ -1446,21 +1650,19 @@ const LabelEditDialog: React.FC<LabelEditDialogProps> = ({
         </div>
       </DialogContent>
       
-      <DialogActions 
+      <DialogActions
         style={{ 
           padding: '16px 24px',
           borderTop: `1px solid ${colors.border}`,
-          justifyContent: 'space-between',
         }}
       >
         <Button 
           onClick={onClose}
+          variant="outlined"
           style={{ 
+            borderColor: colors.border,
             color: colors.textSecondary,
           }}
-          variant="text"
-          startIcon={<CloseIcon />}
-          disabled={saving}
         >
           Cancel
         </Button>
@@ -1489,10 +1691,22 @@ const SelectWorkloadDialog: React.FC<SelectWorkloadDialogProps> = ({
   onClose,
   workloads,
   onSelectWorkload,
+  onSelectWorkloads,
   isDark,
   colors
 }) => {
   const [searchTerm, setSearchTerm] = useState('');
+  const [selectedItems, setSelectedItems] = useState<Record<string, boolean>>({});
+  const [bulkSelectMode, setBulkSelectMode] = useState(false);
+  
+  // Reset selections when dialog opens
+  useEffect(() => {
+    if (open) {
+      setSelectedItems({});
+      setBulkSelectMode(false);
+      setSearchTerm('');
+    }
+  }, [open]);
   
   const filteredWorkloads = searchTerm 
     ? workloads.filter(workload => 
@@ -1506,6 +1720,31 @@ const SelectWorkloadDialog: React.FC<SelectWorkloadDialogProps> = ({
         )
       )
     : workloads;
+    
+  const toggleItemSelection = (workload: Workload) => {
+    const workloadId = `${workload.kind}-${workload.namespace || 'default'}-${workload.name}`;
+    setSelectedItems(prev => ({
+      ...prev,
+      [workloadId]: !prev[workloadId]
+    }));
+  };
+  
+  const toggleBulkSelectMode = () => {
+    setBulkSelectMode(!bulkSelectMode);
+    if (!bulkSelectMode) {
+      // When entering bulk mode, clear any existing selections
+      setSelectedItems({});
+    }
+  };
+  
+  const getSelectedWorkloads = () => {
+    return workloads.filter(workload => {
+      const workloadId = `${workload.kind}-${workload.namespace || 'default'}-${workload.name}`;
+      return selectedItems[workloadId];
+    });
+  };
+  
+  const selectedCount = Object.values(selectedItems).filter(Boolean).length;
 
   return (
     <Dialog
@@ -1538,7 +1777,7 @@ const SelectWorkloadDialog: React.FC<SelectWorkloadDialogProps> = ({
       >
         <div className="flex items-center gap-2">
           <Typography variant="h6" component="span">
-            Select Workload to Edit
+            {bulkSelectMode ? "Select Multiple Workloads" : "Select Workload to Edit"}
           </Typography>
         </div>
         <IconButton onClick={onClose} size="small" style={{ color: colors.textSecondary }}>
@@ -1547,6 +1786,32 @@ const SelectWorkloadDialog: React.FC<SelectWorkloadDialogProps> = ({
       </DialogTitle>
       
       <DialogContent style={{ padding: '16px 24px' }}>
+        <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
+          <FormControlLabel
+            control={
+              <Checkbox 
+                checked={bulkSelectMode} 
+                onChange={toggleBulkSelectMode}
+                sx={{
+                  color: colors.primary,
+                  '&.Mui-checked': {
+                    color: colors.primary,
+                  },
+                }}
+              />
+            }
+            label="Bulk Edit Mode"
+          />
+          
+          {bulkSelectMode && selectedCount > 0 && (
+            <Chip 
+              label={`${selectedCount} selected`}
+              color="primary"
+              size="small"
+            />
+          )}
+        </Box>
+        
         <TextField
           placeholder="Search workloads..."
           value={searchTerm}
@@ -1607,94 +1872,127 @@ const SelectWorkloadDialog: React.FC<SelectWorkloadDialogProps> = ({
           }}
         >
           {filteredWorkloads.length > 0 ? (
-            filteredWorkloads.map((workload) => (
-              <ListItemButton
-                key={`${workload.kind}-${workload.namespace || 'default'}-${workload.name}`}
-                onClick={() => onSelectWorkload(workload)}
-                sx={{
-                  borderRadius: '8px',
-                  mb: 1,
-                  border: `1px solid ${colors.border}`,
-                  backgroundColor: isDark ? 'rgba(47, 134, 255, 0.08)' : 'rgba(47, 134, 255, 0.04)',
-                  '&:hover': {
-                    backgroundColor: isDark ? 'rgba(47, 134, 255, 0.15)' : 'rgba(47, 134, 255, 0.08)',
-                  },
-                  transition: 'all 0.2s ease',
-                }}
-              >
-                <ListItemText 
-                  primary={
-                    <React.Fragment>
-                      {workload.name}
-                      <Chip
-                        size="small"
-                        label={workload.kind}
-                        sx={{
-                          ml: 1,
-                          fontSize: '0.7rem',
-                          height: 20,
-                          bgcolor: isDark
-                            ? alpha(colors.secondary, 0.2)
-                            : alpha(colors.secondary, 0.1),
-                          color: isDark
-                            ? colors.secondary
-                            : colors.secondary,
-                        }}
-                      />
-                    </React.Fragment>
-                  } 
-                  secondary={
-                    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, mt: 0.5 }}>
-                      <Typography variant="caption" sx={{ color: colors.textSecondary }}>
-                        {workload.namespace || 'default'}
-                      </Typography>
-                      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-                        {Object.entries(workload.labels || {}).slice(0, 3).map(([key, value]) => (
-                          <Chip
-                            key={`${key}-${value}`}
-                            size="small"
-                            label={`${key}=${value}`}
-                            sx={{ 
-                              height: 20,
-                              fontSize: '0.7rem',
-                              bgcolor: alpha(colors.primary, 0.1),
-                              color: colors.primary,
-                            }}
-                          />
-                        ))}
-                        {Object.keys(workload.labels || {}).length > 3 && (
-                          <Chip
-                            size="small"
-                            label={`+${Object.keys(workload.labels || {}).length - 3} more`}
-                            sx={{ 
-                              height: 20,
-                              fontSize: '0.7rem',
-                              bgcolor: alpha(colors.secondary, 0.1),
-                              color: colors.secondary,
-                            }}
-                          />
-                        )}
-                      </Box>
-                    </Box>
-                  }
-                  primaryTypographyProps={{
-                    style: { 
-                      color: colors.text,
-                      fontWeight: 500,
-                      display: 'flex',
-                      alignItems: 'center',
+            filteredWorkloads.map((workload) => {
+              const workloadId = `${workload.kind}-${workload.namespace || 'default'}-${workload.name}`;
+              const isSelected = !!selectedItems[workloadId];
+              
+              return (
+                <ListItemButton
+                  key={workloadId}
+                  onClick={() => {
+                    if (bulkSelectMode) {
+                      toggleItemSelection(workload);
+                    } else {
+                      onSelectWorkload(workload);
                     }
                   }}
-                  secondaryTypographyProps={{
-                    style: { 
-                      color: colors.textSecondary,
+                  sx={{
+                    borderRadius: '8px',
+                    mb: 1,
+                    border: `1px solid ${colors.border}`,
+                    backgroundColor: isSelected
+                      ? (isDark ? 'rgba(47, 134, 255, 0.2)' : 'rgba(47, 134, 255, 0.1)')
+                      : (isDark ? 'rgba(47, 134, 255, 0.08)' : 'rgba(47, 134, 255, 0.04)'),
+                    '&:hover': {
+                      backgroundColor: isSelected 
+                        ? (isDark ? 'rgba(47, 134, 255, 0.25)' : 'rgba(47, 134, 255, 0.15)')
+                        : (isDark ? 'rgba(47, 134, 255, 0.15)' : 'rgba(47, 134, 255, 0.08)'),
                     },
-                    component: 'div'
+                    transition: 'all 0.2s ease',
                   }}
-                />
-                <EditIcon fontSize="small" sx={{ color: colors.primary, opacity: 0.7 }} />
-              </ListItemButton>
-            ))
+                >
+                  {bulkSelectMode && (
+                    <Checkbox 
+                      checked={isSelected}
+                      onChange={() => toggleItemSelection(workload)}
+                      onClick={(e) => e.stopPropagation()}
+                      sx={{
+                        color: colors.primary,
+                        '&.Mui-checked': {
+                          color: colors.primary,
+                        },
+                        marginRight: 1,
+                        padding: 0,
+                      }}
+                    />
+                  )}
+                  
+                  <ListItemText 
+                    primary={
+                      <React.Fragment>
+                        {workload.name}
+                        <Chip
+                          size="small"
+                          label={workload.kind}
+                          sx={{
+                            ml: 1,
+                            fontSize: '0.7rem',
+                            height: 20,
+                            bgcolor: isDark
+                              ? alpha(colors.secondary, 0.2)
+                              : alpha(colors.secondary, 0.1),
+                            color: isDark
+                              ? colors.secondary
+                              : colors.secondary,
+                          }}
+                        />
+                      </React.Fragment>
+                    } 
+                    secondary={
+                      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, mt: 0.5 }}>
+                        <Typography variant="caption" sx={{ color: colors.textSecondary }}>
+                          {workload.namespace || 'default'}
+                        </Typography>
+                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                          {Object.entries(workload.labels || {}).slice(0, 3).map(([key, value]) => (
+                            <Chip
+                              key={`${key}-${value}`}
+                              size="small"
+                              label={`${key}=${value}`}
+                              sx={{ 
+                                height: 20,
+                                fontSize: '0.7rem',
+                                bgcolor: alpha(colors.primary, 0.1),
+                                color: colors.primary,
+                              }}
+                            />
+                          ))}
+                          {Object.keys(workload.labels || {}).length > 3 && (
+                            <Chip
+                              size="small"
+                              label={`+${Object.keys(workload.labels || {}).length - 3} more`}
+                              sx={{ 
+                                height: 20,
+                                fontSize: '0.7rem',
+                                bgcolor: alpha(colors.secondary, 0.1),
+                                color: colors.secondary,
+                              }}
+                            />
+                          )}
+                        </Box>
+                      </Box>
+                    }
+                    primaryTypographyProps={{
+                      style: { 
+                        color: colors.text,
+                        fontWeight: 500,
+                        display: 'flex',
+                        alignItems: 'center',
+                      }
+                    }}
+                    secondaryTypographyProps={{
+                      style: { 
+                        color: colors.textSecondary,
+                      },
+                      component: 'div'
+                    }}
+                  />
+                  {!bulkSelectMode && (
+                    <EditIcon fontSize="small" sx={{ color: colors.primary, opacity: 0.7 }} />
+                  )}
+                </ListItemButton>
+              );
+            })
           ) : (
             <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', py: 4 }}>
               <Typography variant="body1" sx={{ color: colors.text, fontWeight: 500, mb: 1 }}>
@@ -1716,13 +2014,28 @@ const SelectWorkloadDialog: React.FC<SelectWorkloadDialogProps> = ({
       >
         <Button 
           onClick={onClose}
+          variant="outlined"
           style={{ 
+            borderColor: colors.border,
             color: colors.textSecondary,
           }}
-          variant="text"
         >
           Cancel
         </Button>
+        
+        {bulkSelectMode && (
+          <Button 
+            onClick={() => onSelectWorkloads(getSelectedWorkloads())}
+            variant="contained"
+            disabled={selectedCount === 0}
+            style={{ 
+              backgroundColor: colors.primary,
+              color: colors.white,
+            }}
+          >
+            Edit {selectedCount} Resources
+          </Button>
+        )}
       </DialogActions>
     </Dialog>
   );

--- a/src/components/ClustersTable.tsx
+++ b/src/components/ClustersTable.tsx
@@ -61,6 +61,8 @@ interface ClustersTableProps {
   currentPage: number;
   totalPages: number;
   onPageChange: (page: number) => void;
+  initialShowCreateOptions?: boolean;
+  initialActiveOption?: string;
 }
 
 // Add a new ColorTheme interface before the LabelEditDialogProps interface
@@ -544,14 +546,16 @@ const ClustersTable: React.FC<ClustersTableProps> = ({
   currentPage,
   totalPages,
   onPageChange,
+  initialShowCreateOptions = false,
+  initialActiveOption = "option1",
 }) => {
   const [query, setQuery] = useState("");
   const [filteredClusters, setFilteredClusters] = useState<ManagedClusterInfo[]>(clusters);
   const [filter, setFilter] = useState<string>("");
   const [selectAll, setSelectAll] = useState(false);
   const [selectedClusters, setSelectedClusters] = useState<string[]>([]);
-  const [showCreateOptions, setShowCreateOptions] = useState(false);
-  const [activeOption, setActiveOption] = useState<string | null>("option1");
+  const [showCreateOptions, setShowCreateOptions] = useState(initialShowCreateOptions);
+  const [activeOption, setActiveOption] = useState<string | null>(initialActiveOption);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [selectedCluster, setSelectedCluster] = useState<ManagedClusterInfo | null>(null);
   const [loadingClusterEdit, setLoadingClusterEdit] = useState<string | null>(null);
@@ -564,6 +568,15 @@ const ClustersTable: React.FC<ClustersTableProps> = ({
 
   const { useUpdateClusterLabels } = useClusterQueries();
   const updateLabelsMutation = useUpdateClusterLabels();
+
+  // Initialize with initial props if provided
+  useEffect(() => {
+    if (initialShowCreateOptions) {
+      setShowCreateOptions(true);
+      // Set the active option to "kubeconfig" for import dialog
+      setActiveOption(initialActiveOption);
+    }
+  }, [initialShowCreateOptions, initialActiveOption]);
 
   // Add useEffect for keyboard shortcuts
   useEffect(() => {
@@ -929,7 +942,7 @@ const ClustersTable: React.FC<ClustersTableProps> = ({
             )}
           >
             <MenuItem value="">All Status</MenuItem>
-            <MenuItem value="active">
+            <MenuItem value="active✓">
               <span className="flex items-center gap-2">
                 <span className="w-3 h-3 rounded-full" style={{ backgroundColor: colors.success }}></span>
                 Active

--- a/src/components/TreeViewComponent.tsx
+++ b/src/components/TreeViewComponent.tsx
@@ -51,6 +51,7 @@ import ListViewComponent from "../components/ListViewComponent";
 import ContextDropdown from "../components/ContextDropdown";
 import { ResourceItem as ListResourceItem } from "./ListViewComponent"; // Import ResourceItem from ListViewComponent
 import useLabelHighlightStore from "../stores/labelHighlightStore";
+import { useLocation } from "react-router-dom";
 
 // Interfaces
 export interface NodeData {
@@ -535,6 +536,7 @@ const TreeViewComponent = (_props: TreeViewComponentProps) => {
   const [resources, setResources] = useState<ResourceItem[]>([]);
   const [contextResourceCounts, setContextResourceCounts] = useState<Record<string, number>>({});
   const [totalResourceCount, setTotalResourceCount] = useState<number>(0);
+  const location = useLocation();
 
   const { isConnected, connect, hasValidData } = useWebSocket();
   const NAMESPACE_QUERY_KEY = ["namespaces"];
@@ -584,6 +586,15 @@ const TreeViewComponent = (_props: TreeViewComponentProps) => {
       setDataReceived(true);
     }
   }, [websocketData, dataReceived]);
+
+  // Check for create=true in URL parameter to automatically open dialog
+  useEffect(() => {
+    const searchParams = new URLSearchParams(location.search);
+    if (searchParams.get('create') === 'true') {
+      setShowCreateOptions(true);
+      setActiveOption("option1");
+    }
+  }, [location.search]);
 
   const getTimeAgo = useCallback((timestamp: string | undefined): string => {
     if (!timestamp) return "Unknown";

--- a/src/hooks/queries/useBPQueries.ts
+++ b/src/hooks/queries/useBPQueries.ts
@@ -1019,6 +1019,12 @@ export const useBPQueries = () => {
               return;
             }
             
+            // Check if resources is null or undefined before processing
+            if (!resources) {
+              console.warn(`Resources is null for namespace ${namespace}, resourceType ${resourceType}`);
+              return;
+            }
+            
             // Process workload resources
             resources.forEach(resource => {
               if (resource.labels) {
@@ -1045,6 +1051,12 @@ export const useBPQueries = () => {
 
         Object.entries(state.data.clusterScoped).forEach(([resourceType, resources]) => {
           if (excludedTypes.has(resourceType) || !includeClusterResourceTypes.has(resourceType)) {
+            return;
+          }
+          
+          // Check if resources is null or undefined before processing
+          if (!resources) {
+            console.warn(`Resources is null for cluster-scoped resourceType ${resourceType}`);
             return;
           }
           

--- a/src/hooks/queries/useBPQueries.ts
+++ b/src/hooks/queries/useBPQueries.ts
@@ -636,7 +636,7 @@ export const useBPQueries = () => {
         if (!formattedRequest.workloadLabels || Object.keys(formattedRequest.workloadLabels).length === 0) {
           console.warn("No workload labels provided");
           formattedRequest.workloadLabels = {
-            'kubernetes.io/kubestellar.workload.name': 'unknown' // Fallback default
+            'kubestellar.io/workload': 'unknown' // Fallback default
           };
         }
         
@@ -703,7 +703,7 @@ export const useBPQueries = () => {
         if (!formattedRequest.workloadLabels || Object.keys(formattedRequest.workloadLabels).length === 0) {
           console.warn("No workload labels provided for YAML generation");
           formattedRequest.workloadLabels = {
-            'kubernetes.io/kubestellar.workload.name': 'unknown' // Fallback default
+            'kubestellar.io/workload': 'unknown' // Fallback default
           };
         }
         

--- a/src/pages/ITS.tsx
+++ b/src/pages/ITS.tsx
@@ -1,13 +1,24 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useClusterQueries } from '../hooks/queries/useClusterQueries';
 import ClustersTable from '../components/ClustersTable';
 import LoadingFallback from '../components/LoadingFallback';
 import Header from '../components/Header';
+import { useLocation } from 'react-router-dom';
 
 const ITS = () => {
   const { useClusters } = useClusterQueries();
   const [currentPage, setCurrentPage] = useState(1);
   const { data, error, isLoading } = useClusters(currentPage);
+  const [openImportDialog, setOpenImportDialog] = useState(false);
+  const location = useLocation();
+
+  useEffect(() => {
+    // Check if the URL has the import=true parameter
+    const searchParams = new URLSearchParams(location.search);
+    if (searchParams.get('import') === 'true') {
+      setOpenImportDialog(true);
+    }
+  }, [location.search]);
 
   if (isLoading) return (
     <div className="w-full max-w-7xl mx-auto p-4">
@@ -57,6 +68,8 @@ const ITS = () => {
             currentPage={currentPage}
             totalPages={totalPages}
             onPageChange={(page) => setCurrentPage(page)}
+            initialShowCreateOptions={openImportDialog}
+            initialActiveOption="kubeconfig"
           />
         </div>
       </div>


### PR DESCRIPTION
### Description
Added a bulk edit mode where multiple resources can be assigned the labels directly from the click and drop binding policy. Also updated the import cluster and create workload button in click and drop.

### Related Issue
Fixes: #706 and #755

### Changes Made
- Implemented the bulk edit mode for both clusters and workloads.
- Split the cluster panel component into 3 sub components.
-  Now the import button in BP takes directly to import cluster dialog.
-  Same for the create workload button in BP takes directly to the create workload dialog.

### Checklist
Please ensure the following before submitting your PR:
- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.


