### PR TITLE
Add Summary Tab as Initial View for Node Clicks and Hide Logs Tab for Non-Pod Objects

### DIFF
--- a/src/components/WecsDetailsPanel.tsx
+++ b/src/components/WecsDetailsPanel.tsx
@@ -446,13 +446,13 @@ const WecsDetailsPanel = ({
     if (currentPodRef.current !== name || !isOpen) {
       // Clean up existing exec terminal resources
       if (execSocketRef.current) {
-        console.log(`Closing exec socket for previous pod: ${currentPodRef.current}`);
+        // console.log(`Closing exec socket for previous pod: ${currentPodRef.current}`);
         execSocketRef.current.close();
         execSocketRef.current = null;
       }
       
       if (execTerminalInstance.current) {
-        console.log(`Disposing exec terminal for previous pod: ${currentPodRef.current}`);
+        // console.log(`Disposing exec terminal for previous pod: ${currentPodRef.current}`);
         execTerminalInstance.current.dispose();
         execTerminalInstance.current = null;
       }
@@ -470,13 +470,13 @@ const WecsDetailsPanel = ({
     const fetchContainers = async () => {
       setLoadingContainers(true);
       try {
-        console.log(`Fetching containers for pod: ${name}`);
+        // console.log(`Fetching containers for pod: ${name}`);
         const response = await api.get(`/list/container/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}?context=${encodeURIComponent(cluster)}`);
         if (response.data && response.data.data) {
           setContainers(response.data.data);
           // Set the first container as selected by default if available
           if (response.data.data.length > 0) {
-            console.log(`Setting default container to: ${response.data.data[0].ContainerName}`);
+            // console.log(`Setting default container to: ${response.data.data[0].ContainerName}`);
             setSelectedContainer(response.data.data[0].ContainerName);
           }
         }
@@ -497,7 +497,7 @@ const WecsDetailsPanel = ({
   useEffect(() => {
     if (type.toLowerCase() === "pod") {
       const newKey = `${cluster}-${namespace}-${name}-${selectedContainer}-${Date.now()}`;
-      console.log(`Updating exec terminal key: ${newKey}`);
+      // console.log(`Updating exec terminal key: ${newKey}`);
       setExecTerminalKey(newKey);
     }
   }, [cluster, namespace, name, type, selectedContainer]);
@@ -525,17 +525,17 @@ const WecsDetailsPanel = ({
     // Only initialize exec terminal when the exec tab is active
     if (!execTerminalRef.current || type.toLowerCase() !== "pod" || tabValue !== 3) return;
     
-    console.log(`Initializing exec terminal for pod: ${name}, container: ${selectedContainer}, key: ${execTerminalKey}`);
+    // console.log(`Initializing exec terminal for pod: ${name}, container: ${selectedContainer}, key: ${execTerminalKey}`);
     
     // Always clean up previous terminal when switching to the exec tab
     if (execTerminalInstance.current) {
-      console.log(`Disposing previous exec terminal for pod: ${currentPodRef.current}`);
+      // console.log(`Disposing previous exec terminal for pod: ${currentPodRef.current}`);
       execTerminalInstance.current.dispose();
       execTerminalInstance.current = null;
     }
     
     if (execSocketRef.current) {
-      console.log(`Closing previous exec socket for pod: ${currentPodRef.current}`);
+      // console.log(`Closing previous exec socket for pod: ${currentPodRef.current}`);
       execSocketRef.current.close();
       execSocketRef.current = null;
     }
@@ -585,7 +585,7 @@ const WecsDetailsPanel = ({
         }
         
         term.open(execTerminalRef.current);
-        console.log(`Terminal opened successfully for pod: ${name}`);
+        // console.log(`Terminal opened successfully for pod: ${name}`);
         
         setTimeout(() => {
           try {
@@ -622,7 +622,7 @@ const WecsDetailsPanel = ({
       execSocketRef.current = socket;
     
     socket.onopen = () => {
-        console.log(`WebSocket connection established for pod: ${name}, container: ${containerName}`);
+        // console.log(`WebSocket connection established for pod: ${name}, container: ${containerName}`);
       // Completely clear the terminal once connected
       term.reset();
       term.clear();
@@ -640,7 +640,7 @@ const WecsDetailsPanel = ({
         }
       } catch {
         // If it's not JSON, write it directly
-          console.log(`Received raw message: ${event.data}`);
+          // console.log(`Received raw message: ${event.data}`);
         term.writeln(event.data);
       }
     };
@@ -651,7 +651,7 @@ const WecsDetailsPanel = ({
     };
     
     socket.onclose = (event) => {
-        console.log(`WebSocket closed for pod ${name}:`, event);
+        // console.log(`WebSocket closed for pod ${name}:`, event);
       if (event.code !== 1000 && event.code !== 1001) {
           term.writeln(`\x1b[31mConnection closed\x1b[0m`);
       }
@@ -686,7 +686,7 @@ const WecsDetailsPanel = ({
       currentPodRef.current = name;
     
     return () => {
-        console.log(`Cleaning up exec terminal resources for pod: ${name}`);
+        // console.log(`Cleaning up exec terminal resources for pod: ${name}`);
       clearInterval(pingInterval);
         
         if (socket && socket.readyState === WebSocket.OPEN) {
@@ -708,7 +708,7 @@ const WecsDetailsPanel = ({
   useEffect(() => {
     // Reset container selection and containers list when pod changes
     if (type.toLowerCase() === "pod") {
-      console.log(`Pod changed to ${name}, resetting container selection`);
+      // console.log(`Pod changed to ${name}, resetting container selection`);
       setSelectedContainer("");
       setContainers([]);
     }
@@ -750,7 +750,7 @@ const WecsDetailsPanel = ({
   const handleClose = () => {
     // Don't close if container selection is active
     if (isContainerSelectActive) {
-      console.log("Container select is active, preventing panel close");
+      // console.log("Container select is active, preventing panel close");
       return;
     }
     
@@ -1251,7 +1251,7 @@ const WecsDetailsPanel = ({
                         size="small" 
                         className="container-dropdown"
                         onMouseDown={() => {
-                          console.log("Container dropdown interaction started");
+                          // console.log("Container dropdown interaction started");
                           setIsContainerSelectActive(true);
                         }}
                         sx={{ 
@@ -1278,11 +1278,11 @@ const WecsDetailsPanel = ({
                           displayEmpty
                           onMouseDown={(e: React.MouseEvent<HTMLElement>) => {
                             e.stopPropagation();
-                            console.log("Select mousedown");
+                            // console.log("Select mousedown");
                             setIsContainerSelectActive(true);
                           }}
                           onClose={() => {
-                            console.log("Select dropdown closed");
+                            // console.log("Select dropdown closed");
                             // Delay setting this to false to allow click events to process first
                             setTimeout(() => setIsContainerSelectActive(false), 300);
                           }}
@@ -1346,7 +1346,7 @@ const WecsDetailsPanel = ({
                               }}
                               onMouseDown={(e: React.MouseEvent<HTMLLIElement>) => {
                                 e.stopPropagation();
-                                console.log(`MenuItem ${container.ContainerName} mousedown`);
+                                // console.log(`MenuItem ${container.ContainerName} mousedown`);
                                 setIsContainerSelectActive(true);
                               }}
                             >

--- a/src/components/WecsTopology.tsx
+++ b/src/components/WecsTopology.tsx
@@ -50,6 +50,7 @@ import ListViewComponent from "../components/ListViewComponent";
 // Updated Interfaces
 export interface NodeData {
   label: JSX.Element;
+  isDeploymentOrJobPod?: boolean;
 }
 
 export interface BaseNode {
@@ -175,6 +176,7 @@ interface SelectedNode {
   resourceData?: ResourceItem;
   initialTab?: number;
   cluster?: string;
+  isDeploymentOrJobPod?: boolean;
 }
 
 interface ContextMenuState {
@@ -608,6 +610,13 @@ const WecsTreeview = () => {
       const timeAgo = getTimeAgo(timestamp);
       const cachedNode = nodeCache.current.get(id);
 
+      // Check if this is a pod that belongs to a Deployment, ReplicaSet, or Job
+      let isDeploymentOrJobPod = false;
+      if (type.toLowerCase() === "pod" && parent) {
+        const parentType = parent.split(":")[0]?.toLowerCase();
+        isDeploymentOrJobPod = ["deployment", "replicaset", "job"].includes(parentType);
+      }
+
       const node =
         cachedNode ||
         ({
@@ -640,12 +649,15 @@ const WecsTreeview = () => {
                     onClose: handleClosePanel,
                     isOpen: true,
                     resourceData,
+                    initialTab: 0,
                     cluster,
+                    isDeploymentOrJobPod,
                   });
                 }}
                 onMenuClick={(e) => handleMenuOpen(e, id)}
               />
             ),
+            isDeploymentOrJobPod,
           },
           position: { x: 0, y: 0 },
           style: {
@@ -1061,7 +1073,7 @@ const WecsTreeview = () => {
             namespace = nodeIdParts[2];
             cluster = nodeIdParts[1];
           } else if (nodeIdParts.length >= 4) {
-            nodeType = "pod";
+            nodeType = nodeIdParts[0].toLowerCase();
             namespace = nodeIdParts[2];
             cluster = nodeIdParts[1];
           } else {
@@ -1069,6 +1081,7 @@ const WecsTreeview = () => {
           }
 
           const resourceData = node.data.label.props.resourceData;
+          const isDeploymentOrJobPod = node.data.isDeploymentOrJobPod;
 
           switch (action) {
             case "Details":
@@ -1081,6 +1094,7 @@ const WecsTreeview = () => {
                 resourceData,
                 initialTab: 0,
                 cluster,
+                isDeploymentOrJobPod,
               });
               break;
             case "Edit":
@@ -1093,19 +1107,23 @@ const WecsTreeview = () => {
                 resourceData,
                 initialTab: 1,
                 cluster,
+                isDeploymentOrJobPod,
               });
               break;
             case "Logs":
-              setSelectedNode({
-                namespace: namespace || "default",
-                name: nodeName,
-                type: nodeType,
-                onClose: handleClosePanel,
-                isOpen: true,
-                resourceData,
-                initialTab: 2,
-                cluster,
-              });
+              if (nodeType === "pod" && isDeploymentOrJobPod) {
+                setSelectedNode({
+                  namespace: namespace || "default",
+                  name: nodeName,
+                  type: nodeType,
+                  onClose: handleClosePanel,
+                  isOpen: true,
+                  resourceData,
+                  initialTab: 2,
+                  cluster,
+                  isDeploymentOrJobPod,
+                });
+              }
               break;
             default:
               break;
@@ -1343,6 +1361,7 @@ const WecsTreeview = () => {
           isOpen={selectedNode?.isOpen || false}
           initialTab={selectedNode?.initialTab}
           cluster={selectedNode?.cluster || ""}
+          isDeploymentOrJobPod={selectedNode?.isDeploymentOrJobPod}
         />
       </div>
     </Box>


### PR DESCRIPTION
### Description
This PR improves the UX by setting the Summary tab as the default view when a user clicks on any node in the topology. Additionally, it removes/hides the Logs tab for all objects except Pod objects, reducing clutter for unsupported views.

### Changes Made
<!-- Provide a detailed list of changes made in this PR. -->
- [x]  Set Summary tab as the default/initial tab on node click
- [x]  Removed/hid the Logs tab for non-pod objects

### Checklist
Please ensure the following before submitting your PR:
- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.