### PR TITLE
fix: Continuous request loop to cluster info api

### DIFF
--- a/src/components/WecsTopology.tsx
+++ b/src/components/WecsTopology.tsx
@@ -667,7 +667,6 @@ const WecsTreeview = () => {
       );
 
       const timestampMap = new Map(clusterNames.map((name, index) => [name, timestamps[index]]));
-
       return timestampMap;
     } catch (error) {
       console.error('Error fetching cluster timestamps:', error);
@@ -1266,7 +1265,7 @@ const WecsTreeview = () => {
 
       processData();
     }
-  }, [transformDataToTree, wecsData]); // Added wecsData to dependency array
+  }, [transformDataToTree]);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {


### PR DESCRIPTION
### Description
This PR fixes the issue where the WecsTopology component on load up continuously sends api requests to the server for clusters info

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #978 

### Changes Made

- [x] Removed wecsData as dependency from useEffect  

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

[Screencast from 2025-06-05 03-06-49.webm](https://github.com/user-attachments/assets/82769e24-d960-4249-b3b7-284205c92c65)

