### PR TITLE
update readme to help resolve its1.localtest.me

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Before you begin, ensure that your system meets the following requirements:
 - Ensure you have access to a Kubernetes clusters setup with Kubestellar Getting Started Guide & Kubestellar prerequisites installed
 
 - **Kubestellar guide**: [Guide](https://docs.kubestellar.io/release-0.25.1/direct/get-started/)
+>[!NOTE] If you're running on macOS, you may need to manually add a host entry to resolve its1.localtest.me to localhost using ```echo "127.0.0.1 its1.localtest.me" | sudo tee -a /etc/hosts```
 
 ### 5. Make and Air
 


### PR DESCRIPTION
### Description

On macOS, the domain its1.localtest.me may not automatically resolve to localhost.
This can cause DNS resolution errors when setting up the demo environment.
This PR adds a helpful note to the README.md to assist macOS users with configuration.

### Related Issue

Fixes #944

### Changes Made

- [x] Updated README.md with a note explaining how to manually add a host entry for its1.localtest.me on macOS.
### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.
