### PR TITLE
Feat: Full Screen in WDS, WECS Toggle Component Implementation and Improvements

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { HiBars3CenterLeft, HiArrowRightOnRectangle, HiUserCircle } from "react-icons/hi2";
-import { RxEnterFullScreen, RxExitFullScreen } from "react-icons/rx";
 import { FiLogOut } from "react-icons/fi";
 import { FiSun, FiMoon } from "react-icons/fi";
 import { menu } from "./menu/data";
@@ -12,6 +11,7 @@ import useTheme from "../stores/themeStore";
 import { useHeaderQueries } from '../hooks/queries/useHeaderQueries';
 import HeaderSkeleton from "./ui/HeaderSkeleton";
 import { useAuth, useAuthActions } from '../hooks/useAuth';
+import FullScreenToggle from "./ui/FullScreenToggle";
 
 interface Context {
   name: string;
@@ -25,8 +25,6 @@ const profileIcons = [
 ];
 
 const Header = ({ isLoading }: { isLoading: boolean }) => {
-  const [isFullScreen, setIsFullScreen] = React.useState(false);
-  const element = document.getElementById("root");
   const { useContexts } = useHeaderQueries();
   const { data: contextsData, error } = useContexts();
   const setSelectedCluster = useClusterStore((state) => state.setSelectedCluster)
@@ -49,10 +47,6 @@ const Header = ({ isLoading }: { isLoading: boolean }) => {
   });
 
   const toggleDrawer = () => setDrawerOpen(!isDrawerOpen);
-
-  const toggleFullScreen = () => {
-    setIsFullScreen((prev) => !prev);
-  };
 
   useEffect(() => {
     if (authData?.isAuthenticated) {
@@ -119,18 +113,6 @@ const Header = ({ isLoading }: { isLoading: boolean }) => {
         setSelectedCluster(null);
       });
   }, [setSelectedCluster, setHasAvailableClusters]);
-
-  React.useEffect(() => {
-    if (!isFullScreen && document.fullscreenElement) {
-      document.exitFullscreen().catch((err) => {
-        console.error("Error exiting full screen:", err.message);
-      });
-    } else if (isFullScreen && !document.fullscreenElement) {
-      element?.requestFullscreen({ navigationUI: "auto" }).catch((err) => {
-        console.error("Error entering full screen:", err.message);
-      });
-    }
-  }, [element, isFullScreen]);
 
   const handleClusterChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newCluster = e.target.value;
@@ -350,16 +332,14 @@ const Header = ({ isLoading }: { isLoading: boolean }) => {
           </>
         )}
         
-        <button
-          onClick={toggleFullScreen}
-          className="hidden xl:inline-flex btn btn-circle btn-ghost"
-        >
-          {!isFullScreen ? (
-            <RxEnterFullScreen className="xl:text-xl 2xl:text-2xl 3xl:text-3xl" />
-          ) : (
-            <RxExitFullScreen className="xl:text-xl 2xl:text-2xl 3xl:text-3xl" />
-          )}
-        </button>
+        {/* Replace the fullscreen button with our component */}
+        <div className="hidden xl:inline-flex">
+          <FullScreenToggle 
+            position="inline" 
+            className="btn btn-circle btn-ghost" 
+            iconSize={20}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/components/TreeViewComponent.tsx
+++ b/src/components/TreeViewComponent.tsx
@@ -53,6 +53,7 @@ import ContextDropdown from "../components/ContextDropdown";
 import { ResourceItem as ListResourceItem } from "./ListViewComponent"; // Import ResourceItem from ListViewComponent
 import useLabelHighlightStore from "../stores/labelHighlightStore";
 import { useLocation } from "react-router-dom";
+import FullScreenToggle from "./ui/FullScreenToggle";
 
 // Interfaces
 export interface NodeData {
@@ -1781,8 +1782,10 @@ const TreeViewComponent = (_props: TreeViewComponentProps) => {
     }
   }, [highlightedLabels, dataReceived, websocketData, theme]);
 
+  const containerRef = useRef<HTMLDivElement>(null);
+
   return (
-    <Box sx={{ display: "flex", height: "85vh", width: "100%", position: "relative" }}>
+    <Box ref={containerRef} sx={{ display: "flex", height: "85vh", width: "100%", position: "relative" }}>
       <Box
         sx={{
           flex: 1,
@@ -1935,6 +1938,12 @@ const TreeViewComponent = (_props: TreeViewComponentProps) => {
               <ReactFlowProvider>
                 <FlowCanvas nodes={nodes} edges={edges} renderStartTime={renderStartTime} theme={theme} />
                 <ZoomControls theme={theme} onToggleCollapse={handleToggleCollapse} isCollapsed={isCollapsed} onExpandAll={handleExpandAll} onCollapseAll={handleCollapseAll} />
+                <FullScreenToggle 
+                  containerRef={containerRef} 
+                  position="top-right" 
+                  tooltipPosition="left"
+                  tooltipText="Toggle fullscreen view" 
+                />
               </ReactFlowProvider>
             </Box>
           ) : viewMode === 'list' ? (
@@ -1976,6 +1985,12 @@ const TreeViewComponent = (_props: TreeViewComponentProps) => {
                     </Button>
                   </Box>
                 </Box>
+                <FullScreenToggle 
+                  containerRef={containerRef} 
+                  position="top-right" 
+                  tooltipPosition="left"
+                  tooltipText="Toggle fullscreen view" 
+                />
               </ReactFlowProvider>
             </Box>
           )}

--- a/src/components/WecsTopology.tsx
+++ b/src/components/WecsTopology.tsx
@@ -47,6 +47,7 @@ import useTheme from "../stores/themeStore";
 import WecsDetailsPanel from "./WecsDetailsPanel";
 import { FlowCanvas } from "./Wds_Topology/FlowCanvas";
 import ListViewComponent from "../components/ListViewComponent";
+import FullScreenToggle from "./ui/FullScreenToggle";
 
 // Updated Interfaces
 export interface NodeData {
@@ -544,6 +545,7 @@ const WecsTreeview = () => {
   const prevWecsData = useRef<WecsCluster[] | null>(null);
   const stateRef = useRef({ isCollapsed, isExpanded });
   const [viewMode, setViewMode] = useState<'tiles' | 'list'>('tiles');
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const { wecsIsConnected, hasValidWecsData, wecsData } = useWebSocket();
 
@@ -1292,7 +1294,7 @@ const WecsTreeview = () => {
   const isLoading = !wecsIsConnected || !hasValidWecsData || isTransforming || !minimumLoadingTimeElapsed;
 
   return (
-    <Box sx={{ display: "flex", height: "85vh", width: "100%", position: "relative" }}>
+    <Box ref={containerRef} sx={{ display: "flex", height: "85vh", width: "100%", position: "relative" }}>
       <Box
         sx={{
           flex: 1,
@@ -1423,6 +1425,12 @@ const WecsTreeview = () => {
               <ReactFlowProvider>
                 <FlowCanvas nodes={nodes} edges={edges} renderStartTime={renderStartTime} theme={theme} />
                 <ZoomControls theme={theme} onToggleCollapse={handleToggleCollapse} isCollapsed={isCollapsed} onExpandAll={handleExpandAll} onCollapseAll={handleCollapseAll} />
+                <FullScreenToggle 
+                  containerRef={containerRef} 
+                  position="top-right" 
+                  tooltipPosition="left"
+                  tooltipText="Toggle fullscreen view" 
+                />
               </ReactFlowProvider>
             </Box>
           ) : (

--- a/src/components/ui/FullScreenToggle.tsx
+++ b/src/components/ui/FullScreenToggle.tsx
@@ -1,0 +1,221 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { RxEnterFullScreen, RxExitFullScreen } from 'react-icons/rx';
+import useTheme from '../../stores/themeStore';
+
+// Define interfaces for browser-specific fullscreen APIs
+interface FullscreenElement extends HTMLElement {
+  webkitRequestFullscreen?: () => Promise<void>;
+  mozRequestFullScreen?: () => Promise<void>;
+  msRequestFullscreen?: () => Promise<void>;
+}
+
+interface FullscreenDocument extends Document {
+  webkitExitFullscreen?: () => Promise<void>;
+  mozCancelFullScreen?: () => Promise<void>;
+  msExitFullscreen?: () => Promise<void>;
+  webkitFullscreenElement?: Element | null;
+  mozFullScreenElement?: Element | null;
+  msFullscreenElement?: Element | null;
+}
+
+interface FullScreenToggleProps {
+  containerRef?: React.RefObject<HTMLElement>;
+  className?: string;
+  iconSize?: number;
+  position?: 'top-right' | 'bottom-right' | 'top-left' | 'bottom-left' | 'inline';
+  tooltipPosition?: 'top' | 'bottom' | 'left' | 'right';
+  tooltipText?: string;
+  onFullScreenChange?: (isFullScreen: boolean) => void;
+}
+
+const FullScreenToggle: React.FC<FullScreenToggleProps> = ({
+  containerRef,
+  className = '',
+  iconSize = 24,
+  position = 'top-right',
+  tooltipPosition = 'bottom',
+  tooltipText = 'Toggle fullscreen',
+  onFullScreenChange,
+}) => {
+  const [isFullScreen, setIsFullScreen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isHovered, setIsHovered] = useState(false);
+  const theme = useTheme((state) => state.theme);
+
+  const handleFullScreenChange = useCallback(() => {
+    const doc = document as FullscreenDocument;
+    const fullscreenElement = 
+      doc.fullscreenElement || 
+      doc.webkitFullscreenElement || 
+      doc.mozFullScreenElement || 
+      doc.msFullscreenElement;
+    
+    setIsFullScreen(!!fullscreenElement);
+    onFullScreenChange?.(!!fullscreenElement);
+    setError(null);
+  }, [onFullScreenChange]);
+
+  useEffect(() => {
+    // Check initial fullscreen state
+    handleFullScreenChange();
+
+    // Add event listeners for fullscreen changes
+    document.addEventListener('fullscreenchange', handleFullScreenChange);
+    document.addEventListener('webkitfullscreenchange', handleFullScreenChange);
+    document.addEventListener('mozfullscreenchange', handleFullScreenChange);
+    document.addEventListener('MSFullscreenChange', handleFullScreenChange);
+
+    return () => {
+      document.removeEventListener('fullscreenchange', handleFullScreenChange);
+      document.removeEventListener('webkitfullscreenchange', handleFullScreenChange);
+      document.removeEventListener('mozfullscreenchange', handleFullScreenChange);
+      document.removeEventListener('MSFullscreenChange', handleFullScreenChange);
+    };
+  }, [handleFullScreenChange]);
+
+  const toggleFullScreen = async () => {
+    try {
+      setError(null);
+      const doc = document as FullscreenDocument;
+      
+      if (!doc.fullscreenElement && 
+          !doc.webkitFullscreenElement && 
+          !doc.mozFullScreenElement && 
+          !doc.msFullscreenElement) {
+        // Enter full screen for the specific container or document
+        const element = (containerRef?.current || document.documentElement) as FullscreenElement;
+        
+        if (element.requestFullscreen) {
+          await element.requestFullscreen();
+        } else if (element.webkitRequestFullscreen) {
+          await element.webkitRequestFullscreen();
+        } else if (element.mozRequestFullScreen) {
+          await element.mozRequestFullScreen();
+        } else if (element.msRequestFullscreen) {
+          await element.msRequestFullscreen();
+        } else {
+          throw new Error('Fullscreen API is not supported in this browser');
+        }
+      } else {
+        // Exit full screen
+        if (doc.exitFullscreen) {
+          await doc.exitFullscreen();
+        } else if (doc.webkitExitFullscreen) {
+          await doc.webkitExitFullscreen();
+        } else if (doc.mozCancelFullScreen) {
+          await doc.mozCancelFullScreen();
+        } else if (doc.msExitFullscreen) {
+          await doc.msExitFullscreen();
+        }
+      }
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to toggle fullscreen';
+      setError(errorMessage);
+      console.error('Error toggling fullscreen:', err);
+    }
+  };
+
+  // Position classes based on the position prop
+  const positionClasses = {
+    'top-right': 'absolute top-4 right-4',
+    'bottom-right': 'absolute bottom-4 right-4',
+    'top-left': 'absolute top-4 left-4',
+    'bottom-left': 'absolute bottom-4 left-4',
+    'inline': '',
+  };
+
+  // Tooltip position classes
+  const tooltipClasses = {
+    'top': 'tooltip-top',
+    'bottom': 'tooltip-bottom',
+    'left': 'tooltip-left',
+    'right': 'tooltip-right',
+  };
+
+  // Button styles based on theme and state
+  const buttonStyles = {
+    base: `
+      btn btn-circle 
+      transition-all duration-300 ease-in-out
+      transform hover:scale-110 active:scale-95
+      shadow-lg hover:shadow-xl
+      backdrop-blur-sm
+      border border-opacity-20
+      focus:outline-none focus:ring-2 focus:ring-offset-2
+    `,
+    dark: `
+      bg-gray-800/80 hover:bg-gray-700/90
+      border-gray-600
+      focus:ring-blue-500
+      ${error ? 'ring-2 ring-red-500' : ''}
+    `,
+    light: `
+      bg-white/90 hover:bg-gray-50/95
+      border-gray-200
+      focus:ring-blue-400
+      ${error ? 'ring-2 ring-red-500' : ''}
+    `,
+  };
+
+  // Icon styles based on theme and state
+  const iconStyles = {
+    base: `
+      transition-all duration-300 ease-in-out
+      ${isHovered ? 'scale-110' : 'scale-100'}
+    `,
+    dark: `
+      text-gray-200 group-hover:text-white
+    `,
+    light: `
+      text-gray-700 group-hover:text-gray-900
+    `,
+  };
+
+  return (
+    <div 
+      className={`
+        tooltip 
+        ${tooltipClasses[tooltipPosition]} 
+        ${position !== 'inline' ? positionClasses[position] : ''} 
+        ${className}
+        group
+      `}
+      data-tip={error || tooltipText}
+    >
+      <button
+        onClick={toggleFullScreen}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+        className={`
+          ${buttonStyles.base}
+          ${theme === 'dark' ? buttonStyles.dark : buttonStyles.light}
+        `}
+        aria-label={error || tooltipText}
+        aria-pressed={isFullScreen}
+        role="switch"
+      >
+        {isFullScreen ? (
+          <RxExitFullScreen 
+            size={iconSize} 
+            className={`
+              ${iconStyles.base}
+              ${theme === 'dark' ? iconStyles.dark : iconStyles.light}
+            `}
+            aria-hidden="true"
+          />
+        ) : (
+          <RxEnterFullScreen 
+            size={iconSize} 
+            className={`
+              ${iconStyles.base}
+              ${theme === 'dark' ? iconStyles.dark : iconStyles.light}
+            `}
+            aria-hidden="true"
+          />
+        )}
+      </button>
+    </div>
+  );
+};
+
+export default FullScreenToggle; 

--- a/src/components/ui/HeaderSkeleton.tsx
+++ b/src/components/ui/HeaderSkeleton.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import useTheme from '../../stores/themeStore';
 import Skeleton from './Skeleton';
 import { FiSun, FiMoon } from 'react-icons/fi';
-import { RxEnterFullScreen } from 'react-icons/rx';
+import FullScreenToggle from './FullScreenToggle';
 
 const HeaderSkeleton: React.FC = () => {
   const theme = useTheme((state) => state.theme);
@@ -59,13 +59,10 @@ const HeaderSkeleton: React.FC = () => {
         </div>
         
         {/* Fullscreen button skeleton with conditional text color */}
-        <div className="hidden xl:inline-flex btn btn-circle btn-ghost pointer-events-none">
-          <RxEnterFullScreen 
-            className="xl:text-xl 2xl:text-2xl 3xl:text-3xl" 
-            style={{ 
-              color: isDark ? 'rgba(255, 255, 255, 0.4)' : 'rgba(0, 0, 0, 0.4)'
-            }}
-          />
+        <div className="hidden xl:inline-flex">
+          <div className="btn btn-circle btn-ghost pointer-events-none opacity-50">
+            <FullScreenToggle position="inline" className="pointer-events-none" />
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# FullScreen Toggle Component Implementation
Fixes #797

## Overview
Added a reusable FullScreen toggle component to enhance the user experience in both WDS and WECS  views. The component provides a consistent and accessible way to toggle fullscreen mode across different parts of the application.

## Changes Made

### 1. Component Creation
- Created a new reusable `FullScreenToggle` component in `src/components/ui/FullScreenToggle.tsx`
- Implemented with TypeScript for better type safety and maintainability
- Added comprehensive prop interface for flexible usage

### 2. Core Features
- **Fullscreen Toggle Functionality**
  - Support for both container-specific and document-level fullscreen
  - Cross-browser compatibility (Chrome, Firefox, Safari, Edge)
  - Proper cleanup of event listeners
  - Error handling for unsupported browsers

- **Accessibility**
  - ARIA attributes for screen readers
  - Keyboard navigation support
  - Focus management
  - Clear visual feedback

- **Theme Support**
  - Dark/Light mode compatibility
  - Consistent styling across themes
  - Smooth transitions between states

### 3. UI/UX Improvements
- **Visual Design**
  - Modern floating button design
  - Semi-transparent background with blur effect
  - Smooth hover and click animations
  - Clear visual feedback for all states

- **Interactive Elements**
  - Scale transform on hover
  - Click feedback
  - Smooth transitions
  - Tooltip integration

#### Key Features
- Position customization
- Tooltip support
- Theme-aware styling
- Error handling
- Event callbacks

### 5. Integration Points

#### WDS Integration
- Added to the WDS topology view
- Positioned in the top-right corner
- Container-specific fullscreen support

#### WECS Integration
- Implemented in the WECS treeview
- Consistent positioning and behavior
- Reused component for maintainability

<img width="1512" alt="Screenshot 2025-05-17 at 4 53 02 PM" src="https://github.com/user-attachments/assets/8da5259c-cf47-4b1e-9792-d4e172c9947f" />


<img width="1512" alt="Screenshot 2025-05-17 at 4 53 13 PM" src="https://github.com/user-attachments/assets/76793a36-d04e-42ef-a850-db1e3c758bc2" />

