### PR TITLE
fix: Ignore yaml file by prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -28,3 +28,7 @@ Dockerfile
 docker-compose.yml
 docker-compose*.yml
 *.dockerfile
+
+# Ignore yaml files
+*.yaml
+*.yml


### PR DESCRIPTION
### Description

This PR fixes the auto format by prettier on yaml/yml files which were wrongly formatted and breaking Helm template syntax.
<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #1135


### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated .prettierignore file to exclude all YAML files (*.yaml, *.yml)
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
