### PR TITLE
Fix : TLS Certificate Verification Errors

### DIFF
--- a/backend/its/manual/handlers/cluster.go
+++ b/backend/its/manual/handlers/cluster.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/kubestellar/ui/utils"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -90,6 +91,9 @@ func GetITSInfo() ([]ManagedClusterInfo, error) {
 			log.Printf("Skipping context %s: %v", contextName, err)
 			continue
 		}
+
+		// Use the utility function to configure TLS settings
+		restConfig = utils.ConfigureTLSInsecure(restConfig)
 
 		clientset, err := kubernetes.NewForConfig(restConfig)
 		if err != nil {
@@ -264,6 +268,10 @@ func GetKubeInfo() ([]ContextInfo, []string, string, error, []ManagedClusterInfo
 				log.Printf("Error creating REST config for context %s: %v", contextName, err)
 				continue
 			}
+			
+			// Use the utility function to configure TLS settings
+			restConfig = utils.ConfigureTLSInsecure(restConfig)
+
 			clientset, err := kubernetes.NewForConfig(restConfig)
 			if err != nil {
 				log.Printf("Error creating clientset for context %s: %v", contextName, err)

--- a/backend/k8s/client.go
+++ b/backend/k8s/client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/kubestellar/ui/utils"
 	"k8s.io/client-go/rest"
 
 	"k8s.io/client-go/dynamic"
@@ -34,7 +35,7 @@ func GetClientSet() (*kubernetes.Clientset, dynamic.Interface, error) {
 		return nil, nil, fmt.Errorf("failed to load kubeconfig: %v", err)
 	}
 
-	// Use WDS1 context specifically
+	// Check if context "wds1" exists
 	ctxContext := config.Contexts["wds1"]
 	if ctxContext == nil {
 		return nil, nil, fmt.Errorf("failed to find context 'wds1'")
@@ -52,6 +53,9 @@ func GetClientSet() (*kubernetes.Clientset, dynamic.Interface, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create restconfig: %v", err)
 	}
+	
+	// Use the utility function to configure TLS settings
+	restConfig = utils.ConfigureTLSInsecure(restConfig)
 
 	clientset, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
@@ -98,6 +102,9 @@ func GetClientSetWithContext(contextName string) (*kubernetes.Clientset, dynamic
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create restconfig: %v", err)
 	}
+	
+	// Use the utility function to configure TLS settings
+	restConfig = utils.ConfigureTLSInsecure(restConfig)
 
 	clientset, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
@@ -143,6 +150,9 @@ func GetClientSetWithConfigContext(contextName string) (*kubernetes.Clientset, *
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create restconfig: %v", err)
 	}
+	
+	// Use the utility function to configure TLS settings
+	restConfig = utils.ConfigureTLSInsecure(restConfig)
 
 	clientset, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {

--- a/backend/utils/k8s_client.go
+++ b/backend/utils/k8s_client.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"k8s.io/client-go/rest"
+)
+
+// ConfigureTLSInsecure modifies a REST config to skip TLS certificate verification.
+// This should only be used in development environments.
+func ConfigureTLSInsecure(config *rest.Config) *rest.Config {
+	// Skip TLS verification to fix certificate errors
+	config.TLSClientConfig.Insecure = true
+	config.TLSClientConfig.CAData = nil
+	config.TLSClientConfig.CAFile = ""
+	return config
+} 

--- a/backend/wds/bp/utils.go
+++ b/backend/wds/bp/utils.go
@@ -14,6 +14,7 @@ import (
 	bpv1alpha1 "github.com/kubestellar/kubestellar/pkg/generated/clientset/versioned/typed/control/v1alpha1"
 	"github.com/kubestellar/ui/log"
 	"github.com/kubestellar/ui/redis"
+	"github.com/kubestellar/ui/utils"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -98,6 +99,9 @@ func getClientForBp() (*bpv1alpha1.ControlV1alpha1Client, error) {
 		log.LogError("Failed to get rest config", zap.String("error", err.Error()))
 		return nil, err
 	}
+	
+	// Use the utility function to configure TLS settings
+	restcnfg = utils.ConfigureTLSInsecure(restcnfg)
 
 	// Create client
 	c, err := bpv1alpha1.NewForConfig(restcnfg)
@@ -170,6 +174,9 @@ func extractWorkloads(bp *v1alpha1.BindingPolicy) []string {
 		log.LogError("failed to load kubeconfig for context 'wds1'", zap.Error(err))
 		return workloads // Return an empty list of workloads on failure
 	}
+	
+	// Use the utility function to configure TLS settings
+	config = utils.ConfigureTLSInsecure(config)
 
 	// Create dynamic client
 	dynClient, err := dynamic.NewForConfig(config)

--- a/backend/wds/common.go
+++ b/backend/wds/common.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
+	"github.com/kubestellar/ui/utils"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -66,6 +67,9 @@ func GetClientSetKubeConfig() (*kubernetes.Clientset, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create restconfig")
 	}
+	
+	// Use the utility function to configure TLS settings
+	restConfig = utils.ConfigureTLSInsecure(restConfig)
 
 	clientset, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {

--- a/backend/wecs/wecs.go
+++ b/backend/wecs/wecs.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kubestellar/ui/its/manual/handlers"
 	"github.com/kubestellar/ui/k8s"
 	"github.com/kubestellar/ui/redis"
+	"github.com/kubestellar/ui/utils"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
@@ -125,6 +126,10 @@ func getITSData() ([]handlers.ManagedClusterInfo, error) {
 				log.Printf("Error creating REST config for context %s: %v", contextName, err)
 				continue
 			}
+			
+			// Use the utility function to configure TLS settings
+			restConfig = utils.ConfigureTLSInsecure(restConfig)
+			
 			clientset, err := kubernetes.NewForConfig(restConfig)
 			if err != nil {
 				log.Printf("Error creating clientset for context %s: %v", contextName, err)


### PR DESCRIPTION
### Description
This PR addresses TLS certificate verification failures that occur when connecting to the Kubernetes API server on macOS and WSL environments. The issue was caused by self-signed certificates not being trusted across different operating systems.

### Related Issue

Fixes #950 

### Changes Made

- Created a central utility function `ConfigureTLSInsecure `in `backend/utils/k8s_client.go` to handle TLS verification skipping in a consistent way
- Updated all Kubernetes client configurations to use this utility function
- Improved code maintainability by centralizing TLS configuration
