### PR TITLE
fix: add stable alphabetical sorting to binding policies list to prev…

### DIFF
--- a/src/components/BindingPolicy/BPTable.tsx
+++ b/src/components/BindingPolicy/BPTable.tsx
@@ -208,7 +208,12 @@ const BPTable: React.FC<BPTableProps> = ({
   console.log(
     `BPTable received ${policies.length} policies with status filter: ${activeFilters.status || 'none'}`
   );
-  const filteredPolicies = policies;
+  // Apply stable sorting by name to prevent reordering on re-renders
+  const filteredPolicies = [...policies].sort((a, b) => {
+    const nameA = a?.name?.toLowerCase() || '';
+    const nameB = b?.name?.toLowerCase() || '';
+    return nameA.localeCompare(nameB);
+  });
 
   // Function to map cluster labels to actual cluster names
   const mapClusterLabelsToNames = useCallback(

--- a/src/pages/BP.tsx
+++ b/src/pages/BP.tsx
@@ -211,7 +211,8 @@ const BP = () => {
       return [];
     }
 
-    return bindingPolicies.filter(policy => {
+    // Filter the policies first
+    const filtered = bindingPolicies.filter(policy => {
       try {
         if (!policy) return false;
 
@@ -234,6 +235,13 @@ const BP = () => {
         console.error('Error filtering policy:', error, policy);
         return false; // Skip this policy if there's an error
       }
+    });
+
+    // Apply stable sorting by name to prevent reordering on re-renders
+    return [...filtered].sort((a, b) => {
+      const nameA = a?.name?.toLowerCase() || '';
+      const nameB = b?.name?.toLowerCase() || '';
+      return nameA.localeCompare(nameB);
     });
   }, [bindingPolicies, searchQuery, activeFilters.status]);
 


### PR DESCRIPTION
## Description

The problem was caused by lack of stable sorting logic, which made it difficult to manage policies as they kept jumping around in the UI.

fixes #939 

## Changes Made

- Added stable sorting to the `getFilteredPolicies` function in `BP.tsx` to sort binding policies alphabetically by name.
- This ensures a consistent display order that doesn't change on re-renders.

## Screenshots (if applicable)

[Screencast from 2025-05-30 02-27-55.webm](https://github.com/user-attachments/assets/3a1eeb7c-5490-4975-838e-6b740d1e285d)

