### PR TITLE
fix: correct frontend build context and Dockerfile path in release wo…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Build & Push Frontend
         uses: docker/build-push-action@v5
         with:
-          context: .
-          file: ./Dockerfile
+          context: ./frontend
+          file: ./frontend/Dockerfile
           push: true
           target: frontend
           tags: |


### PR DESCRIPTION
Fixes the issue where the release workflow fails to build the frontend Docker image due to incorrect build context and Dockerfile path. Now points to the correct `frontend/` folder.

Fixes : #1227 