### PR TITLE
Fix "Delete Selected" button appearing after policy deletion

### DIFF
--- a/src/components/BindingPolicy/BPTable.tsx
+++ b/src/components/BindingPolicy/BPTable.tsx
@@ -560,7 +560,15 @@ const BPTable: React.FC<BPTableProps> = ({
                           transition: 'opacity 0.2s ease',
                           WebkitAppearance: 'none',
                         }}
-                        onClick={() => onDeletePolicy(policy)}
+                        onClick={() => {
+                          // If the policy was selected, also remove it from selectedPolicies
+                          if (selectedPolicies.includes(policy.name)) {
+                            const updatedSelection = selectedPolicies.filter(name => name !== policy.name);
+                            onSelectionChange(updatedSelection);
+                          }
+                          // Then delete the policy
+                          onDeletePolicy(policy);
+                        }}
                       >
                         <Trash2 size={18} />
                       </IconButton>


### PR DESCRIPTION
# Fix "Delete Selected" button appearing after policy deletion

Problem
When a policy that is selected via checkbox is deleted using the trash can icon, the "Delete Selected" button continues to appear even though the policy no longer exists.

Solution
When deleting a policy with the trash can icon, also remove it from the `selectedPolicies` array if it was previously selected.

Fixes #940 

Before : 

https://github.com/user-attachments/assets/1aedc114-60e8-47d2-93be-16736f4466a2

After " 

https://github.com/user-attachments/assets/f12cb824-38c3-4a71-bd40-f2a43f1893a6
