### PR TITLE
fix: buggy behaviour of zoom controls

### DIFF
--- a/src/components/Wds_Topology/ZoomControls.tsx
+++ b/src/components/Wds_Topology/ZoomControls.tsx
@@ -33,7 +33,16 @@ export const ZoomControls = memo<ZoomControlsProps>(
       const interval = setInterval(updateZoomLevel, 100);
 
       return () => clearInterval(interval);
-    }, [getZoom, snapToStep]);
+    }, [getZoom, snapToStep, setViewport]);
+
+    useEffect(() => {
+      const reset = () => {
+        setViewport({ ...getViewport(), zoom: 1 }, { duration: 0 });
+        setZoomLevel(100);
+      };
+      const timer = setTimeout(reset, 100);
+      return () => clearTimeout(timer);
+    }, [setViewport, getViewport]);
 
     const animateZoom = useCallback(
       (targetZoom: number, duration: number = 200) => {

--- a/src/components/Wds_Topology/ZoomControls.tsx
+++ b/src/components/Wds_Topology/ZoomControls.tsx
@@ -13,7 +13,7 @@ interface ZoomControlsProps {
 
 export const ZoomControls = memo<ZoomControlsProps>(
   ({ theme, onToggleCollapse, isCollapsed, onExpandAll, onCollapseAll }) => {
-    const { getZoom, setViewport } = useReactFlow();
+    const { getZoom, setViewport, getViewport } = useReactFlow();
     const [zoomLevel, setZoomLevel] = useState<number>(100);
 
     const snapToStep = useCallback((zoom: number) => {
@@ -22,21 +22,35 @@ export const ZoomControls = memo<ZoomControlsProps>(
     }, []);
 
     useEffect(() => {
-      const currentZoom = getZoom() * 100;
-      const snappedZoom = snapToStep(currentZoom);
-      setZoomLevel(Math.min(Math.max(snappedZoom, 10), 200));
+      const updateZoomLevel = () => {
+        const currentZoom = getZoom() * 100;
+        const snappedZoom = snapToStep(currentZoom);
+        setZoomLevel(Math.min(Math.max(snappedZoom, 10), 200));
+      };
+
+      updateZoomLevel();
+
+      const interval = setInterval(updateZoomLevel, 100);
+
+      return () => clearInterval(interval);
     }, [getZoom, snapToStep]);
 
     const animateZoom = useCallback(
       (targetZoom: number, duration: number = 200) => {
         const startZoom = getZoom();
+        const currentViewport = getViewport();
         const startTime = performance.now();
 
         const step = (currentTime: number) => {
           const elapsed = currentTime - startTime;
           const progress = Math.min(elapsed / duration, 1);
           const newZoom = startZoom + (targetZoom - startZoom) * progress;
-          setViewport({ zoom: newZoom, x: 0, y: 10 });
+
+          setViewport({
+            zoom: newZoom,
+            x: currentViewport.x,
+            y: currentViewport.y,
+          });
 
           if (progress < 1) {
             requestAnimationFrame(step);
@@ -47,21 +61,29 @@ export const ZoomControls = memo<ZoomControlsProps>(
 
         requestAnimationFrame(step);
       },
-      [getZoom, setViewport, snapToStep]
+      [getZoom, getViewport, setViewport, snapToStep]
     );
 
     const handleZoomIn = useCallback(() => {
-      const currentZoom = getZoom() * 100;
-      const newZoomPercentage = snapToStep(currentZoom + 10);
-      const newZoom = Math.min(newZoomPercentage / 100, 2);
-      animateZoom(newZoom);
+      const currentZoom = getZoom();
+      const currentZoomPercentage = currentZoom * 100;
+      const newZoomPercentage = Math.min(snapToStep(currentZoomPercentage + 10), 200);
+      const newZoom = newZoomPercentage / 100;
+
+      if (Math.abs(newZoom - currentZoom) > 0.01) {
+        animateZoom(newZoom);
+      }
     }, [animateZoom, getZoom, snapToStep]);
 
     const handleZoomOut = useCallback(() => {
-      const currentZoom = getZoom() * 100;
-      const newZoomPercentage = snapToStep(currentZoom - 10);
-      const newZoom = Math.max(newZoomPercentage / 100, 0.1);
-      animateZoom(newZoom);
+      const currentZoom = getZoom();
+      const currentZoomPercentage = currentZoom * 100;
+      const newZoomPercentage = Math.max(snapToStep(currentZoomPercentage - 10), 10);
+      const newZoom = newZoomPercentage / 100;
+
+      if (Math.abs(newZoom - currentZoom) > 0.01) {
+        animateZoom(newZoom);
+      }
     }, [animateZoom, getZoom, snapToStep]);
 
     return (

--- a/src/components/Wds_Topology/ZoomControls.tsx
+++ b/src/components/Wds_Topology/ZoomControls.tsx
@@ -14,7 +14,7 @@ interface ZoomControlsProps {
 export const ZoomControls = memo<ZoomControlsProps>(
   ({ theme, onToggleCollapse, isCollapsed, onExpandAll, onCollapseAll }) => {
     const { getZoom, setViewport, getViewport } = useReactFlow();
-    const [zoomLevel, setZoomLevel] = useState<number>(100);
+    const [zoomLevel, setZoomLevel] = useState<number>(120);
 
     const snapToStep = useCallback((zoom: number) => {
       const step = 10;


### PR DESCRIPTION
### Description
This PR addresses the issue where the zoom controls behave in a buggy manner
1. On loading of the canvas , the zoom label shows an incorrect value
2. Label fails to change value upon zooming in/out using Ctrl  + pinch on touchpad

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #971 

### Changes Made

- [x] Fixed viewport position in `animateZoom`
- [x] Used `getViewPort` hook

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

[Screencast from 2025-06-03 23-15-08.webm](https://github.com/user-attachments/assets/73d8fcce-5461-42aa-87b8-ed755c8889c3)
