### PR TITLE
Add SECURITY.md to Complete Community Standards

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+<!--security-start-->
+## Security Announcements
+
+Join the [kubestellar-security-announce](https://groups.google.com/u/1/g/kubestellar-security-announce) group for emails about security and major API announcements.
+
+## Report a Vulnerability
+
+We're extremely grateful for security researchers and users that report vulnerabilities to the KubeStellar Open Source Community. All reports are thoroughly investigated by a set of community volunteers.
+
+You can also email the private [kubestellar-security-announce@googlegroups.com](mailto:kubestellar-security-announce@googlegroups.com) list with the security details and the details expected for [all KubeStellar bug reports](https://github.com/kubestellar/kubestellar/blob/main/.github/ISSUE_TEMPLATE/bug_report.yaml).
+
+### When Should I Report a Vulnerability?
+
+- You think you discovered a potential security vulnerability in KubeStellar
+- You are unsure how a vulnerability affects KubeStellar
+- You think you discovered a vulnerability in another project that KubeStellar depends on
+  - For projects with their own vulnerability reporting and disclosure process, please report it directly there
+
+
+### When Should I NOT Report a Vulnerability?
+
+- You need help tuning KubeStellar components for security
+- You need help applying security related updates
+- Your issue is not security related
+
+## Security Vulnerability Response
+
+Each report is acknowledged and analyzed by the maintainers of KubeStellar within 3 working days.
+
+Any vulnerability information shared with Security Response Committee stays within KubeStellar project and will not be disseminated to other projects unless it is necessary to get the issue fixed.
+
+As the security issue moves from triage, to identified fix, to release planning we will keep the reporter updated.
+
+## Public Disclosure Timing
+
+A public disclosure date is negotiated by the KubeStellar Security Response Committee and the bug submitter. We prefer to fully disclose the bug as soon as possible once a user mitigation is available. It is reasonable to delay disclosure when the bug or the fix is not yet fully understood, the solution is not well-tested, or for vendor coordination. The timeframe for disclosure is from immediate (especially if it's already publicly known) to a few weeks. For a vulnerability with a straightforward mitigation, we expect report date to disclosure date to be on the order of 7 days. The KubeStellar maintainers hold the final say when setting a disclosure date.
+<!--security-end-->


### PR DESCRIPTION
FIxes #806

This pull request adds a SECURITY.md file to the repository, helping us fulfill the final item in GitHub’s [community standards checklist](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-up-a-project-with-the-community-checklist).

## Details:

- The SECURITY.md has been adapted from the [kubestellar/kubestellar](https://github.com/kubestellar/kubestellar) repository.

- It includes information on how to responsibly disclose vulnerabilities and what to expect in terms of response timelines.
 
- This document also encourages safe and secure collaboration from the open-source community.

##  Benefits:

- Completes GitHub’s recommended community health checklist.

- Establishes clear guidelines for reporting security issues.
