### PR TITLE
fix: prevent policy name reset on dialog reopen by tracking initial o…

### DIFF
--- a/src/components/BindingPolicy/PolicyNameDialog.tsx
+++ b/src/components/BindingPolicy/PolicyNameDialog.tsx
@@ -42,12 +42,20 @@ const PolicyNameDialog: React.FC<PolicyNameDialogProps> = ({
   const [policyName, setPolicyName] = useState(defaultName);
   const [isEditing, setIsEditing] = useState(false);
 
+  // Track whether dialog has been opened
+  const [hasOpened, setHasOpened] = useState(false);
+
   useEffect(() => {
-    if (open) {
+    if (open && !hasOpened) {
+      // Only set the policy name when the dialog first opens
       setPolicyName(defaultName);
       setIsEditing(false);
+      setHasOpened(true);
+    } else if (!open) {
+      // Reset the state when dialog closes
+      setHasOpened(false);
     }
-  }, [open, defaultName]);
+  }, [open, defaultName, hasOpened]);
 
   const handleConfirm = () => {
     if (policyName.trim()) {


### PR DESCRIPTION
## Description
Fixes #926 - Prevents the binding policy name dialog from overwriting user input with default generated names.

## Changes Made
- Added tracking state to detect when the dialog has been initially opened
- Modified the useEffect hook to only set the policy name when the dialog first opens, not on subsequent re-renders
- Ensured tracking state is reset when dialog closes


[Screencast from 2025-05-27 23-50-20.webm](https://github.com/user-attachments/assets/ccc5fb40-33d4-4369-b220-8d9c5e1dfa91)

