### PR TITLE
fix: remove redundant token verification after login

### DIFF
--- a/src/hooks/queries/useLogin.ts
+++ b/src/hooks/queries/useLogin.ts
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useWebSocket } from '../../context/WebSocketProvider';
 import toast from 'react-hot-toast';
 import axios from 'axios';
-import { LoginUser, VerifyToken } from '../../api/auth';
+import { LoginUser } from '../../api/auth';
 import { AUTH_QUERY_KEY } from '../../api/auth/constant';
 
 interface LoginCredentials {
@@ -36,16 +36,7 @@ export const useLogin = () => {
           localStorage.removeItem('rememberedPassword');
         }
 
-        // Verify token to ensure it's valid
-        try {
-          const token = localStorage.getItem('jwtToken');
-          if (token) {
-            await VerifyToken(token);
-          }
-        } catch (verifyError) {
-          console.error('Token verification failed:', verifyError);
-          // Continue anyway since we just received the token
-        }
+        // Token is assumed valid since we just received it from the server
 
         return response;
       } catch (error) {

--- a/src/hooks/queries/useLogin.ts
+++ b/src/hooks/queries/useLogin.ts
@@ -36,8 +36,6 @@ export const useLogin = () => {
           localStorage.removeItem('rememberedPassword');
         }
 
-        // Token is assumed valid since we just received it from the server
-
         return response;
       } catch (error) {
         console.error('Login error:', error);


### PR DESCRIPTION
# Remove redundant token verification


## Description
This PR removes an unnecessary token verification that happens during the login process. The token is verified immediately after being received from the server, which is redundant since:
1. The token is fresh from the server
2. The verification result is ignored anyway
3. The `useAuth` hook will verify the token when needed

## Changes
- Removed redundant token verification in [useLogin.ts]
- Removed unused import


