### PR TITLE
Fixed the cacheing issues of Binding Policy

### DIFF
--- a/backend/wds/bp/handlers.go
+++ b/backend/wds/bp/handlers.go
@@ -38,7 +38,7 @@ type WorkloadInfo struct {
 }
 
 // Global store for binding policies created via the UI
-var uiCreatedPolicies = make(map[string]*StoredBindingPolicy)
+var UICreatedPolicies = make(map[string]*StoredBindingPolicy)
 
 // BindingPolicyWithStatus adds status information to the BindingPolicy
 type BindingPolicyWithStatus struct {
@@ -60,9 +60,18 @@ func GetBindingPolicies(namespace string) ([]map[string]interface{}, error) {
 	if err != nil {
 		log.LogWarn("failed to get binding policies from Redis cache", zap.Error(err))
 	} else if cachedPolicies != nil && len(cachedPolicies) > 0 {
+		log.LogInfo("Using cached binding policies from Redis", zap.Int("count", len(cachedPolicies)))
 		// Convert cached policies to response format
 		responseArray := make([]map[string]interface{}, len(cachedPolicies))
 		for i, bpolicy := range cachedPolicies {
+			// Ensure YAML content is properly mapped
+			yamlContent := bpolicy.RawYAML
+			if yamlContent == "" {
+				log.LogWarn("Empty YAML content in cached policy", zap.String("policyName", bpolicy.Name))
+			} else {
+				log.LogDebug("Found YAML content in cached policy", zap.String("policyName", bpolicy.Name), zap.Int("yamlLength", len(yamlContent)))
+			}
+
 			responseArray[i] = map[string]interface{}{
 				"name":              bpolicy.Name,
 				"namespace":         bpolicy.Namespace,
@@ -75,7 +84,7 @@ func GetBindingPolicies(namespace string) ([]map[string]interface{}, error) {
 				"clustersCount":     len(bpolicy.Clusters),
 				"workloadsCount":    len(bpolicy.Workloads),
 				"creationTimestamp": bpolicy.CreationTimestamp,
-				"yaml":              bpolicy.RawYAML,
+				"yaml":              yamlContent, // Use the yamlContent variable to ensure proper mapping
 			}
 		}
 
@@ -128,6 +137,12 @@ func GetBindingPolicies(namespace string) ([]map[string]interface{}, error) {
 			status = "active"
 		}
 
+		log.LogDebug("Determined BP status from Kubernetes",
+			zap.String("policyName", bpList.Items[i].Name),
+			zap.String("status", status),
+			zap.Int64("generation", bpList.Items[i].ObjectMeta.Generation),
+			zap.Int64("observedGeneration", bpList.Items[i].Status.ObservedGeneration))
+
 		// Extract binding mode
 		bindingMode := "Downsync" // Default to Downsync since KubeStellar currently only supports Downsync
 
@@ -136,7 +151,7 @@ func GetBindingPolicies(namespace string) ([]map[string]interface{}, error) {
 
 		// Check if we have stored data for this policy that might have more details
 		policyName := bpList.Items[i].Name
-		storedBP, exists := uiCreatedPolicies[policyName]
+		storedBP, exists := UICreatedPolicies[policyName]
 
 		if exists {
 			log.LogDebug("GetAllBp - Found stored BP in memory with key", zap.String("key", policyName))
@@ -335,7 +350,7 @@ func GetBindingPolicies(namespace string) ([]map[string]interface{}, error) {
 		}
 		if _, exists := bpWithStatus.Annotations["yaml"]; !exists {
 			// Check if this is a quick connect policy by looking for the annotation
-			if storedBP, exists := uiCreatedPolicies[bpWithStatus.Name]; exists && storedBP.RawYAML != "" {
+			if storedBP, exists := UICreatedPolicies[bpWithStatus.Name]; exists && storedBP.RawYAML != "" {
 				// Use the original YAML for quick connect policies
 				bpWithStatus.Annotations["yaml"] = storedBP.RawYAML
 			} else {
@@ -492,7 +507,7 @@ func GetBindingPolicies(namespace string) ([]map[string]interface{}, error) {
 		}
 
 		// Check if this is a quick connect policy and use its original YAML
-		if storedBP, exists := uiCreatedPolicies[bp.Name]; exists && storedBP.RawYAML != "" {
+		if storedBP, exists := UICreatedPolicies[bp.Name]; exists && storedBP.RawYAML != "" {
 			policyMap["yaml"] = storedBP.RawYAML
 		} else {
 			policyMap["yaml"] = bp.Annotations["yaml"]
@@ -503,6 +518,18 @@ func GetBindingPolicies(namespace string) ([]map[string]interface{}, error) {
 
 	// After getting policies from Kubernetes, store them in Redis
 	for _, bp := range bpsWithStatus {
+		// Get the YAML content from annotations or stored policies
+		yamlContent := ""
+		if storedBP, exists := UICreatedPolicies[bp.Name]; exists && storedBP.RawYAML != "" {
+			yamlContent = storedBP.RawYAML
+			log.LogDebug("Using stored YAML for caching", zap.String("policyName", bp.Name), zap.Int("yamlLength", len(yamlContent)))
+		} else if bp.Annotations != nil && bp.Annotations["yaml"] != "" {
+			yamlContent = bp.Annotations["yaml"]
+			log.LogDebug("Using annotations YAML for caching", zap.String("policyName", bp.Name), zap.Int("yamlLength", len(yamlContent)))
+		} else {
+			log.LogWarn("No YAML content found for caching", zap.String("policyName", bp.Name))
+		}
+
 		cachedPolicy := &redis.BindingPolicyCache{
 			Name:              bp.Name,
 			Namespace:         bp.Namespace,
@@ -511,11 +538,14 @@ func GetBindingPolicies(namespace string) ([]map[string]interface{}, error) {
 			Clusters:          bp.Clusters,
 			Workloads:         bp.Workloads,
 			CreationTimestamp: bp.CreationTimestamp.Format(time.RFC3339),
-			RawYAML:           bp.Annotations["yaml"],
+			RawYAML:           yamlContent,
 		}
 
+		log.LogDebug("Caching binding policy", zap.String("policyName", bp.Name), zap.Int("yamlLength", len(yamlContent)))
 		if err := redis.StoreBindingPolicy(cachedPolicy); err != nil {
 			log.LogWarn("failed to cache binding policy", zap.Error(err))
+		} else {
+			log.LogDebug("Successfully cached binding policy", zap.String("policyName", bp.Name))
 		}
 	}
 
@@ -616,8 +646,11 @@ func CreateBp(ctx *gin.Context) {
 		RawYAML:           string(bpRawYamlBytes),
 	}
 
+	log.LogInfo("Storing binding policy in Redis cache", zap.String("policyName", bp.Name), zap.Int("yamlLength", len(string(bpRawYamlBytes))))
 	if err := redis.StoreBindingPolicy(cachedBPolicy); err != nil {
 		log.LogWarn("failed to cache new binding policy", zap.Error(err))
+	} else {
+		log.LogInfo("Successfully cached new binding policy", zap.String("policyName", bp.Name))
 	}
 
 	ctx.JSON(http.StatusOK, gin.H{"message": fmt.Sprintf("Created binding policy '%s' successfully", bp.Name)})
@@ -705,6 +738,16 @@ func GetBpStatus(ctx *gin.Context) {
 	if err != nil {
 		log.LogWarn("failed to get binding policy from Redis cache", zap.Error(err))
 	} else if cachedPolicy != nil {
+		log.LogInfo("Using cached binding policy from Redis", zap.String("policyName", name))
+
+		// Ensure YAML content is properly mapped
+		yamlContent := cachedPolicy.RawYAML
+		if yamlContent == "" {
+			log.LogWarn("Empty YAML content in cached policy", zap.String("policyName", name))
+		} else {
+			log.LogDebug("Found YAML content in cached policy", zap.String("policyName", name), zap.Int("yamlLength", len(yamlContent)))
+		}
+
 		ctx.JSON(http.StatusOK, gin.H{
 			"name":              cachedPolicy.Name,
 			"namespace":         cachedPolicy.Namespace,
@@ -716,7 +759,7 @@ func GetBpStatus(ctx *gin.Context) {
 			"clustersCount":     len(cachedPolicy.Clusters),
 			"workloadsCount":    len(cachedPolicy.Workloads),
 			"creationTimestamp": cachedPolicy.CreationTimestamp,
-			"yaml":              cachedPolicy.RawYAML,
+			"yaml":              yamlContent, // Use the yamlContent variable to ensure proper mapping
 		})
 		return
 	}
@@ -774,8 +817,8 @@ func GetBpStatus(ctx *gin.Context) {
 		log.LogDebug("GetBpStatus - Found BP with matching name in namespace", zap.String("namespace", bp.Namespace))
 	}
 
-	// Look for this binding policy in the uiCreatedPolicies map
-	storedBP, exists := uiCreatedPolicies[name]
+	// Look for this binding policy in the UICreatedPolicies map
+	storedBP, exists := UICreatedPolicies[name]
 	if exists {
 		log.LogDebug("GetBpStatus - Found stored BP in memory with key", zap.String("name", name))
 		// Debug the stored policy
@@ -1394,7 +1437,7 @@ func CreateBpFromJson(ctx *gin.Context) {
 	}
 
 	// Store policy before API call
-	uiCreatedPolicies[newBP.Name] = storedBP
+	UICreatedPolicies[newBP.Name] = storedBP
 	log.LogInfo("Stored policy in memory cache", zap.String("key", newBP.Name))
 
 	// Get client
@@ -1774,7 +1817,7 @@ func CreateQuickBindingPolicy(ctx *gin.Context) {
 		Namespace: namespace,
 		RawYAML:   rawYAML,
 	}
-	uiCreatedPolicies[policyName] = storedBP
+	UICreatedPolicies[policyName] = storedBP
 
 	// Get client and create the binding policy
 	c, err := getClientForBp()

--- a/backend/wds/bp/utils.go
+++ b/backend/wds/bp/utils.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
 	"github.com/kubestellar/kubestellar/pkg/generated/clientset/versioned/scheme"
@@ -14,6 +15,7 @@ import (
 	"github.com/kubestellar/ui/log"
 	"github.com/kubestellar/ui/redis"
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -339,17 +341,31 @@ func watchOnBps() {
 			switch event.Type {
 			case "MODIFIED":
 				bp, _ := event.Object.(*v1alpha1.BindingPolicy)
-				if bp.ObjectMeta.Generation == bp.Status.ObservedGeneration {
-					log.LogInfo("reconciled successfully", zap.String("name", bp.Name))
-				} else {
-					log.LogInfo("reconciling...", zap.String("name", bp.Name))
-				}
-				log.LogInfo("BP modified: ", zap.String("name", bp.Name))
 
-				// Update the cache with the modified binding policy
+				// Determine the correct status
 				status := "inactive"
 				if bp.ObjectMeta.Generation == bp.Status.ObservedGeneration {
 					status = "active"
+					log.LogInfo("BP reconciled successfully - updating cache to active", zap.String("name", bp.Name))
+				} else {
+					log.LogInfo("BP reconciling - keeping as inactive", zap.String("name", bp.Name))
+				}
+
+				log.LogInfo("BP modified", zap.String("name", bp.Name), zap.String("newStatus", status))
+
+				// preserve existing YAML content from cache
+				existingYAML := ""
+				if existingPolicy, err := redis.GetBindingPolicy(bp.Name); err == nil && existingPolicy != nil {
+					existingYAML = existingPolicy.RawYAML
+					log.LogDebug("Preserving existing YAML content from cache", zap.String("policyName", bp.Name), zap.Int("yamlLength", len(existingYAML)))
+				}
+
+				// If don't have existing YAML, try to generate it from the current BP
+				if existingYAML == "" {
+					if yamlBytes, err := yaml.Marshal(bp); err == nil {
+						existingYAML = string(yamlBytes)
+						log.LogDebug("Generated YAML for modified policy", zap.String("policyName", bp.Name), zap.Int("yamlLength", len(existingYAML)))
+					}
 				}
 
 				cachedPolicy := &redis.BindingPolicyCache{
@@ -360,16 +376,32 @@ func watchOnBps() {
 					Clusters:          extractTargetClusters(bp),
 					Workloads:         extractWorkloads(bp),
 					CreationTimestamp: bp.CreationTimestamp.Format("2006-01-02T15:04:05Z"),
-					RawYAML:           "", // We don't have the raw YAML in watch events
+					RawYAML:           existingYAML, // Preserve existing YAML content
 				}
 
+				log.LogInfo("Updating binding policy cache", zap.String("policyName", bp.Name), zap.String("status", status))
 				if err := redis.StoreBindingPolicy(cachedPolicy); err != nil {
 					log.LogWarn("failed to update binding policy in cache", zap.Error(err))
+				} else {
+					log.LogInfo("Successfully updated binding policy cache", zap.String("policyName", bp.Name), zap.String("status", status))
 				}
 
 			case "ADDED":
 				bp, _ := event.Object.(*v1alpha1.BindingPolicy)
 				log.LogInfo("BP added: ", zap.String("name", bp.Name))
+
+				//  YAML content from stored policies or generate it
+				yamlContent := ""
+				if storedBP, exists := UICreatedPolicies[bp.Name]; exists && storedBP.RawYAML != "" {
+					yamlContent = storedBP.RawYAML
+					log.LogDebug("Using stored YAML for new policy", zap.String("policyName", bp.Name), zap.Int("yamlLength", len(yamlContent)))
+				} else {
+					// Generate YAML from the binding policy object
+					if yamlBytes, err := yaml.Marshal(bp); err == nil {
+						yamlContent = string(yamlBytes)
+						log.LogDebug("Generated YAML for new policy", zap.String("policyName", bp.Name), zap.Int("yamlLength", len(yamlContent)))
+					}
+				}
 
 				// Add the new binding policy to cache
 				cachedPolicy := &redis.BindingPolicyCache{
@@ -380,7 +412,7 @@ func watchOnBps() {
 					Clusters:          extractTargetClusters(bp),
 					Workloads:         extractWorkloads(bp),
 					CreationTimestamp: bp.CreationTimestamp.Format("2006-01-02T15:04:05Z"),
-					RawYAML:           "", // We don't have the raw YAML in watch events
+					RawYAML:           yamlContent, // Use the YAML content we found or generated
 				}
 
 				if err := redis.StoreBindingPolicy(cachedPolicy); err != nil {
@@ -401,7 +433,89 @@ func watchOnBps() {
 
 	}
 }
-func init() {
 
+// forces a refresh of all binding policies in the cache
+func RefreshBindingPolicyCache() error {
+	log.LogInfo("Refreshing binding policy cache from Kubernetes")
+
+	c, err := getClientForBp()
+	if err != nil {
+		log.LogError("failed to create client for cache refresh", zap.Error(err))
+		return err
+	}
+
+	// Get all binding policies from Kubernetes
+	bpList, err := c.BindingPolicies().List(context.TODO(), v1.ListOptions{})
+	if err != nil {
+		log.LogError("failed to list binding policies for cache refresh", zap.Error(err))
+		return err
+	}
+
+	log.LogInfo("Refreshing cache with policies from Kubernetes", zap.Int("policyCount", len(bpList.Items)))
+
+	// Update cache for each policy
+	for _, bp := range bpList.Items {
+		status := "inactive"
+		if bp.ObjectMeta.Generation == bp.Status.ObservedGeneration {
+			status = "active"
+		}
+
+		//  preserve existing YAML content from cache
+		existingYAML := ""
+		if existingPolicy, err := redis.GetBindingPolicy(bp.Name); err == nil && existingPolicy != nil {
+			existingYAML = existingPolicy.RawYAML
+		}
+
+		// don't have existing YAML, generate it from the current BP
+		if existingYAML == "" {
+			if yamlBytes, err := yaml.Marshal(bp); err == nil {
+				existingYAML = string(yamlBytes)
+			}
+		}
+
+		cachedPolicy := &redis.BindingPolicyCache{
+			Name:              bp.Name,
+			Namespace:         bp.Namespace,
+			Status:            status,
+			BindingMode:       "Downsync",
+			Clusters:          extractTargetClusters(&bp),
+			Workloads:         extractWorkloads(&bp),
+			CreationTimestamp: bp.CreationTimestamp.Format("2006-01-02T15:04:05Z"),
+			RawYAML:           existingYAML,
+		}
+
+		log.LogDebug("Refreshing cache for policy",
+			zap.String("policyName", bp.Name),
+			zap.String("status", status),
+			zap.Int64("generation", bp.ObjectMeta.Generation),
+			zap.Int64("observedGeneration", bp.Status.ObservedGeneration))
+
+		if err := redis.StoreBindingPolicy(cachedPolicy); err != nil {
+			log.LogWarn("failed to refresh binding policy in cache", zap.String("policyName", bp.Name), zap.Error(err))
+		}
+	}
+
+	log.LogInfo("Completed binding policy cache refresh")
+	return nil
+}
+
+func init() {
 	go watchOnBps()
+
+	// Refresh the cache on startup after a short delay to allow Redis to be ready
+	go func() {
+		time.Sleep(5 * time.Second)
+		if err := RefreshBindingPolicyCache(); err != nil {
+			log.LogWarn("failed to refresh binding policy cache on startup", zap.Error(err))
+		}
+
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			if err := RefreshBindingPolicyCache(); err != nil {
+				log.LogWarn("failed to refresh binding policy cache periodically", zap.Error(err))
+			}
+		}
+	}()
 }


### PR DESCRIPTION
### Description

Fixed the all the cache issues for the binding policy for the redis.

### Related Issue

Fixes #916 
Under #54 

### Changes Made

- Fixed yaml Content, bp status Mapping in Redis Cache.
- Enhanced YAML Content Preservation 
- Added Cache Refresh for the binding policy when server restarts
-  Made UICreatedPolicies Accessible to the utils.go for the watch events

### Checklist

Please ensure the following before submitting your PR:

- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

