### PR TITLE
Updated the Closure of Create Bp dialog

### DIFF
--- a/src/components/BindingPolicy/CreateBindingPolicyDialog.tsx
+++ b/src/components/BindingPolicy/CreateBindingPolicyDialog.tsx
@@ -619,10 +619,10 @@ const CreateBindingPolicyDialog: React.FC<CreateBindingPolicyDialogProps> = ({
 
       setSuccessMessage('Binding policy created successfully');
       handleClearPolicyCanvas();
-      onClose();
     } catch (error) {
       console.error('Error creating binding policy:', error);
       toast.error('Failed to create binding policy');
+      setIsLoading(false);
     }
   };
 
@@ -880,7 +880,6 @@ const CreateBindingPolicyDialog: React.FC<CreateBindingPolicyDialogProps> = ({
         setShowDeployDialog(false);
         handleClearPolicyCanvas();
         setIsLoading(false);
-        onClose();
       } catch (error) {
         console.error('Failed to create binding policy:', error);
         setDeploymentError(

--- a/src/hooks/queries/useBPQueries.ts
+++ b/src/hooks/queries/useBPQueries.ts
@@ -549,7 +549,7 @@ export const useBPQueries = () => {
         }, 1500); // 1.5 second delay to ensure status change is captured
       },
       onError: (error: Error) => {
-        toast.error('Failed to create binding policy');
+        // toast.error('Failed to create binding policy new check');
         console.error('Mutation error:', error);
       },
     });

--- a/src/pages/BP.tsx
+++ b/src/pages/BP.tsx
@@ -701,7 +701,6 @@ const BP = () => {
         setBindingPolicies(current =>
           current.filter(policy => !results.success.includes(policy.name))
         );
-
       } else {
         setSuccessMessage(
           `Deleted ${results.success.length} policies, but failed to delete ${results.failures.length} policies`

--- a/src/pages/BP.tsx
+++ b/src/pages/BP.tsx
@@ -590,16 +590,9 @@ const BP = () => {
         // Use the mutation for creating a binding policy
         await createBindingPolicyMutation.mutateAsync(formattedPolicyData);
 
-        // Close the dialog and show success message
         setCreateDialogOpen(false);
-        setSuccessMessage(`Binding Policy "${policyData.name}" created successfully`);
       } catch (error) {
         console.error('Error creating binding policy:', error);
-        // Still close the dialog but show error message
-        setCreateDialogOpen(false);
-        setSuccessMessage(
-          `Error creating Binding Policy "${policyData.name}": ${error instanceof Error ? error.message : 'Unknown error'}`
-        );
       }
     },
     [createBindingPolicyMutation, setSuccessMessage, setCreateDialogOpen]
@@ -709,7 +702,6 @@ const BP = () => {
           current.filter(policy => !results.success.includes(policy.name))
         );
 
-        setSuccessMessage(`Successfully deleted ${results.success.length} binding policies`);
       } else {
         setSuccessMessage(
           `Deleted ${results.success.length} policies, but failed to delete ${results.failures.length} policies`


### PR DESCRIPTION
### Description

Removed the bottom toast on delete binding policy.
Updated the create bp dialog to do not close on error just show the error
Made the error message on fail more clear



### Checklist

Please ensure the following before submitting your PR:

- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.


