### PR TITLE
fix: show logs tab for pods from StatefulSet, DaemonSet and check own…

### DIFF
--- a/src/components/WecsTopology.tsx
+++ b/src/components/WecsTopology.tsx
@@ -280,7 +280,7 @@ const getLayoutedElements = (
 
   // Step 1: Initial Dagre layout
   const dagreGraph = new dagre.graphlib.Graph();
-  dagreGraph.setDefaultEdgeLabel(() => ({}));
+  dagreGraph.setDefaultEdgeLabel(() => "");
   dagreGraph.setGraph({ rankdir: direction, nodesep: NODE_SEP, ranksep: RANK_SEP });
 
   const nodeMap = new Map<string, CustomNode>();

--- a/src/components/WecsTopology.tsx
+++ b/src/components/WecsTopology.tsx
@@ -280,7 +280,7 @@ const getLayoutedElements = (
 
   // Step 1: Initial Dagre layout
   const dagreGraph = new dagre.graphlib.Graph();
-  dagreGraph.setDefaultEdgeLabel(() => "");
+  dagreGraph.setDefaultEdgeLabel(() => '');
   dagreGraph.setGraph({ rankdir: direction, nodesep: NODE_SEP, ranksep: RANK_SEP });
 
   const nodeMap = new Map<string, CustomNode>();

--- a/src/components/WecsTopology.tsx
+++ b/src/components/WecsTopology.tsx
@@ -677,15 +677,24 @@ const WecsTreeview = () => {
       let isDeploymentOrJobPod = false;
       if (type.toLowerCase() === 'pod' && parent) {
         const parentType = parent.split(':')[0]?.toLowerCase();
-        isDeploymentOrJobPod = ['deployment', 'replicaset', 'job', 'statefulset', 'daemonset'].includes(parentType);
-        
+        isDeploymentOrJobPod = [
+          'deployment',
+          'replicaset',
+          'job',
+          'statefulset',
+          'daemonset',
+        ].includes(parentType);
+
         // If not determined by parent, check resourceData for owner references
         if (!isDeploymentOrJobPod && resourceData?.raw) {
           try {
             const podData = JSON.parse(resourceData.raw);
             if (podData.metadata?.ownerReferences) {
-              isDeploymentOrJobPod = podData.metadata.ownerReferences.some((owner: OwnerReference) => 
-                ['Deployment', 'ReplicaSet', 'Job', 'StatefulSet', 'DaemonSet'].includes(owner.kind)
+              isDeploymentOrJobPod = podData.metadata.ownerReferences.some(
+                (owner: OwnerReference) =>
+                  ['Deployment', 'ReplicaSet', 'Job', 'StatefulSet', 'DaemonSet'].includes(
+                    owner.kind
+                  )
               );
             }
           } catch (e) {


### PR DESCRIPTION
## fix: show logs tab for pods from StatefulSet, DaemonSet, and check owner references

This PR resolves [issue #855](https://github.com/kubestellar/ui/issues/855).

- Expands the logic for displaying the pod logs tab to include pods managed by **StatefulSets** and **DaemonSets**, not just Deployments, ReplicaSets, and Jobs.
- Also checks the pod's `ownerReferences` to ensure pods created by Helm charts (like Drupal) are properly detected and the logs tab is shown.

### How to test

1. Deploy Drupal or any Helm chart that creates pods not directly under a Deployment/ReplicaSet/Job.
2. The pod logs tab should now appear for those pods in the UI.
Will be adding screenshots in a little while
---

Closes #855