### PR TITLE
Migrate Helm Chart for KubeStellar UI into kubestellar/ui

### DIFF
--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,3 +1,6 @@
+# This chart was originally developed by @MAVRICK-1
+# Source: https://github.com/MAVRICK-1/kubestellar-ui
+
 apiVersion: v2
 name: kubestellar-ui
 description: A Helm chart for Kubernetes

--- a/chart/templates/deployment-backend.yaml
+++ b/chart/templates/deployment-backend.yaml
@@ -1,3 +1,6 @@
+# This chart was originally developed by @MAVRICK-1
+# Source: https://github.com/MAVRICK-1/kubestellar-ui
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/chart/templates/deployment-frontend.yaml
+++ b/chart/templates/deployment-frontend.yaml
@@ -1,3 +1,6 @@
+# This chart was originally developed by @MAVRICK-1
+# Source: https://github.com/MAVRICK-1/kubestellar-ui
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,3 +1,6 @@
+# This chart was originally developed by @MAVRICK-1
+# Source: https://github.com/MAVRICK-1/kubestellar-ui
+
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -1,3 +1,6 @@
+# This chart was originally developed by @MAVRICK-1
+# Source: https://github.com/MAVRICK-1/kubestellar-ui
+
 apiVersion: v1
 kind: Secret
 metadata:

--- a/chart/templates/service-backend.yaml
+++ b/chart/templates/service-backend.yaml
@@ -1,3 +1,6 @@
+# This chart was originally developed by @MAVRICK-1
+# Source: https://github.com/MAVRICK-1/kubestellar-ui
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/chart/templates/service-frontend.yaml
+++ b/chart/templates/service-frontend.yaml
@@ -1,3 +1,6 @@
+# This chart was originally developed by @MAVRICK-1
+# Source: https://github.com/MAVRICK-1/kubestellar-ui
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,3 +1,6 @@
+# This chart was originally developed by @MAVRICK-1
+# Source: https://github.com/MAVRICK-1/kubestellar-ui
+
 replicaCount: 1
 
 frontend:


### PR DESCRIPTION
Description

This PR migrates the kubestellar-ui Helm chart from the [MAVERICK repo](https://github.com/MAVRICK-1/kubestellar-ui) to the official kubestellar/ui repo under chart/kubestellar-ui.

Copied files:

Chart.yaml

values.yaml

.helmignore

templates/

This sets the stage for future improvements, automated testing, and release workflows.

Acknowledgment: Original chart from MAVERICK repo.

Fixes #1112