### PR TITLE
Refactor Dockerfile and docker-compose for build arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,16 @@ COPY .git .git
 # Extract Git commit hash
 RUN git rev-parse HEAD > commit_hash.txt
 
-ENV VITE_APP_VERSION=0.1.0
-# Skip prerequisites check in Docker environment
-ENV VITE_SKIP_PREREQUISITES_CHECK=true
+# Accept build arguments
+ARG VITE_APP_VERSION=0.1.0
+ARG VITE_SKIP_PREREQUISITES_CHECK=true
+ARG VITE_BASE_URL
+
+# Set environment variables from build args
+ENV VITE_APP_VERSION=$VITE_APP_VERSION
+ENV VITE_SKIP_PREREQUISITES_CHECK=$VITE_SKIP_PREREQUISITES_CHECK
+ENV VITE_BASE_URL=$VITE_BASE_URL
+
 # Build frontend
 RUN npm run build
 
@@ -33,9 +40,6 @@ RUN mv commit_hash.txt dist/
 FROM nginx:alpine AS frontend
 COPY --from=frontend-builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
-
-# Pass environment variables to runtime (needed for client-side apps)
-ENV VITE_SKIP_PREREQUISITES_CHECK=true
 
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,10 @@ services:
   frontend:
     build:
       dockerfile: Dockerfile
+      args:
+        - VITE_BASE_URL=http://localhost:4000
+        - VITE_SKIP_PREREQUISITES_CHECK=true
+        - VITE_APP_VERSION=0.1.0
     ports:
       - '5173:80'
     depends_on:


### PR DESCRIPTION
# Fix Docker build failure due to missing environment variables

## Description
Fixes issue #912 where Docker build was failing because `VITE_BASE_URL` environment variable was not available during the build stage.

## Problem
The `vite-plugin-environment` plugin was throwing an error during `npm run build` because environment variables defined in `docker-compose.yml` are only available at runtime, not during the Docker build process.

```
Error: vite-plugin-environment: the `VITE_BASE_URL` environment variable is undefined.
```

## Solution
- Updated `Dockerfile` to accept build arguments for all required environment variables
- Modified `docker-compose.yml` to pass environment variables as build arguments
- Ensured all Vite environment variables are available during the build stage

## Changes Made

### Dockerfile
- Added `ARG` declarations for all Vite environment variables
- Set `ENV` variables from build arguments
- Removed redundant environment variable declarations

### docker-compose.yml
- Added `build.args` section to pass environment variables during build
- Maintained existing `environment` section for runtime compatibility

## Files Changed
- `Dockerfile`
- `docker-compose.yml`

## Testing
- [x] Docker build completes successfully
- [x] Frontend container starts without errors
- [x] Application loads with correct configuration
- [x] All environment variables are properly injected

## Before/After

### Before
```bash
docker-compose build
# ❌ Build failed with vite-plugin-environment error
```

### After
```bash
docker-compose build
# ✅ Build completes successfully
docker-compose up
# ✅ All services start correctly
```

## Breaking Changes
None. This is a backwards-compatible fix that maintains existing functionality while resolving the build issue.

## Related Issues
Closes #912

---

**Author:** @pranvhname
**Reviewers:** Please verify that the build works correctly in your local environment.