### PR TITLE
fix: add vendor folder to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,7 @@ coverage
 
 # Node modules
 node_modules
+vendor
 
 # Logs
 *.log


### PR DESCRIPTION
### Description

This PR adds the `vendor` directory to the [.prettierignore] to prevent Prettier from checking files in the vendor directory during pre-commit hooks. This is a common practice to avoid unnecessary formatting of third-party code.

### Related Issue

Fixes #849

### Changes Made

- Added `vendor` to [.prettierignore] to exclude vendor directory from Prettier checks

### Checklist

- [x] I have reviewed the project's contribution guidelines.
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Additional Notes
