### PR TITLE
Feat/dashboard for plugins

### DIFF
--- a/backend/plugin/common/types.go
+++ b/backend/plugin/common/types.go
@@ -1,0 +1,37 @@
+package common
+
+import "github.com/gin-gonic/gin"
+
+// Plugin defines the interface that all plugins must implement
+type Plugin interface {
+	// Name returns the unique name of the plugin
+	Name() string
+	
+	// Version returns the version of the plugin
+	Version() string
+	
+	// Enabled returns an integer indicating if the plugin is enabled
+	// Non-zero values indicate the plugin is enabled
+	Enabled() int
+	
+	// Description returns a user-friendly description of the plugin
+	Description() string
+	
+	// Routes returns information about the routes this plugin exposes
+	Routes() []PluginRoutesMeta
+}
+
+// PluginRoutesMeta contains metadata about a plugin's route
+type PluginRoutesMeta struct {
+	// Method is the HTTP method (GET, POST, DELETE, etc.)
+	Method string
+	
+	// Path is the URL path for the route
+	Path string
+	
+	// Description is a user-friendly description of what the route does
+	Description string
+	
+	// Handler is the route handler function
+	Handler func(c *gin.Context)
+}

--- a/backend/plugin/common/types.go
+++ b/backend/plugin/common/types.go
@@ -6,17 +6,17 @@ import "github.com/gin-gonic/gin"
 type Plugin interface {
 	// Name returns the unique name of the plugin
 	Name() string
-	
+
 	// Version returns the version of the plugin
 	Version() string
-	
+
 	// Enabled returns an integer indicating if the plugin is enabled
 	// Non-zero values indicate the plugin is enabled
 	Enabled() int
-	
+
 	// Description returns a user-friendly description of the plugin
 	Description() string
-	
+
 	// Routes returns information about the routes this plugin exposes
 	Routes() []PluginRoutesMeta
 }
@@ -25,13 +25,13 @@ type Plugin interface {
 type PluginRoutesMeta struct {
 	// Method is the HTTP method (GET, POST, DELETE, etc.)
 	Method string
-	
+
 	// Path is the URL path for the route
 	Path string
-	
+
 	// Description is a user-friendly description of what the route does
 	Description string
-	
+
 	// Handler is the route handler function
 	Handler func(c *gin.Context)
 }

--- a/backend/plugin/plugin.go
+++ b/backend/plugin/plugin.go
@@ -1,25 +1,16 @@
 package plugin
 
-import "github.com/gin-gonic/gin"
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/kubestellar/ui/plugin/common"
+)
 
-// plugin interface defines methods that a KS plugin must implement
-type Plugin interface {
-	// name of the plugin
-	Name() string
-	// version of your plugin
-	Version() string
-	// plugin enabled or disabled 1 for enabled 0 for disabled
-	Enabled() int
-	// routes and http methods to communicate with this plugin to do operations
-	Routes() []PluginRoutesMeta
-}
+// Plugin is an alias for common.Plugin interface to maintain backward compatibility
+type Plugin = common.Plugin
 
-// Metadata about routes of the plugin
+// PluginRoutesMeta extends common.PluginRoutesMeta with handler functionality
 type PluginRoutesMeta struct {
-	// http method
-	Method string
-	// route path
-	Path string
+	common.PluginRoutesMeta
 	// route handler
 	Handler func(c *gin.Context)
 }

--- a/backend/plugin/plugins/backup_plugin.go
+++ b/backend/plugin/plugins/backup_plugin.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/kubestellar/ui/k8s"
 	"github.com/kubestellar/ui/log"
-	"github.com/kubestellar/ui/plugin"
+	"github.com/kubestellar/ui/plugin/common"
 	"go.uber.org/zap"
 	v1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -34,22 +34,28 @@ func (p backupPlugin) Name() string {
 func (p backupPlugin) Version() string {
 	return pluginVersion
 }
+
+func (p backupPlugin) Description() string {
+	return "A plugin for taking database backups of the KubeStellar system"
+}
+
 func (p backupPlugin) Enabled() int {
 	return 1
-
 }
-func (p backupPlugin) Routes() []plugin.PluginRoutesMeta {
+func (p backupPlugin) Routes() []common.PluginRoutesMeta {
 
-	routes := []plugin.PluginRoutesMeta{}
-	routes = append(routes, plugin.PluginRoutesMeta{
-		Method:  http.MethodGet,
-		Path:    "/plugins/backup-plugin/",
-		Handler: rootHandler,
+	routes := []common.PluginRoutesMeta{}
+	routes = append(routes, common.PluginRoutesMeta{
+		Method:      http.MethodGet,
+		Path:        "/plugins/backup-plugin/",
+		Description: "Get basic information about the backup plugin",
+		Handler:     rootHandler,
 	})
-	routes = append(routes, plugin.PluginRoutesMeta{
-		Method:  http.MethodGet,
-		Path:    "/plugins/backup-plugin/snapshot",
-		Handler: takeSnapshot,
+	routes = append(routes, common.PluginRoutesMeta{
+		Method:      http.MethodGet,
+		Path:        "/plugins/backup-plugin/snapshot",
+		Description: "Take a snapshot backup of the KubeStellar database",
+		Handler:     takeSnapshot,
 	})
 
 	return routes

--- a/backend/plugin/plugins/manager.go
+++ b/backend/plugin/plugins/manager.go
@@ -7,15 +7,13 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/kubestellar/ui/log"
-	"github.com/kubestellar/ui/plugin"
+	"github.com/kubestellar/ui/plugin/common"
 	"go.uber.org/zap"
 )
 
-// this file contains the plugin Manager implementation  for KS
-// a centralized manager that handles our plugins
-
+// pluginManager is a centralized manager that handles KubeStellar plugins
 type pluginManager struct {
-	plugins map[string]plugin.Plugin
+	plugins map[string]common.Plugin
 	mx      sync.Mutex
 }
 
@@ -59,7 +57,7 @@ func (pm *pluginManager) SetupPluginsRoutes(e *gin.Engine) {
 }
 
 // registers a plugin to plugin Manager
-func (pm *pluginManager) Register(p plugin.Plugin) {
+func (pm *pluginManager) Register(p common.Plugin) {
 	pm.mx.Lock()
 	defer pm.mx.Unlock()
 	pm.plugins[p.Name()] = p
@@ -67,11 +65,29 @@ func (pm *pluginManager) Register(p plugin.Plugin) {
 }
 
 // deregisters  a plugin to plugin manager
-func (pm *pluginManager) Deregister(p plugin.Plugin) {
+func (pm *pluginManager) Deregister(p common.Plugin) {
 	pm.mx.Lock()
 	defer pm.mx.Unlock()
 	delete(pm.plugins, p.Name())
 	log.LogInfo("deregistered plugin", zap.String("NAME", p.Name()))
 }
 
-var Pm *pluginManager = &pluginManager{plugins: map[string]plugin.Plugin{}}
+// GetPlugins returns all registered plugins
+func (pm *pluginManager) GetPlugins() []common.Plugin {
+	pm.mx.Lock()
+	defer pm.mx.Unlock()
+	plugins := make([]common.Plugin, 0, len(pm.plugins))
+	for _, p := range pm.plugins {
+		plugins = append(plugins, p)
+	}
+	return plugins
+}
+
+// GetPlugin returns a specific plugin by name
+func (pm *pluginManager) GetPlugin(name string) common.Plugin {
+	pm.mx.Lock()
+	defer pm.mx.Unlock()
+	return pm.plugins[name]
+}
+
+var Pm *pluginManager = &pluginManager{plugins: map[string]common.Plugin{}}

--- a/backend/routes/plugins.go
+++ b/backend/routes/plugins.go
@@ -1,0 +1,126 @@
+package routes
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/kubestellar/ui/plugin/common"
+	"github.com/kubestellar/ui/plugin/plugins"
+)
+
+// PluginResponse represents plugin information returned to the frontend
+type PluginResponse struct {
+	Name        string            `json:"name"`
+	Version     string            `json:"version"`
+	Enabled     bool              `json:"enabled"`
+	Type        string            `json:"type"` // "static" or "dynamic"
+	Status      string            `json:"status"`
+	Description string            `json:"description"`
+	Routes      []PluginRouteInfo `json:"routes"`
+}
+
+// PluginRouteInfo represents route information for a plugin
+type PluginRouteInfo struct {
+	Method      string `json:"method"`
+	Path        string `json:"path"`
+	Description string `json:"description,omitempty"`
+}
+
+// setupPluginRoutes registers plugin API endpoints
+func setupPluginRoutes(router *gin.Engine) {
+	api := router.Group("/api")
+	{
+		api.GET("/plugins", listPlugins)
+		api.GET("/plugins/:name", getPluginDetails)
+	}
+}
+
+// listPlugins returns a list of all registered plugins
+func listPlugins(c *gin.Context) {
+	allPlugins := plugins.Pm.GetPlugins()
+	result := make([]PluginResponse, 0, len(allPlugins))
+
+	for _, p := range allPlugins {
+		routes := make([]PluginRouteInfo, 0)
+		for _, r := range p.Routes() {
+			routes = append(routes, PluginRouteInfo{
+				Method:      r.Method,
+				Path:        r.Path,
+				Description: getRouteDescription(r),
+			})
+		}
+
+		status := PluginResponse{
+			Name:        p.Name(),
+			Version:     p.Version(),
+			Enabled:     p.Enabled() > 0,
+			Type:        "static", // Default to static for now
+			Status:      getPluginStatus(p),
+			Description: p.Description(),
+			Routes:      routes,
+		}
+
+		result = append(result, status)
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// getPluginDetails returns details for a specific plugin
+func getPluginDetails(c *gin.Context) {
+	name := c.Param("name")
+	p := plugins.Pm.GetPlugin(name)
+
+	if p == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Plugin not found"})
+		return
+	}
+
+	routes := make([]PluginRouteInfo, 0)
+	for _, r := range p.Routes() {
+		routes = append(routes, PluginRouteInfo{
+			Method:      r.Method,
+			Path:        r.Path,
+			Description: getRouteDescription(r),
+		})
+	}
+
+	status := PluginResponse{
+		Name:        p.Name(),
+		Version:     p.Version(),
+		Enabled:     p.Enabled() > 0,
+		Type:        "static", // Default to static for now
+		Status:      getPluginStatus(p),
+		Description: p.Description(),
+		Routes:      routes,
+	}
+
+	c.JSON(http.StatusOK, status)
+}
+
+// getPluginStatus returns the plugin status string
+func getPluginStatus(p common.Plugin) string {
+	if p.Enabled() > 0 {
+		return "active"
+	}
+	return "inactive"
+}
+
+// getRouteDescription returns a description for a route
+func getRouteDescription(r common.PluginRoutesMeta) string {
+	if r.Description != "" {
+		return r.Description
+	}
+	
+	// Generate a default description based on the path and method
+	switch r.Method {
+	case http.MethodGet:
+		return "Get information from " + r.Path
+	case http.MethodPost:
+		return "Create or update resource at " + r.Path
+	case http.MethodDelete:
+		return "Delete resource at " + r.Path
+	default:
+		return "Operation on " + r.Path
+	}
+}

--- a/backend/routes/plugins.go
+++ b/backend/routes/plugins.go
@@ -111,7 +111,7 @@ func getRouteDescription(r common.PluginRoutesMeta) string {
 	if r.Description != "" {
 		return r.Description
 	}
-	
+
 	// Generate a default description based on the path and method
 	switch r.Method {
 	case http.MethodGet:

--- a/backend/routes/setup.go
+++ b/backend/routes/setup.go
@@ -19,7 +19,7 @@ func SetupRoutes(router *gin.Engine) {
 	setupHelmRoutes(router)
 	setupGitHubRoutes(router)
 	setupDeploymentHistoryRoutes(router)
-	setupPluginRoutes(router) // API endpoints for plugin dashboard
+	setupPluginRoutes(router)             // API endpoints for plugin dashboard
 	plugins.Pm.SetupPluginsRoutes(router) // Plugin-specific endpoints
 
 	setupAuthRoutes(router)

--- a/backend/routes/setup.go
+++ b/backend/routes/setup.go
@@ -19,7 +19,8 @@ func SetupRoutes(router *gin.Engine) {
 	setupHelmRoutes(router)
 	setupGitHubRoutes(router)
 	setupDeploymentHistoryRoutes(router)
-	plugins.Pm.SetupPluginsRoutes(router)
+	setupPluginRoutes(router) // API endpoints for plugin dashboard
+	plugins.Pm.SetupPluginsRoutes(router) // Plugin-specific endpoints
 
 	setupAuthRoutes(router)
 	setupArtifactHubRoutes(router)

--- a/src/components/PluginDetailsPanel.tsx
+++ b/src/components/PluginDetailsPanel.tsx
@@ -1,0 +1,252 @@
+import { useState } from 'react';
+import {
+  Drawer,
+  Box,
+  Typography,
+  IconButton,
+  Divider,
+  Tabs,
+  Tab,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Chip,
+  Button,
+} from '@mui/material';
+import { toast } from 'react-hot-toast';
+import { X, RefreshCw } from 'lucide-react';
+import { Plugin } from '../hooks/usePluginQueries';
+import useTheme from '../stores/themeStore';
+
+interface PluginDetailsPanelProps {
+  plugin: Plugin;
+  onClose: () => void;
+}
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+function TabPanel(props: TabPanelProps) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`plugin-tabpanel-${index}`}
+      aria-labelledby={`plugin-tab-${index}`}
+      {...other}
+    >
+      {value === index && <Box sx={{ p: 3 }}>{children}</Box>}
+    </div>
+  );
+}
+
+const PluginDetailsPanel = ({ plugin, onClose }: PluginDetailsPanelProps) => {
+  const [tabValue, setTabValue] = useState(0);
+  const theme = useTheme(state => state.theme);
+  const isDark = theme === 'dark';
+
+  const handleTabChange = (_: React.SyntheticEvent, newValue: number) => {
+    setTabValue(newValue);
+  };
+
+  const getStatusColor = (status: string) => {
+    switch (status.toLowerCase()) {
+      case 'active':
+        return 'success';
+      case 'inactive':
+        return 'error';
+      default:
+        return 'warning';
+    }
+  };
+
+  // Special handling for the backup plugin
+  const isBackupPlugin = plugin.name === 'backup-plugin';
+
+  return (
+    <Drawer
+      anchor="right"
+      open={true}
+      onClose={onClose}
+      sx={{
+        '& .MuiDrawer-paper': {
+          width: { xs: '100%', sm: 600 },
+          boxSizing: 'border-box',
+          backgroundColor: isDark ? 'rgb(15, 23, 42)' : '#ffffff',
+          color: isDark ? '#f8fafc' : '#334155',
+          borderLeft: isDark
+            ? '1px solid rgba(255, 255, 255, 0.1)'
+            : '1px solid rgba(0, 0, 0, 0.1)',
+        },
+      }}
+    >
+      <Box sx={{ p: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Typography variant="h6">Plugin Details</Typography>
+        <IconButton onClick={onClose} aria-label="close">
+          <X size={20} />
+        </IconButton>
+      </Box>
+      <Divider />
+
+      <Box sx={{ p: 3 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+          <Typography variant="h5">{plugin.name}</Typography>
+          <Chip
+            label={plugin.status}
+            color={getStatusColor(plugin.status) as 'success' | 'error' | 'warning'}
+          />
+        </Box>
+        <Typography variant="body1" sx={{ mb: 2 }}>
+          {plugin.description}
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 2, mb: 3 }}>
+          <Chip label={`Version: ${plugin.version}`} variant="outlined" />
+          <Chip label={`Type: ${plugin.type}`} variant="outlined" />
+        </Box>
+      </Box>
+
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Tabs value={tabValue} onChange={handleTabChange} aria-label="plugin details tabs">
+          <Tab label="API Endpoints" />
+          {isBackupPlugin && <Tab label="Backup Operations" />}
+        </Tabs>
+      </Box>
+
+      <TabPanel value={tabValue} index={0}>
+        <TableContainer
+          component={Paper}
+          variant="outlined"
+          sx={{
+            background: isDark ? 'rgba(15, 23, 42, 0.8)' : undefined,
+            '& .MuiTableCell-head': {
+              fontWeight: 'bold',
+              backgroundColor: isDark ? 'rgba(51, 65, 85, 0.5)' : undefined,
+              color: isDark ? '#f8fafc' : undefined,
+            },
+            '& .MuiTableCell-body': {
+              color: isDark ? '#f1f5f9' : undefined,
+              borderColor: isDark ? 'rgba(148, 163, 184, 0.2)' : undefined,
+            },
+            '& .MuiTableRow-root:hover': {
+              backgroundColor: isDark ? 'rgba(51, 65, 85, 0.3)' : undefined,
+            },
+          }}
+        >
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Method</TableCell>
+                <TableCell>Path</TableCell>
+                <TableCell>Description</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {plugin.routes.map((route, index) => (
+                <TableRow key={index}>
+                  <TableCell>
+                    <Chip
+                      label={route.method}
+                      size="small"
+                      color={
+                        route.method === 'GET'
+                          ? 'primary'
+                          : route.method === 'POST'
+                            ? 'success'
+                            : route.method === 'DELETE'
+                              ? 'error'
+                              : 'default'
+                      }
+                      sx={{ fontWeight: 'bold' }}
+                    />
+                  </TableCell>
+                  <TableCell>{route.path}</TableCell>
+                  <TableCell>{route.description || 'No description available'}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </TabPanel>
+
+      {isBackupPlugin && (
+        <TabPanel value={tabValue} index={1}>
+          <Typography variant="h6" sx={{ mb: 3 }}>
+            Backup Management
+          </Typography>
+
+          <Box sx={{ mb: 4 }}>
+            <Typography variant="subtitle1" sx={{ mb: 2 }}>
+              Create Backup
+            </Typography>
+            <Typography variant="body2" sx={{ mb: 2 }}>
+              Create a snapshot of your KubeStellar database. This will backup all your
+              configuration and settings.
+            </Typography>
+            <Button
+              variant="contained"
+              startIcon={<RefreshCw size={18} />}
+              onClick={() => {
+                toast.loading('Taking database snapshot...', {
+                  id: 'backup-toast',
+                  style: {
+                    background: isDark ? 'rgba(30, 64, 175, 0.9)' : '#3b82f6',
+                    color: '#ffffff',
+                  },
+                });
+
+                fetch('/api/plugins/backup-plugin/snapshot')
+                  .then(response => {
+                    if (response.ok) {
+                      toast.success('Backup snapshot created successfully', {
+                        id: 'backup-toast',
+                        style: {
+                          background: isDark ? 'rgba(4, 120, 87, 0.9)' : '#10b981',
+                          color: '#ffffff',
+                        },
+                      });
+                    } else {
+                      throw new Error('Failed to create backup');
+                    }
+                  })
+                  .catch(error => {
+                    console.error('Backup error:', error);
+                    toast.error('Failed to create backup snapshot', {
+                      id: 'backup-toast',
+                      style: {
+                        background: isDark ? 'rgba(153, 27, 27, 0.9)' : '#dc2626',
+                        color: '#ffffff',
+                      },
+                    });
+                  });
+              }}
+            >
+              Take Snapshot
+            </Button>
+          </Box>
+
+          <Divider sx={{ my: 3 }} />
+
+          <Box>
+            <Typography variant="subtitle1" sx={{ mb: 2 }}>
+              Backup History
+            </Typography>
+            <Typography variant="body2">
+              Feature coming soon: View and restore from previous backups.
+            </Typography>
+          </Box>
+        </TabPanel>
+      )}
+    </Drawer>
+  );
+};
+
+export default PluginDetailsPanel;

--- a/src/components/PluginDetailsPanel.tsx
+++ b/src/components/PluginDetailsPanel.tsx
@@ -109,13 +109,45 @@ const PluginDetailsPanel = ({ plugin, onClose }: PluginDetailsPanelProps) => {
           {plugin.description}
         </Typography>
         <Box sx={{ display: 'flex', gap: 2, mb: 3 }}>
-          <Chip label={`Version: ${plugin.version}`} variant="outlined" />
-          <Chip label={`Type: ${plugin.type}`} variant="outlined" />
+          <Chip
+            label={`Version: ${plugin.version}`}
+            variant="outlined"
+            sx={{
+              color: isDark ? 'rgba(255, 255, 255, 0.7)' : 'inherit',
+              borderColor: isDark ? 'rgba(255, 255, 255, 0.2)' : 'inherit',
+            }}
+          />
+          <Chip
+            label={`Type: ${plugin.type}`}
+            variant="outlined"
+            sx={{
+              color: isDark ? 'rgba(255, 255, 255, 0.7)' : 'inherit',
+              borderColor: isDark ? 'rgba(255, 255, 255, 0.2)' : 'inherit',
+            }}
+          />
         </Box>
       </Box>
 
-      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-        <Tabs value={tabValue} onChange={handleTabChange} aria-label="plugin details tabs">
+      <Box sx={{ borderBottom: 1, borderColor: isDark ? 'rgba(255, 255, 255, 0.1)' : 'divider' }}>
+        <Tabs
+          value={tabValue}
+          onChange={handleTabChange}
+          aria-label="plugin details tabs"
+          sx={{
+            '& .MuiTabs-indicator': {
+              backgroundColor: isDark ? '#3b82f6' : '#1976d2',
+            },
+            '& .MuiTab-root': {
+              color: isDark ? 'rgba(255, 255, 255, 0.7)' : 'rgba(0, 0, 0, 0.6)',
+              '&.Mui-selected': {
+                color: isDark ? '#3b82f6' : '#1976d2',
+              },
+              '&:hover': {
+                color: isDark ? '#60a5fa' : '#115293',
+              },
+            },
+          }}
+        >
           <Tab label="API Endpoints" />
           {isBackupPlugin && <Tab label="Backup Operations" />}
         </Tabs>

--- a/src/components/menu/data.ts
+++ b/src/components/menu/data.ts
@@ -1,6 +1,5 @@
 import { HiOutlineHome, HiOutlineCube, HiOutlineCommandLine } from 'react-icons/hi2';
-
-import { MdPolicy, MdAssuredWorkload } from 'react-icons/md';
+import { MdPolicy, MdAssuredWorkload, MdExtension } from 'react-icons/md';
 
 export const menu = [
   {
@@ -44,6 +43,12 @@ export const menu = [
         url: '/wecs/treeview',
         icon: MdAssuredWorkload,
         label: `Deployed Workloads`,
+      },
+      {
+        isLink: true,
+        url: '/plugins',
+        icon: MdExtension,
+        label: 'Plugins',
       },
     ],
   },

--- a/src/hooks/usePluginQueries.ts
+++ b/src/hooks/usePluginQueries.ts
@@ -1,0 +1,53 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+
+export interface PluginRoute {
+  method: string;
+  path: string;
+  description?: string;
+}
+
+export interface Plugin {
+  name: string;
+  version: string;
+  enabled: boolean;
+  type: string;
+  status: string;
+  description: string;
+  routes: PluginRoute[];
+}
+
+export const usePluginQueries = () => {
+  const usePlugins = () => {
+    return useQuery<Plugin[]>({
+      queryKey: ['plugins'],
+      queryFn: async () => {
+        const response = await api.get<Plugin[]>('/api/plugins');
+        return response.data;
+      },
+      staleTime: 30000, // 30 seconds
+      gcTime: 300000, // 5 minutes
+    });
+  };
+
+  const usePluginDetails = (pluginName: string | undefined) => {
+    return useQuery<Plugin>({
+      queryKey: ['plugins', pluginName],
+      queryFn: async () => {
+        if (!pluginName) {
+          throw new Error('Plugin name is required');
+        }
+        const response = await api.get<Plugin>(`/api/plugins/${pluginName}`);
+        return response.data;
+      },
+      enabled: !!pluginName,
+      staleTime: 30000,
+      gcTime: 300000,
+    });
+  };
+
+  return {
+    usePlugins,
+    usePluginDetails,
+  };
+};

--- a/src/pages/Plugins.tsx
+++ b/src/pages/Plugins.tsx
@@ -1,0 +1,162 @@
+import { useState } from 'react';
+import {
+  Box,
+  Typography,
+  Grid,
+  Card,
+  CardContent,
+  CardActions,
+  Button,
+  Chip,
+  Divider,
+  CircularProgress,
+} from '@mui/material';
+import { toast } from 'react-hot-toast';
+import { usePluginQueries, Plugin } from '../hooks/usePluginQueries';
+import PluginDetailsPanel from '../components/PluginDetailsPanel';
+import useTheme from '../stores/themeStore';
+
+const Plugins = () => {
+  const { usePlugins } = usePluginQueries();
+  const { data: plugins, isLoading, error } = usePlugins();
+  const [selectedPlugin, setSelectedPlugin] = useState<Plugin | null>(null);
+  const theme = useTheme(state => state.theme);
+  const isDark = theme === 'dark';
+
+  const handleViewDetails = (plugin: Plugin) => {
+    setSelectedPlugin(plugin);
+    toast(`Viewing ${plugin.name} details`, {
+      icon: '🔌',
+      style: {
+        background: isDark ? 'rgba(30, 41, 59, 0.9)' : 'rgba(255, 255, 255, 0.9)',
+        color: isDark ? '#fff' : '#334155',
+      },
+    });
+  };
+
+  const handleCloseDetails = () => {
+    setSelectedPlugin(null);
+  };
+
+  const getStatusColor = (status: string) => {
+    switch (status.toLowerCase()) {
+      case 'active':
+        return 'success';
+      case 'inactive':
+        return 'error';
+      default:
+        return 'warning';
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Box display="flex" justifyContent="center" alignItems="center" height="80vh">
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ p: 4 }}>
+        <Typography variant="h6" color="error">
+          Error loading plugins: {error instanceof Error ? error.message : 'Unknown error'}
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (!plugins || plugins.length === 0) {
+    return (
+      <Box sx={{ p: 4 }}>
+        <Typography variant="h6">No plugins available</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: 4 }}>
+      <Typography variant="h4" sx={{ mb: 4 }}>
+        KubeStellar Plugins
+      </Typography>
+      <Typography variant="body1" sx={{ mb: 4 }}>
+        Manage and monitor all available plugins for your KubeStellar instance.
+      </Typography>
+
+      <Grid container spacing={3}>
+        {plugins.map(plugin => (
+          <Grid item xs={12} sm={6} md={4} key={plugin.name}>
+            <Card
+              elevation={3}
+              sx={{
+                height: '100%',
+                display: 'flex',
+                flexDirection: 'column',
+                transition: 'transform 0.2s, box-shadow 0.2s',
+                backgroundColor: isDark ? 'rgba(15, 23, 42, 0.8)' : '#ffffff',
+                border: isDark
+                  ? '1px solid rgba(255, 255, 255, 0.1)'
+                  : '1px solid rgba(0, 0, 0, 0.05)',
+                backdropFilter: 'blur(10px)',
+                '&:hover': {
+                  transform: 'translateY(-4px)',
+                  boxShadow: isDark
+                    ? '0 6px 20px rgba(0, 0, 0, 0.3), 0 0 15px rgba(255, 255, 255, 0.05)'
+                    : '0 6px 20px rgba(0, 0, 0, 0.1)',
+                },
+              }}
+            >
+              <CardContent sx={{ flexGrow: 1 }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    mb: 2,
+                  }}
+                >
+                  <Typography variant="h6" component="div">
+                    {plugin.name}
+                  </Typography>
+                  <Chip
+                    label={plugin.status}
+                    color={getStatusColor(plugin.status) as 'success' | 'error' | 'warning'}
+                    size="small"
+                  />
+                </Box>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                  {plugin.description}
+                </Typography>
+                <Divider sx={{ my: 1.5 }} />
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 2 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    Version: {plugin.version}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    Type: {plugin.type}
+                  </Typography>
+                </Box>
+              </CardContent>
+              <CardActions>
+                <Button
+                  size="small"
+                  onClick={() => handleViewDetails(plugin)}
+                  sx={{ fontWeight: 'medium' }}
+                >
+                  View Details
+                </Button>
+              </CardActions>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+
+      {selectedPlugin && (
+        <PluginDetailsPanel plugin={selectedPlugin} onClose={handleCloseDetails} />
+      )}
+    </Box>
+  );
+};
+
+export default Plugins;

--- a/src/pages/Plugins.tsx
+++ b/src/pages/Plugins.tsx
@@ -11,7 +11,6 @@ import {
   Divider,
   CircularProgress,
 } from '@mui/material';
-import { toast } from 'react-hot-toast';
 import { usePluginQueries, Plugin } from '../hooks/usePluginQueries';
 import PluginDetailsPanel from '../components/PluginDetailsPanel';
 import useTheme from '../stores/themeStore';
@@ -25,13 +24,6 @@ const Plugins = () => {
 
   const handleViewDetails = (plugin: Plugin) => {
     setSelectedPlugin(plugin);
-    toast(`Viewing ${plugin.name} details`, {
-      icon: '🔌',
-      style: {
-        background: isDark ? 'rgba(30, 41, 59, 0.9)' : 'rgba(255, 255, 255, 0.9)',
-        color: isDark ? '#fff' : '#334155',
-      },
-    });
   };
 
   const handleCloseDetails = () => {
@@ -116,7 +108,13 @@ const Plugins = () => {
                     mb: 2,
                   }}
                 >
-                  <Typography variant="h6" component="div">
+                  <Typography
+                    variant="h6"
+                    component="div"
+                    sx={{
+                      color: isDark ? '#f8fafc' : 'inherit',
+                    }}
+                  >
                     {plugin.name}
                   </Typography>
                   <Chip
@@ -125,15 +123,27 @@ const Plugins = () => {
                     size="small"
                   />
                 </Box>
-                <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                <Typography
+                  variant="body2"
+                  sx={{
+                    mb: 2,
+                    color: isDark ? 'rgba(255, 255, 255, 0.7)' : 'text.secondary',
+                  }}
+                >
                   {plugin.description}
                 </Typography>
                 <Divider sx={{ my: 1.5 }} />
                 <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 2 }}>
-                  <Typography variant="caption" color="text.secondary">
+                  <Typography
+                    variant="caption"
+                    sx={{ color: isDark ? 'rgba(255, 255, 255, 0.7)' : 'text.secondary' }}
+                  >
                     Version: {plugin.version}
                   </Typography>
-                  <Typography variant="caption" color="text.secondary">
+                  <Typography
+                    variant="caption"
+                    sx={{ color: isDark ? 'rgba(255, 255, 255, 0.7)' : 'text.secondary' }}
+                  >
                     Type: {plugin.type}
                   </Typography>
                 </Box>

--- a/src/routes/routes-config.tsx
+++ b/src/routes/routes-config.tsx
@@ -12,6 +12,7 @@ import PublicRoute from '../components/PublicRoute';
 import KubeStellarVisualization from '../components/login/index';
 import InstallationPage from '../pages/InstallationPage';
 import KubeStellarStatusChecker from '../components/KubeStellarStatusChecker';
+import Plugins from '../pages/Plugins';
 
 const ClustersLazy = lazy(() => import(/* webpackPrefetch: true */ '../components/Clusters'));
 const ITSLazy = lazy(() => import(/* webpackPrefetch: true */ '../pages/ITS'));
@@ -94,6 +95,14 @@ export const routesConfig: RouteObject[] = [
         element: (
           <ProtectedRoute>
             <WecsTreeview />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: 'plugins',
+        element: (
+          <ProtectedRoute>
+            <Plugins />
           </ProtectedRoute>
         ),
       },


### PR DESCRIPTION
# Plugin Dashboard Implementation

## Description
This PR implements a complete plugin dashboard feature for KubeStellar, including backend API endpoints and frontend components. It enables users to discover and interact with plugins, with special handling for the backup plugin.

## Changes
- **Backend**:
  - Created new API endpoints for plugins at `/api/plugins` and `/api/plugins/:name`
  - Enhanced the plugin interface to include a `Description` method

- **Frontend**:
  - Created a new Plugins dashboard page
  - Implemented plugin details panel with API endpoints view
  - Added special backup operations for the backup plugin

## Screenshots
[Screencast from 2025-05-25 02-56-32.webm](https://github.com/user-attachments/assets/ca4dd545-59d8-448d-9ff3-42d22cf76b09)


## Related Issues
Closes #889
<!-- Add any other context, suggestions, or questions related to this PR. -->
