### PR TITLE
Fix/selected bp after trash icon deletion

### DIFF
--- a/src/hooks/queries/useBPQueries.ts
+++ b/src/hooks/queries/useBPQueries.ts
@@ -562,9 +562,9 @@ export const useBPQueries = () => {
         const response = await api.delete(`/api/bp/delete/${name}`);
         return response.data;
       },
-      onSuccess: () => {
+      onSuccess: (_data, variables) => {
         queryClient.invalidateQueries({ queryKey: ['binding-policies'] });
-        toast.success('Binding policy deleted successfully');
+        toast.success(`Binding policy "${variables}" deleted successfully`);
       },
       onError: (error: Error) => {
         toast.error('Failed to delete binding policy');
@@ -602,10 +602,11 @@ export const useBPQueries = () => {
           throw error;
         }
       },
-      onSuccess: data => {
+      onSuccess: (data, variables) => {
         console.log('useDeletePolicies - Mutation succeeded with data:', data);
         queryClient.invalidateQueries({ queryKey: ['binding-policies'] });
-        toast.success('Selected binding policies deleted successfully');
+        const count = variables.length;
+        toast.success(`${count} binding ${count === 1 ? 'policy' : 'policies'} deleted successfully`);
       },
       onError: (error: Error) => {
         toast.error('Failed to delete binding policies');

--- a/src/hooks/queries/useBPQueries.ts
+++ b/src/hooks/queries/useBPQueries.ts
@@ -606,7 +606,9 @@ export const useBPQueries = () => {
         console.log('useDeletePolicies - Mutation succeeded with data:', data);
         queryClient.invalidateQueries({ queryKey: ['binding-policies'] });
         const count = variables.length;
-        toast.success(`${count} binding ${count === 1 ? 'policy' : 'policies'} deleted successfully`);
+        toast.success(
+          `${count} binding ${count === 1 ? 'policy' : 'policies'} deleted successfully`
+        );
       },
       onError: (error: Error) => {
         toast.error('Failed to delete binding policies');

--- a/src/pages/BP.tsx
+++ b/src/pages/BP.tsx
@@ -505,11 +505,14 @@ const BP = () => {
           current.filter(policy => policy.name !== selectedPolicy.name)
         );
 
-        // Update UI state after successful deletion
-        setSuccessMessage(`Binding Policy "${selectedPolicy.name}" deleted successfully`);
+        if (selectedPolicies.includes(selectedPolicy.name)) {
+          setSelectedPolicies(current => current.filter(name => name !== selectedPolicy.name));
+        }
+
+        // Notification handled by toast in the query hook
       } catch (error) {
         console.error('Error deleting binding policy:', error);
-        setSuccessMessage(`Error deleting binding policy "${selectedPolicy.name}"`);
+        // Error notification handled by toast in the query hook
       } finally {
         setDeleteDialogOpen(false);
         setSelectedPolicy(null);
@@ -517,11 +520,13 @@ const BP = () => {
     }
   }, [
     selectedPolicy,
+    selectedPolicies,
     deleteBindingPolicyMutation,
     setSuccessMessage,
     setDeleteDialogOpen,
     setSelectedPolicy,
     setBindingPolicies,
+    setSelectedPolicies,
   ]);
 
   const handleCreatePolicySubmit = useCallback(
@@ -1046,11 +1051,12 @@ const BP = () => {
         </DialogActions>
       </Dialog>
 
+      {/* Snackbar removed in favor of toast notifications */}
       <Snackbar
-        open={!!successMessage}
+        open={!!successMessage && !successMessage.includes('deleted successfully')}
         autoHideDuration={6000}
         onClose={() => setSuccessMessage('')}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
       >
         <Alert
           onClose={() => setSuccessMessage('')}


### PR DESCRIPTION
## Description
Fixes #940 


## Changes Made
- Fixed selection state management when deleting a policy
- Enhanced toast notifications to include the binding policy name
- Prevented 2 same notifications during deletion operations
- Ensured proper cleanup of selected policies on deletion

##Screenshots
![Screenshot from 2025-05-30 02-35-07](https://github.com/user-attachments/assets/5375ef27-30c7-4f82-a88b-769452508075)
-you can see 2 notifications came(on top and bottom after deletion). Now after changes only one comes.


[Screencast from 2025-05-30 02-48-52.webm](https://github.com/user-attachments/assets/d051845c-de96-4397-8422-5c4ecb5d7dd0)
