### PR TITLE
feat: add ESC key support to language dropdown #1134

### DIFF
--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -28,7 +28,7 @@ const LanguageSwitcher = () => {
     setIsOpen(false);
   };
 
-  // Close dropdown when clicking outside
+  // Close dropdown when clicking outside or pressing ESC
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
@@ -36,11 +36,20 @@ const LanguageSwitcher = () => {
       }
     };
 
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && isOpen) {
+        setIsOpen(false);
+      }
+    };
+
     document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKeyDown);
+
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
     };
-  }, []);
+  }, [isOpen]);
 
   // Get current language info
   const currentLang = languages.find(lang => lang.code === i18n.language) || languages[0];
@@ -122,9 +131,18 @@ const LanguageSwitcher = () => {
           >
             {!isLoginPage && (
               <div
-                className={`border-b px-3 py-2 ${isDark ? 'border-gray-700 text-gray-400' : 'border-gray-200 text-gray-500'}`}
+                className={`flex items-center justify-between border-b px-3 py-2 ${isDark ? 'border-gray-700 text-gray-400' : 'border-gray-200 text-gray-500'}`}
               >
                 <p className="text-xs font-medium uppercase tracking-wider">Select Language</p>
+                <kbd
+                  className="hidden items-center rounded px-1.5 py-0.5 text-xs font-semibold sm:inline-flex"
+                  style={{
+                    background: isDark ? 'rgba(55, 65, 81, 0.5)' : 'rgba(229, 231, 235, 0.5)',
+                    color: isDark ? 'rgba(156, 163, 175, 1)' : 'rgba(107, 114, 128, 1)',
+                  }}
+                >
+                  ESC
+                </kbd>
               </div>
             )}
             <div className="max-h-60 overflow-auto py-1">


### PR DESCRIPTION
### Description
<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->
This PR enhances the language dropdown component by adding ESC key functionality to close the dropdown, providing consistent UX behavior with the command palette. The enhancement includes both the keyboard functionality and a visual ESC key indicator in the dropdown header.

### Related Issue
<!-- Link the issue(s) this PR addresses. -->
Fixes #1134

### Changes Made
<!-- Provide a detailed list of changes made in this PR. -->
- [x] Added ESC key event listener to close language dropdown when pressed
- [x] Updated useEffect hook to handle keydown events alongside existing click-outside functionality
- [x] Added visual ESC key indicator in dropdown header with theme-aware styling
- [x] Enhanced dropdown header layout with flexbox to position ESC indicator on the right
- [x] Maintained consistent styling with existing command palette ESC key design
- [x] Ensured ESC indicator only displays on non-login pages for consistency

### Checklist
Please ensure the following before submitting your PR:
- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)
<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->
**Before:** Language dropdown could only be closed by clicking outside or selecting a language
**After:** 
Language dropdown now closes with ESC key press and shows visual ESC indicator

[Screencast from 2025-06-22 12-02-10.webm](https://github.com/user-attachments/assets/853291b5-1581-4440-9296-b4418497bb9a)

**Testing scenarios verified:**
- ✅ ESC key closes dropdown when open
- ✅ ESC key does not interfere when dropdown is closed
- ✅ Click outside functionality remains intact
- ✅ ESC indicator displays correctly in both dark and light themes
- ✅ ESC indicator hidden on login page as expected
- ✅ Dropdown animations and transitions work smoothly

### Additional Notes
<!-- Add any other context, suggestions, or questions related to this PR. -->
The implementation follows the same pattern used in the command palette component for consistency. The ESC key event listener is properly cleaned up to prevent memory leaks, and the dependency array includes `isOpen` state to ensure the event listener behavior is correct.

The visual ESC indicator uses the same styling pattern as other kbd elements in the application, maintaining design consistency across the UI.