### PR TITLE
Fix/836 update kubestellar version

### DIFF
--- a/src/components/ContextDropdown.tsx
+++ b/src/components/ContextDropdown.tsx
@@ -37,7 +37,7 @@ const ContextDropdown = ({
   const { theme } = useTheme();
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [contextName, setContextName] = useState('');
-  const [contextVersion, setContextVersion] = useState('0.27.0');
+  const [contextVersion, setContextVersion] = useState('0.27.2');
   const [isCreating, setIsCreating] = useState(false);
   const [creationError, setCreationError] = useState('');
   const [creationSuccess, setCreationSuccess] = useState('');
@@ -82,7 +82,7 @@ const ContextDropdown = ({
 
   const handleOpenCreateDialog = () => {
     setContextName('');
-    setContextVersion('0.27.0');
+    setContextVersion('0.27.2');
     setCreationError('');
     setCreationSuccess('');
     setCreateDialogOpen(true);
@@ -130,6 +130,11 @@ const ContextDropdown = ({
   const handleCreateContext = async () => {
     if (!contextName) {
       setCreationError('Context name is required');
+      return;
+    }
+    
+    if (contextName === 'wds2') {
+      setCreationError("Cannot create context named 'wds2' as it's reserved as host");
       return;
     }
 

--- a/src/components/ContextDropdown.tsx
+++ b/src/components/ContextDropdown.tsx
@@ -132,7 +132,7 @@ const ContextDropdown = ({
       setCreationError('Context name is required');
       return;
     }
-    
+
     if (contextName === 'wds2') {
       setCreationError("Cannot create context named 'wds2' as it's reserved as host");
       return;


### PR DESCRIPTION
### Description

This PR updates the KubeStellar version from 0.27.0 to 0.27.2 and adds validation to prevent the creation of a context named "wds2" as it's reserved as a host. These changes ensure compatibility with the latest KubeStellar version and prevent potential conflicts with reserved context names.

### Related Issue

Fixes #836

### Changes Made

- [x] Updated KubeStellar version from 0.27.0 to 0.27.2 in `ContextDropdown.tsx` and `InstallationPage.tsx`
- [x] Added validation to prevent creation of a context named "wds2" as it's reserved as a host

### Checklist

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs

**Context Creation Validation:**