### PR TITLE
Add WSL Troubleshooting Note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,18 @@ To stop the application
 docker compose down
 ```
 
+---
+
+> **Note for WSL Users 🐧**
+>
+> If you've successfully installed the KubeStellar but they are not detected by frontend, it might be due to a communication issue between Docker and WSL.
+>
+> Here are a few steps to resolve it:
+>
+> 1. Open Docker Desktop settings and ensure WSL integration is enabled for your distribution (e.g., Ubuntu).
+> 2. If the issue persists, consider uninstalling Docker Desktop from Windows and instead install Docker **directly inside your WSL environment** (e.g., Ubuntu).
+> 3. After installing Docker inside WSL, reinstall the KubeStellar. This setup typically resolves the detection issues. ✅
+
 ### Accessing the Application
 
 1. **Backend API**: [http://localhost:4000](http://localhost:4000)


### PR DESCRIPTION
**Summary**  
This PR adds a note to the README to help WSL users who may experience issues with Docker Desktop not detecting KubeStellar demo clusters. It outlines the potential cause (communication issues between Docker Desktop and WSL) and provides a step-by-step workaround.

**Changes Made**
- Added a new "Note for WSL Users" section to the README.
- Included troubleshooting steps and a recommended workaround using Docker installed directly inside WSL.

**Reason for the Change**  
Several users have reported that even after successfully installing KubeStellar demo clusters, they are not detected by Docker Desktop. This guide will help users quickly diagnose and fix the issue, improving onboarding and user experience.

**Checklist**
- [x] I’ve tested the instructions on a fresh WSL setup
- [x] The note is clear, concise, and helpful
- [x] README renders correctly with the note

**Related Issues**  
Fixes: #947 
