### PR TITLE
feat: Add plugin manager field into search(command palette)

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -15,6 +15,7 @@ import {
 } from 'react-icons/fi';
 import { useAuthActions } from '../hooks/useAuth';
 import { useTranslation } from 'react-i18next';
+import { HiOutlinePuzzlePiece } from 'react-icons/hi2';
 
 // Command types to support various actions
 type CommandType = 'navigation' | 'action' | 'documentation';
@@ -147,6 +148,16 @@ const CommandPalette: React.FC = () => {
         'daemonsets',
         'replicasets',
       ],
+      section: t('commandPalette.sections.navigation'),
+    },
+    {
+      id: 'plugin',
+      type: 'navigation',
+      icon: HiOutlinePuzzlePiece,
+      title: t('commandPalette.commands.plugin.title'),
+      description: t('commandPalette.commands.plugin.description'),
+      action: () => navigate('/plugins/manage'),
+      keywords: ['plugin', 'manage', 'install', 'wasm', 'monitor'],
       section: t('commandPalette.sections.navigation'),
     },
     {

--- a/src/locales/strings.en.json
+++ b/src/locales/strings.en.json
@@ -1927,7 +1927,7 @@
         "title": "Home",
         "description": "Go to dashboard"
       },
-       "plugin": {
+      "plugin": {
         "title": "Plugin Manager",
         "description": "Manage and monitor KubeStellar plugins"
       },

--- a/src/locales/strings.en.json
+++ b/src/locales/strings.en.json
@@ -1927,6 +1927,10 @@
         "title": "Home",
         "description": "Go to dashboard"
       },
+       "plugin": {
+        "title": "Plugin Manager",
+        "description": "Manage and monitor KubeStellar plugins"
+      },
       "clusters": {
         "title": "Remote Clusters",
         "description": "Manage Kubernetes clusters"


### PR DESCRIPTION
### Description
This PR adds the missing field Plugin Manager into search(Command palette)

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes  #1159 

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated CommandPalette.tsx and strings.en.json to add Plugin Manager info
- [ ] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->
<img width="1465" alt="Screenshot 2025-06-24 at 13 37 10" src="https://github.com/user-attachments/assets/440e25e3-d36e-4041-9041-a51e53869403" />


### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
