### PR TITLE
Update KubeStellar status check for multiple context types

### DIFF
--- a/backend/installer/kubestellar_status.go
+++ b/backend/installer/kubestellar_status.go
@@ -36,10 +36,10 @@ func CheckKubeStellarStatus() KubeStellarStatus {
 	}
 
 	contexts := strings.Split(strings.TrimSpace(string(contextsOutput)), "\n")
-	
+
 	// Define the compatible context types to check
 	compatibleTypes := []string{"kubeflex", "kind", "k3d"}
-	
+
 	// Check all contexts to find any compatible one
 	for _, ctx := range contexts {
 		isCompatible := false
@@ -49,7 +49,7 @@ func CheckKubeStellarStatus() KubeStellarStatus {
 				break
 			}
 		}
-		
+
 		if isCompatible {
 			// Found a compatible context
 			status.Context = ctx
@@ -75,7 +75,7 @@ func CheckKubeStellarStatus() KubeStellarStatus {
 				status.Message = fmt.Sprintf("KubeStellar ready on context %s with all required namespaces", ctx)
 				return status // Found a fully working context, return immediately
 			}
-			
+
 			// If not ready, update the message and continue checking other contexts
 			missingNamespaces := []string{}
 			if !status.WDS1Namespace {
@@ -84,11 +84,11 @@ func CheckKubeStellarStatus() KubeStellarStatus {
 			if !status.ITS1Namespace {
 				missingNamespaces = append(missingNamespaces, "its1-system")
 			}
-			status.Message = fmt.Sprintf("Compatible context %s found, but required namespaces are missing: %s", 
+			status.Message = fmt.Sprintf("Compatible context %s found, but required namespaces are missing: %s",
 				ctx, strings.Join(missingNamespaces, ", "))
 		}
 	}
-	
+
 	// If we get here, we didn't find any fully working context
 	return status
 }

--- a/backend/installer/kubestellar_status.go
+++ b/backend/installer/kubestellar_status.go
@@ -16,7 +16,7 @@ type KubeStellarStatus struct {
 	Message       string `json:"message"`
 }
 
-// CheckKubeStellarStatus checks for a context containing "kubestellar" and required namespaces
+// CheckKubeStellarStatus checks for contexts containing "kubeflex", "kind", or "k3d" and required namespaces
 func CheckKubeStellarStatus() KubeStellarStatus {
 	status := KubeStellarStatus{
 		Context:       "",
@@ -24,7 +24,7 @@ func CheckKubeStellarStatus() KubeStellarStatus {
 		WDS1Namespace: false,
 		ITS1Namespace: false,
 		AllReady:      false,
-		Message:       "KubeStellar context not found",
+		Message:       "No compatible KubeStellar context found",
 	}
 
 	// Get all kubectl contexts
@@ -36,9 +36,22 @@ func CheckKubeStellarStatus() KubeStellarStatus {
 	}
 
 	contexts := strings.Split(strings.TrimSpace(string(contextsOutput)), "\n")
-
+	
+	// Define the compatible context types to check
+	compatibleTypes := []string{"kubeflex", "kind", "k3d"}
+	
+	// Check all contexts to find any compatible one
 	for _, ctx := range contexts {
-		if strings.Contains(ctx, "kubeflex") {
+		isCompatible := false
+		for _, ctxType := range compatibleTypes {
+			if strings.Contains(ctx, ctxType) {
+				isCompatible = true
+				break
+			}
+		}
+		
+		if isCompatible {
+			// Found a compatible context
 			status.Context = ctx
 			status.ContextFound = true
 
@@ -56,24 +69,26 @@ func CheckKubeStellarStatus() KubeStellarStatus {
 				status.ITS1Namespace = true
 			}
 
-			status.AllReady = status.WDS1Namespace && status.ITS1Namespace
-
-			// Set the appropriate message based on namespace status
-			if status.AllReady {
-				status.Message = "KubeStellar context and required namespaces verified"
-			} else {
-				missingNamespaces := []string{}
-				if !status.WDS1Namespace {
-					missingNamespaces = append(missingNamespaces, "wds1-system")
-				}
-				if !status.ITS1Namespace {
-					missingNamespaces = append(missingNamespaces, "its1-system")
-				}
-				status.Message = fmt.Sprintf("KubeStellar context found, but required namespaces are missing: %s", strings.Join(missingNamespaces, ", "))
+			// If this context has all required namespaces, it's ready
+			if status.WDS1Namespace && status.ITS1Namespace {
+				status.AllReady = true
+				status.Message = fmt.Sprintf("KubeStellar ready on context %s with all required namespaces", ctx)
+				return status // Found a fully working context, return immediately
 			}
-			break
+			
+			// If not ready, update the message and continue checking other contexts
+			missingNamespaces := []string{}
+			if !status.WDS1Namespace {
+				missingNamespaces = append(missingNamespaces, "wds1-system")
+			}
+			if !status.ITS1Namespace {
+				missingNamespaces = append(missingNamespaces, "its1-system")
+			}
+			status.Message = fmt.Sprintf("Compatible context %s found, but required namespaces are missing: %s", 
+				ctx, strings.Join(missingNamespaces, ", "))
 		}
 	}
-
+	
+	// If we get here, we didn't find any fully working context
 	return status
 }


### PR DESCRIPTION
Title: Support Multiple Context Types in KubeStellar Status Check

Description:
## What this PR does
This PR enhances the `CheckKubeStellarStatus` function to support multiple context types ("kubeflex", "kind", and "k3d") and properly handle environments with multiple available contexts.

## Changes made
- Modified the context check to look for any of the specified compatible types
- Implemented logic to check all available contexts
- Return early with success when any fully functional context is found
- Maintain backward compatibility with the existing API
- Improved error messages to be more descriptive

## How to test this PR
1. Set up an environment with multiple kubectl contexts (at least one should have a compatible type)
2. Ensure at least one context has both required namespaces
3. Run the installer and verify it correctly identifies the working context
4. Remove the required namespaces and verify appropriate error messages

## Related Issue
Fixes #780

## Screenshots (if applicable)
N/A