### PR TITLE
Correct Pods Capacity to Pod Capacity in cluster details

### DIFF
--- a/src/components/ClusterDetailDialog.tsx
+++ b/src/components/ClusterDetailDialog.tsx
@@ -897,7 +897,7 @@ const ClusterDetailDialog: React.FC<ClusterDetailDialogProps> = ({
                           fontWeight: isDark ? 500 : 400,
                         }}
                       >
-                        Pods Capacity
+                        Pod Capacity
                       </Typography>
                     </Box>
                   </Grid>

--- a/src/components/Clusters.tsx
+++ b/src/components/Clusters.tsx
@@ -1557,9 +1557,9 @@ const K8sInfo = () => {
                               <HardDrive size={12} className="mr-1 text-purple-500" />
                               {cluster.memCapacity || 'N/A'}
                             </div>
-                            <div className="flex items-center" title="Pods Capacity">
+                            <div className="flex items-center" title="Pod Capacity">
                               <Layers size={12} className="mr-1 text-green-500" />
-                              {cluster.podsCapacity || 'N/A'} Pods Capacity
+                              {cluster.podsCapacity || 'N/A'} Pod Capacity
                             </div>
                           </div>
                         </div>


### PR DESCRIPTION
### Description

Fixed grammatical error in the cluster details dialog where "Pods Capacity" was incorrectly pluralized. Changed to "Pod Capacity" to maintain consistency with standard Kubernetes terminology and improve UI text accuracy.

### Related Issue

Fixes #918 

### Changes Made

- [x] Fixed grammatical error in ClusterDetailDialog.tsx from "Pods Capacity" to "Pod Capacity"
- [x] Updated capacity section display text to use proper singular form
- [x] Maintained consistency with Kubernetes standard terminology

### Checklist

- [x] I have reviewed the project's contribution guidelines.
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

**Before:** 
- Cluster details showed "Pods Capacity" in the capacity section

**After:**
- Cluster details now correctly shows "Pod Capacity" in the capacity section