### PR TITLE
chore: rename react components `dragdrop` to `selction`

### DIFF
--- a/frontend/src/components/BindingPolicy/ClusterLabelsList.tsx
+++ b/frontend/src/components/BindingPolicy/ClusterLabelsList.tsx
@@ -15,7 +15,7 @@ import {
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import EditIcon from '@mui/icons-material/Edit';
 import { ManagedCluster } from '../../types/bindingPolicy';
-import { usePolicyDragDropStore } from '../../stores/policyDragDropStore';
+import { usePolicySelectionStore } from '../../stores/policySelectionStore';
 import useTheme from '../../stores/themeStore';
 import { useTranslation } from 'react-i18next';
 
@@ -70,7 +70,7 @@ const ClusterLabelsList: React.FC<ClusterLabelsListProps> = ({
     }
 
     // Check if this item is in the canvas
-    const { canvasEntities } = usePolicyDragDropStore.getState();
+    const { canvasEntities } = usePolicySelectionStore.getState();
     const isInCanvas = canvasEntities.clusters.includes(itemId);
 
     // Find the full cluster objects for each cluster in this label group

--- a/frontend/src/components/BindingPolicy/CreateBindingPolicyDialog.tsx
+++ b/frontend/src/components/BindingPolicy/CreateBindingPolicyDialog.tsx
@@ -30,10 +30,10 @@ import {
   getDialogPaperProps,
 } from './styles/CreateBindingPolicyStyles';
 import { DEFAULT_BINDING_POLICY_TEMPLATE } from './constants/index';
-import PolicyDragDrop from './PolicyDragDrop'; // TODO: Rename component to PolicySelection
+import PolicySelection from './PolicySelection';
 import { ManagedCluster, Workload } from '../../types/bindingPolicy';
 import { PolicyConfiguration } from './ConfigurationSidebar';
-import { usePolicyDragDropStore } from '../../stores/policyDragDropStore';
+import { usePolicySelectionStore } from '../../stores/policySelectionStore';
 import { useBPQueries } from '../../hooks/queries/useBPQueries';
 import { toast } from 'react-hot-toast';
 import CancelButton from '../common/CancelButton';
@@ -102,7 +102,7 @@ const CreateBindingPolicyDialog: React.FC<CreateBindingPolicyDialogProps> = ({
     config?: PolicyConfiguration;
   } | null>(null);
 
-  const policyCanvasEntities = usePolicyDragDropStore(state => state.canvasEntities);
+  const policyCanvasEntities = usePolicySelectionStore(state => state.canvasEntities);
 
   const { useGenerateBindingPolicyYaml, useWorkloadSSE } = useBPQueries();
   const generateYamlMutation = useGenerateBindingPolicyYaml();
@@ -934,7 +934,7 @@ const CreateBindingPolicyDialog: React.FC<CreateBindingPolicyDialogProps> = ({
   const isDarkTheme = theme === 'dark';
 
   const handleClearPolicyCanvas = () => {
-    usePolicyDragDropStore.getState().clearCanvas();
+    usePolicySelectionStore.getState().clearCanvas();
   };
 
   const getWorkloadDisplayName = (workloadId: string): string => {
@@ -1436,7 +1436,7 @@ const CreateBindingPolicyDialog: React.FC<CreateBindingPolicyDialogProps> = ({
                     overflow: 'hidden',
                   }}
                 >
-                  <PolicyDragDrop
+                  <PolicySelection
                     clusters={clusters}
                     workloads={allWorkloads}
                     onCreateBindingPolicy={handleCreateBindingPolicy}

--- a/frontend/src/components/BindingPolicy/PolicyCanvas.tsx
+++ b/frontend/src/components/BindingPolicy/PolicyCanvas.tsx
@@ -16,7 +16,7 @@ import AddIcon from '@mui/icons-material/Add';
 import InfoIcon from '@mui/icons-material/Info';
 import AddLinkIcon from '@mui/icons-material/AddLink';
 import KubernetesIcon from './KubernetesIcon';
-import { usePolicyDragDropStore } from '../../stores/policyDragDropStore';
+import { usePolicySelectionStore } from '../../stores/policySelectionStore';
 import { useCanvasStore } from '../../stores/canvasStore';
 import { BindingPolicyInfo, ManagedCluster, Workload } from '../../types/bindingPolicy';
 import StrictModeDroppable from './StrictModeDroppable';
@@ -142,7 +142,7 @@ const PolicyCanvas: React.FC<PolicyCanvasProps> = ({
     assignmentMap: policyAssignmentMap,
     removeFromCanvas: removeFromPolicyCanvas,
     clearCanvas,
-  } = usePolicyDragDropStore();
+  } = usePolicySelectionStore();
 
   const { connectionLines, setConnectionLines, drawingActive } = useCanvasStore();
 
@@ -1110,7 +1110,7 @@ const PolicyCanvas: React.FC<PolicyCanvasProps> = ({
               <Typography variant="body2" fontWeight="bold">
                 {t('bindingPolicy.canvas.policiesOnCanvas')}
               </Typography>
-              <Typography variant="body2">{t('bindingPolicy.dragDrop.infoAlert')}</Typography>
+              <Typography variant="body2">{t('bindingPolicy.selection.infoAlert')}</Typography>
             </Box>
           }
           arrow

--- a/frontend/src/components/BindingPolicy/PolicySelection.tsx
+++ b/frontend/src/components/BindingPolicy/PolicySelection.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { BindingPolicyInfo, Workload, ManagedCluster } from '../../types/bindingPolicy';
 import { PolicyConfiguration } from './ConfigurationSidebar';
-import PolicyDragDropContainer from './PolicyDragDropContainer';
+import PolicySelectionContainer from './PolicySelectionContainer';
 import {
   Dialog,
   DialogTitle,
@@ -27,7 +27,7 @@ import PublishIcon from '@mui/icons-material/Publish';
 import useTheme from '../../stores/themeStore';
 import { useTranslation } from 'react-i18next';
 
-interface PolicyDragDropProps {
+interface PolicySelectionProps {
   policies?: BindingPolicyInfo[];
   clusters?: ManagedCluster[];
   workloads?: Workload[];
@@ -80,7 +80,7 @@ const HelpDialog: React.FC<{ open: boolean; onClose: () => void }> = ({ open, on
               color: isDarkTheme ? 'rgba(255, 255, 255, 0.9)' : undefined,
             }}
           >
-            {t('bindingPolicy.dragDrop.helpDialog.helpDialog.title')}
+            {t('bindingPolicy.selection.helpDialog.helpDialog.title')}
           </Typography>
         </Box>
       </DialogTitle>
@@ -91,7 +91,7 @@ const HelpDialog: React.FC<{ open: boolean; onClose: () => void }> = ({ open, on
             color: isDarkTheme ? 'rgba(255, 255, 255, 0.9)' : undefined,
           }}
         >
-          {t('bindingPolicy.dragDrop.helpDialog.helpDialog.intro')}
+          {t('bindingPolicy.selection.helpDialog.helpDialog.intro')}
         </Typography>
         <List>
           <ListItem>
@@ -101,7 +101,7 @@ const HelpDialog: React.FC<{ open: boolean; onClose: () => void }> = ({ open, on
             <ListItemText
               primary={
                 <Typography sx={{ color: isDarkTheme ? 'rgba(255, 255, 255, 0.9)' : undefined }}>
-                  {t('bindingPolicy.dragDrop.helpDialog.helpDialog.steps.selectLabels')}
+                  {t('bindingPolicy.selection.helpDialog.helpDialog.steps.selectLabels')}
                 </Typography>
               }
               secondary={
@@ -109,7 +109,7 @@ const HelpDialog: React.FC<{ open: boolean; onClose: () => void }> = ({ open, on
                   variant="body2"
                   sx={{ color: isDarkTheme ? 'rgba(255, 255, 255, 0.7)' : undefined }}
                 >
-                  {t('bindingPolicy.dragDrop.helpDialog.helpDialog.steps.selectLabelsDesc')}
+                  {t('bindingPolicy.selection.helpDialog.helpDialog.steps.selectLabelsDesc')}
                 </Typography>
               }
             />
@@ -121,7 +121,7 @@ const HelpDialog: React.FC<{ open: boolean; onClose: () => void }> = ({ open, on
             <ListItemText
               primary={
                 <Typography sx={{ color: isDarkTheme ? 'rgba(255, 255, 255, 0.9)' : undefined }}>
-                  {t('bindingPolicy.dragDrop.helpDialog.helpDialog.steps.deploy')}
+                  {t('bindingPolicy.selection.helpDialog.helpDialog.steps.deploy')}
                 </Typography>
               }
               secondary={
@@ -129,7 +129,7 @@ const HelpDialog: React.FC<{ open: boolean; onClose: () => void }> = ({ open, on
                   variant="body2"
                   sx={{ color: isDarkTheme ? 'rgba(255, 255, 255, 0.7)' : undefined }}
                 >
-                  {t('bindingPolicy.dragDrop.helpDialog.helpDialog.steps.deployDesc')}
+                  {t('bindingPolicy.selection.helpDialog.helpDialog.steps.deployDesc')}
                 </Typography>
               }
             />
@@ -143,7 +143,7 @@ const HelpDialog: React.FC<{ open: boolean; onClose: () => void }> = ({ open, on
             color: isDarkTheme ? 'rgba(255, 255, 255, 0.7)' : 'text.secondary',
           }}
         >
-          {t('bindingPolicy.dragDrop.helpDialog.helpDialog.tip')}
+          {t('bindingPolicy.selection.helpDialog.helpDialog.tip')}
         </Typography>
       </DialogContent>
       <DialogActions
@@ -170,7 +170,7 @@ const HelpDialog: React.FC<{ open: boolean; onClose: () => void }> = ({ open, on
                 }
                 label={
                   <Typography sx={{ color: isDarkTheme ? 'rgba(255, 255, 255, 0.9)' : undefined }}>
-                    {t('bindingPolicy.dragDrop.helpDialog.helpDialog.dontShowAgain')}
+                    {t('bindingPolicy.selection.helpDialog.helpDialog.dontShowAgain')}
                   </Typography>
                 }
               />
@@ -194,7 +194,7 @@ const HelpDialog: React.FC<{ open: boolean; onClose: () => void }> = ({ open, on
               },
             }}
           >
-            {t('bindingPolicy.dragDrop.helpDialog.gotIt')}
+            {t('bindingPolicy.selection.helpDialog.gotIt')}
           </Button>
         </Box>
       </DialogActions>
@@ -202,7 +202,7 @@ const HelpDialog: React.FC<{ open: boolean; onClose: () => void }> = ({ open, on
   );
 };
 
-const PolicyDragDrop: React.FC<PolicyDragDropProps> = props => {
+const PolicySelection: React.FC<PolicySelectionProps> = props => {
   const [helpDialogOpen, setHelpDialogOpen] = useState(false);
 
   const theme = useTheme(state => state.theme);
@@ -227,7 +227,7 @@ const PolicyDragDrop: React.FC<PolicyDragDropProps> = props => {
           zIndex: 10,
         }}
       >
-        <Tooltip title={t('bindingPolicy.dragDrop.helpDialog.helpDialog.tooltip')}>
+        <Tooltip title={t('bindingPolicy.selection.helpDialog.helpDialog.tooltip')}>
           <IconButton
             onClick={() => setHelpDialogOpen(true)}
             size="small"
@@ -246,11 +246,11 @@ const PolicyDragDrop: React.FC<PolicyDragDropProps> = props => {
         </Tooltip>
       </Box>
 
-      <PolicyDragDropContainer {...props} />
+      <PolicySelectionContainer {...props} />
 
       <HelpDialog open={helpDialogOpen} onClose={() => setHelpDialogOpen(false)} />
     </Box>
   );
 };
 
-export default React.memo(PolicyDragDrop);
+export default React.memo(PolicySelection);

--- a/frontend/src/components/BindingPolicy/SuccessNotification.tsx
+++ b/frontend/src/components/BindingPolicy/SuccessNotification.tsx
@@ -4,7 +4,7 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CloseIcon from '@mui/icons-material/Close';
 import LabelIcon from '@mui/icons-material/Label';
 import LinkIcon from '@mui/icons-material/Link';
-import { usePolicyDragDropStore } from '../../stores/policyDragDropStore';
+import { usePolicySelectionStore } from '../../stores/policySelectionStore';
 import { useTranslation } from 'react-i18next'; // Add this import
 
 interface SuccessNotificationProps {
@@ -22,7 +22,7 @@ const SuccessNotification: React.FC<SuccessNotificationProps> = ({
     successMessage: storeMessage,
     clearSuccessMessageAfterDelay,
     setSuccessMessage,
-  } = usePolicyDragDropStore();
+  } = usePolicySelectionStore();
   const { t } = useTranslation(); // Add translation hook
 
   // Use provided props or fallback to store values

--- a/frontend/src/components/BindingPolicy/WorkloadPanel.tsx
+++ b/frontend/src/components/BindingPolicy/WorkloadPanel.tsx
@@ -43,7 +43,7 @@ import SaveIcon from '@mui/icons-material/Save';
 import DeleteIcon from '@mui/icons-material/Delete';
 import LabelIcon from '@mui/icons-material/Label';
 import { Tag, Tags } from 'lucide-react';
-import { usePolicyDragDropStore } from '../../stores/policyDragDropStore';
+import { usePolicySelectionStore } from '../../stores/policySelectionStore';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import { useBPQueries } from '../../hooks/queries/useBPQueries';
 import { toast } from 'react-hot-toast';
@@ -672,7 +672,7 @@ const WorkloadPanel: React.FC<WorkloadPanelProps> = ({
     const itemId = `label-${labelGroup.key}:${labelGroup.value}`;
 
     // Check if this item is in the canvas
-    const { canvasEntities } = usePolicyDragDropStore.getState();
+    const { canvasEntities } = usePolicySelectionStore.getState();
     const isInCanvas = canvasEntities.workloads.includes(itemId);
 
     // Check if this is from a cluster-scoped resource

--- a/frontend/src/locales/strings.en.json
+++ b/frontend/src/locales/strings.en.json
@@ -1091,7 +1091,7 @@
       }
     },
     "loadingCanvas": "Loading canvas data...",
-    "dragDrop": {
+    "selection": {
       "infoAlert": "This interface is using simulated responses to create binding policies. Select clusters and workloads from the lists to add them to the canvas, then click on a workload and then a cluster to create a binding policy connection.",
       "helpDialog": {
         "title": "Create Binding Policies with Direct Connections",
@@ -1635,7 +1635,8 @@
     "creating": "Creating...",
     "createContext": "Create Context"
   },
-  "policyDragDropStore": {
+
+  "policySelectionStore": {
     "labelsAssigned": "Labels automatically assigned to {{itemType}} {{itemId}}",
     "policyAssigned": "Successfully assigned {{policyName}} to {{targetType}} {{targetName}}",
     "clusterAlreadyAssigned": "Cluster {{targetName}} is already assigned to policy {{policyName}}",

--- a/frontend/src/locales/strings.es.json
+++ b/frontend/src/locales/strings.es.json
@@ -1084,7 +1084,7 @@
       }
     },
     "loadingCanvas": "Cargando datos del lienzo...",
-    "dragDrop": {
+    "selection": {
       "infoAlert": "Esta interfaz utiliza respuestas simuladas para crear políticas de vinculación. Selecciona clústeres y cargas de trabajo desde las listas para agregarlos al lienzo, luego haz clic en una carga de trabajo y luego en un clúster para crear una conexión de política de vinculación.",
       "helpDialog": {
         "title": "Crear políticas de vinculación con conexiones directas",
@@ -1628,7 +1628,7 @@
     "creating": "Creando...",
     "createContext": "Crear Contexto"
   },
-  "policyDragDropStore": {
+  "policySelectionStore": {
     "labelsAssigned": "Etiquetas asignadas automáticamente a {{itemType}} {{itemId}}",
     "policyAssigned": "Política {{policyName}} asignada exitosamente a {{targetType}} {{targetName}}",
     "clusterAlreadyAssigned": "El clúster {{targetName}} ya está asignado a la política {{policyName}}",

--- a/frontend/src/locales/strings.fr.json
+++ b/frontend/src/locales/strings.fr.json
@@ -1630,7 +1630,7 @@
     "creating": "Création...",
     "createContext": "Créer un contexte"
   },
-  "policyDragDropStore": {
+  "policySelectionStore": {
     "labelsAssigned": "Étiquettes automatiquement attribuées à {{itemType}} {{itemId}}",
     "policyAssigned": "Politique {{policyName}} assignée avec succès à {{targetType}} {{targetName}}",
     "clusterAlreadyAssigned": "Le cluster {{targetName}} est déjà assigné à la politique {{policyName}}",

--- a/frontend/src/locales/strings.ja.json
+++ b/frontend/src/locales/strings.ja.json
@@ -1629,7 +1629,7 @@
     "creating": "作成中...",
     "createContext": "コンテキストを作成"
   },
-  "policyDragDropStore": {
+  "policySelectionStore": {
     "labelsAssigned": "{{itemType}}「{{itemId}}」にラベルを自動で割り当てました",
     "policyAssigned": "ポリシー「{{policyName}}」を{{targetType}}「{{targetName}}」に正常に割り当てました",
     "clusterAlreadyAssigned": "クラスタ「{{targetName}}」はすでにポリシー「{{policyName}}」に割り当てられています",

--- a/frontend/src/pages/BP.tsx
+++ b/frontend/src/pages/BP.tsx
@@ -31,7 +31,7 @@ import { useWDSQueries } from '../hooks/queries/useWDSQueries';
 import { useBPQueries } from '../hooks/queries/useBPQueries';
 import { PolicyData } from '../components/BindingPolicy/CreateBindingPolicyDialog';
 import BPVisualization from '../components/BindingPolicy/BPVisualization';
-import PolicyDragDrop from '../components/BindingPolicy/PolicyDragDrop';
+import PolicySelection from '../components/BindingPolicy/PolicySelection';
 import EditIcon from '@mui/icons-material/Edit';
 import PublishIcon from '@mui/icons-material/Publish';
 import KubernetesIcon from '../components/BindingPolicy/KubernetesIcon';
@@ -164,11 +164,11 @@ const BP = () => {
   const itemsPerPage = 10;
   const [successMessage, setSuccessMessage] = useState<string>('');
 
-  // Check if we need to activate dragdrop view based on location state
-  const initialViewMode = location.state?.activateView === 'dragdrop' ? 'dragdrop' : 'table';
-  const [viewMode, setViewMode] = useState<'table' | 'dragdrop' | 'visualize'>(initialViewMode);
-  const [showDragDropHelp, setShowDragDropHelp] = useState(
-    location.state?.activateView === 'dragdrop'
+  // Check if we need to activate selection view based on location state
+  const initialViewMode = location.state?.activateView === 'selection' ? 'selection' : 'table';
+  const [viewMode, setViewMode] = useState<'table' | 'selection' | 'visualize'>(initialViewMode);
+  const [showSelectionHelp, setShowSelectionHelp] = useState(
+    location.state?.activateView === 'selection'
   );
 
   const [clusters, setClusters] = useState<ManagedCluster[]>([]);
@@ -179,10 +179,10 @@ const BP = () => {
   useEffect(() => {
     console.log('Location state:', location.state);
 
-    if (location.state?.activateView === 'dragdrop') {
-      console.log('Setting viewMode to dragdrop from location state');
-      setViewMode('dragdrop');
-      setShowDragDropHelp(true);
+    if (location.state?.activateView === 'selection') {
+      console.log('Setting viewMode to selection from location state');
+      setViewMode('selection');
+      setShowSelectionHelp(true);
     }
   }, [location.state]);
 
@@ -196,8 +196,8 @@ const BP = () => {
 
   // Show drag & drop help when the view is activated
   useEffect(() => {
-    if (viewMode === 'dragdrop') {
-      setShowDragDropHelp(true);
+    if (viewMode === 'selection') {
+      setShowSelectionHelp(true);
     }
   }, [viewMode]);
 
@@ -362,12 +362,12 @@ const BP = () => {
 
   // Memoize the tab change handler to prevent rerenders
   const handleViewModeChange = useCallback(
-    (_: React.SyntheticEvent, newValue: 'table' | 'dragdrop' | 'visualize') => {
+    (_: React.SyntheticEvent, newValue: 'table' | 'selection' | 'visualize') => {
       console.log('Tab change to:', newValue, 'from:', viewMode);
       if (newValue && newValue !== viewMode) {
         setViewMode(newValue);
-        if (newValue === 'dragdrop') {
-          setShowDragDropHelp(true);
+        if (newValue === 'selection') {
+          setShowSelectionHelp(true);
         }
       }
     },
@@ -926,7 +926,7 @@ const BP = () => {
           </>
         ) : (
           <Box sx={{ position: 'relative' }}>
-            <PolicyDragDrop
+            <PolicySelection
               policies={[...bindingPolicies, ...simulatedPolicies]}
               clusters={clusters}
               workloads={workloads}
@@ -950,7 +950,7 @@ const BP = () => {
                 },
               }}
             >
-              <Typography variant="body2">{t('bindingPolicy.dragDrop.infoAlert')}</Typography>
+              <Typography variant="body2">{t('bindingPolicy.selection.infoAlert')}</Typography>
             </Alert>
           </Box>
         )}
@@ -981,8 +981,8 @@ const BP = () => {
       </Paper>
       {/* Drag & Drop Help Dialog */}
       <Dialog
-        open={showDragDropHelp}
-        onClose={() => setShowDragDropHelp(false)}
+        open={showSelectionHelp}
+        onClose={() => setShowSelectionHelp(false)}
         maxWidth="sm"
         fullWidth
         PaperProps={{
@@ -1005,7 +1005,7 @@ const BP = () => {
               sx={{ mr: 1, color: theme === 'dark' ? '#90CAF9' : undefined }}
             />
             <Typography variant="h6" sx={{ color: theme === 'dark' ? '#E5E7EB' : undefined }}>
-              {t('bindingPolicy.dragDrop.helpDialog.title')}
+              {t('bindingPolicy.selection.helpDialog.title')}
             </Typography>
           </Box>
         </DialogTitle>
@@ -1016,7 +1016,7 @@ const BP = () => {
           }}
         >
           <Typography paragraph sx={{ color: theme === 'dark' ? '#E5E7EB' : undefined }}>
-            {t('bindingPolicy.dragDrop.helpDialog.intro')}
+            {t('bindingPolicy.selection.helpDialog.intro')}
           </Typography>
           <List
             sx={{
@@ -1032,14 +1032,16 @@ const BP = () => {
               <ListItemIcon>
                 <KubernetesIcon type="cluster" size={24} />
               </ListItemIcon>
-              <ListItemText primary={t('bindingPolicy.dragDrop.helpDialog.steps.selectClusters')} />
+              <ListItemText
+                primary={t('bindingPolicy.selection.helpDialog.steps.selectClusters')}
+              />
             </ListItem>
             <ListItem>
               <ListItemIcon>
                 <KubernetesIcon type="workload" size={24} />
               </ListItemIcon>
               <ListItemText
-                primary={t('bindingPolicy.dragDrop.helpDialog.steps.selectWorkloads')}
+                primary={t('bindingPolicy.selection.helpDialog.steps.selectWorkloads')}
               />
             </ListItem>
             <ListItem>
@@ -1051,20 +1053,20 @@ const BP = () => {
                 </Box>
               </ListItemIcon>
               <ListItemText
-                primary={t('bindingPolicy.dragDrop.helpDialog.steps.createConnection')}
+                primary={t('bindingPolicy.selection.helpDialog.steps.createConnection')}
               />
             </ListItem>
             <ListItem>
               <ListItemIcon>
                 <EditIcon />
               </ListItemIcon>
-              <ListItemText primary={t('bindingPolicy.dragDrop.helpDialog.steps.fillDetails')} />
+              <ListItemText primary={t('bindingPolicy.selection.helpDialog.steps.fillDetails')} />
             </ListItem>
             <ListItem>
               <ListItemIcon>
                 <PublishIcon color="primary" />
               </ListItemIcon>
-              <ListItemText primary={t('bindingPolicy.dragDrop.helpDialog.steps.deploy')} />
+              <ListItemText primary={t('bindingPolicy.selection.helpDialog.steps.deploy')} />
             </ListItem>
           </List>
         </DialogContent>
@@ -1075,8 +1077,8 @@ const BP = () => {
             py: 2,
           }}
         >
-          <Button onClick={() => setShowDragDropHelp(false)} variant="contained" color="primary">
-            {t('bindingPolicy.dragDrop.helpDialog.gotIt')}
+          <Button onClick={() => setShowSelectionHelp(false)} variant="contained" color="primary">
+            {t('bindingPolicy.selection.helpDialog.gotIt')}
           </Button>
         </DialogActions>
       </Dialog>

--- a/frontend/src/stores/policySelectionStore.ts
+++ b/frontend/src/stores/policySelectionStore.ts
@@ -1,12 +1,12 @@
 import { create } from 'zustand';
 import { BindingPolicyInfo } from '../types/bindingPolicy';
 
-// Define the drag types
-export const DragTypes = {
-  CLUSTER: 'CLUSTER_OR_WORKLOAD',
-  WORKLOAD: 'CLUSTER_OR_WORKLOAD',
-  POLICY: 'POLICY',
-};
+// Define selection types
+export enum SelectionTypes {
+  POLICY = 'POLICY',
+  CLUSTER = 'CLUSTER',
+  WORKLOAD = 'WORKLOAD',
+}
 
 type EntityType = 'policy' | 'cluster' | 'workload';
 
@@ -23,18 +23,18 @@ interface ItemLabels {
   workloads: Record<string, Record<string, string>>;
 }
 
-export interface PolicyDragDropTranslations {
+export interface PolicySelectionTranslations {
   labelsAssigned: (itemType: string, itemId: string) => string;
   policyAssigned: (policyName: string, targetType: string, targetName: string) => string;
   clusterAlreadyAssigned: (targetName: string, policyName: string) => string;
   workloadAlreadyAssigned: (targetName: string, policyName: string) => string;
 }
 
-interface PolicyDragDropState {
+interface PolicySelectionState {
   // UI state
-  activeDragItem: { type: string; id: string } | null;
+  activeSelectionItem: { type: string; id: string } | null;
   successMessage: string | null;
-  translations: PolicyDragDropTranslations | null;
+  translations: PolicySelectionTranslations | null;
 
   // Data state
   assignmentMap: Record<string, { clusters: string[]; workloads: string[] }>;
@@ -42,10 +42,10 @@ interface PolicyDragDropState {
   itemLabels: ItemLabels;
 
   // Actions
-  setActiveDragItem: (item: { type: string; id: string } | null) => void;
+  setActiveSelectionItem: (item: { type: string; id: string } | null) => void;
   setSuccessMessage: (message: string | null) => void;
   clearSuccessMessageAfterDelay: () => void;
-  setTranslations: (translations: PolicyDragDropTranslations) => void;
+  setTranslations: (translations: PolicySelectionTranslations) => void;
 
   // Canvas management
   addToCanvas: (itemType: EntityType, itemId: string) => void;
@@ -75,9 +75,9 @@ interface PolicyDragDropState {
 }
 
 // Create the store
-export const usePolicyDragDropStore = create<PolicyDragDropState>((set, get) => ({
+export const usePolicySelectionStore = create<PolicySelectionState>((set, get) => ({
   // Initial state
-  activeDragItem: null,
+  activeSelectionItem: null,
   successMessage: null,
   translations: null,
   assignmentMap: {},
@@ -92,7 +92,7 @@ export const usePolicyDragDropStore = create<PolicyDragDropState>((set, get) => 
   },
 
   // UI state actions
-  setActiveDragItem: item => set({ activeDragItem: item }),
+  setActiveSelectionItem: item => set({ activeSelectionItem: item }),
   setSuccessMessage: message => set({ successMessage: message }),
   setTranslations: translations => set({ translations }),
   clearSuccessMessageAfterDelay: () => {


### PR DESCRIPTION
### Description

Rename components name from `PolicyDragDrop.tsx` to `PolicySelection.tsx` and `PolicyDragDropContainer.tsx` to `PolicySelectionContainer.tsx` and related component name imports and exports 

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #923 

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated ...
- [ ] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Renamed the "PolicyDragDrop" components and related interfaces to "PolicySelection" across the user interface. No changes were made to the functionality or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->