### PR TITLE
Refactor status message handling in CheckKubeStellarStatus function

### DIFF
--- a/backend/installer/kubestellar_status.go
+++ b/backend/installer/kubestellar_status.go
@@ -57,7 +57,7 @@ func CheckKubeStellarStatus() KubeStellarStatus {
 			}
 
 			status.AllReady = status.WDS1Namespace && status.ITS1Namespace
-			
+
 			// Set the appropriate message based on namespace status
 			if status.AllReady {
 				status.Message = "KubeStellar context and required namespaces verified"

--- a/backend/installer/kubestellar_status.go
+++ b/backend/installer/kubestellar_status.go
@@ -57,7 +57,20 @@ func CheckKubeStellarStatus() KubeStellarStatus {
 			}
 
 			status.AllReady = status.WDS1Namespace && status.ITS1Namespace
-			status.Message = "KubeStellar context and required namespaces verified"
+			
+			// Set the appropriate message based on namespace status
+			if status.AllReady {
+				status.Message = "KubeStellar context and required namespaces verified"
+			} else {
+				missingNamespaces := []string{}
+				if !status.WDS1Namespace {
+					missingNamespaces = append(missingNamespaces, "wds1-system")
+				}
+				if !status.ITS1Namespace {
+					missingNamespaces = append(missingNamespaces, "its1-system")
+				}
+				status.Message = fmt.Sprintf("KubeStellar context found, but required namespaces are missing: %s", strings.Join(missingNamespaces, ", "))
+			}
 			break
 		}
 	}


### PR DESCRIPTION
# Pull Request Description
## Problem
The KubeStellar status checker function (`CheckKubeStellarStatus()`) currently reports a success message ("KubeStellar context and required namespaces verified") even when the required namespaces (`wds1-system` and `its1-system`) are not found.

This leads to misleading status reports where the message indicates success but the boolean flags correctly show that the namespaces are missing:
```json
{"context":"k3d-kubeflex","contextFound":true,"wds1Namespace":false,"its1Namespace":false,"allReady":false,"message":"KubeStellar context and required namespaces verified"}
```

## Solution
This PR updates the status message logic to accurately reflect the state of the verification:
1. Only show the success message when both required namespaces are actually found
2. Show a clearer error message when namespaces are missing
3. Fix grammatical issues in the error message

## Changes
```go
// Before
status.Message = "KubeStellar context and required namespaces verified"

// After
if status.AllReady {
    status.Message = "KubeStellar context and required namespaces verified"
} else {
    status.Message = "KubeStellar context found, but the required namespaces are missing"
}
```

## Testing
- Manually verified with missing namespaces, confirming the error message is now accurate
- Verified with all namespaces present, confirming the success message appears correctly

Fixes issue #768