### PR TITLE
🐛 : fix command palettee not covering TreeViewComponent(No workload found box)

### DIFF
--- a/src/components/TreeViewComponent.tsx
+++ b/src/components/TreeViewComponent.tsx
@@ -2494,7 +2494,6 @@ const TreeViewComponent = (_props: TreeViewComponentProps) => {
                     display: 'flex',
                     justifyContent: 'center',
                     alignItems: 'center',
-                    zIndex: 10,
                   }}
                 >
                   <Box


### PR DESCRIPTION

### Description
Upon clicking Searh command section, the workload panel(No workload found box) overlaps Command palttee dropdown. 

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #1001 

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->
![image](https://github.com/user-attachments/assets/fe5c9961-3e1c-44cc-8edb-04067e3c4ba0)


### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the display behavior of the empty state message in the tree view by adjusting its stacking order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->