### PR TITLE
fix(ui.backend): health check route

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -99,15 +99,8 @@ func main() {
 		c.Next()
 	})
 
-	// Health check endpoint (public)
-	router.GET("/health", func(c *gin.Context) {
-		c.JSON(200, gin.H{
-			"status":  "healthy",
-			"service": "kubestellar-ui",
-			"version": "1.0.0",
-			"auth":    "enabled",
-		})
-	})
+	// Setting up comprehensive health endpoints using the existing health routes
+	routes.SetupHealthEndpoints(router, logger)
 
 	// Setup authentication routes
 	routes.SetupRoutes(router)
@@ -123,7 +116,11 @@ func main() {
 			zap.String("mode", cfg.GinMode),
 			zap.String("cors_origin", os.Getenv("CORS_ALLOWED_ORIGIN")))
 		logger.Info("Default admin credentials: admin/admin - CHANGE IMMEDIATELY!")
-		logger.Info("Health check available at: http://localhost:" + cfg.Port + "/health")
+		logger.Info("Health endpoints available:")
+		logger.Info("  - Comprehensive health: http://localhost:" + cfg.Port + "/health")
+		logger.Info("  - Kubernetes liveness: http://localhost:" + cfg.Port + "/healthz")
+		logger.Info("  - Kubernetes readiness: http://localhost:" + cfg.Port + "/readyz")
+		logger.Info("  - Simple status: http://localhost:" + cfg.Port + "/status")
 
 		if err := router.Run(":" + cfg.Port); err != nil {
 			logger.Fatal("Failed to start server", zap.Error(err))

--- a/backend/routes/health.go
+++ b/backend/routes/health.go
@@ -6,21 +6,12 @@ import (
 	"go.uber.org/zap"
 )
 
-// Replace the simple health endpoint in main.go with:
-func setupHealthEndpoints(router *gin.Engine, logger *zap.Logger) {
+func SetupHealthEndpoints(router *gin.Engine, logger *zap.Logger) {
 	// Comprehensive health check
 	router.GET("/health", health.HealthHandler(logger))
 
-	// Kubernetes-style probes
+	// Liveness and Readiness probes
 	router.GET("/healthz", health.LivenessHandler()) // Liveness probe
 	router.GET("/readyz", health.ReadinessHandler()) // Readiness probe
 
-	// Simple status endpoint
-	router.GET("/status", func(c *gin.Context) {
-		c.JSON(200, gin.H{
-			"service": "kubestellar-ui",
-			"status":  "running",
-			"version": "1.0.0",
-		})
-	})
 }


### PR DESCRIPTION
### Description

This PR removes ad‑hoc health routes from jwt.go and also remove the dummy health route from main.go file, consolidates all probes into a single routes/health.go, . Now, Kubernetes probes use the standard /healthz (liveness) and /readyz (readiness) paths, and a single /health endpoint returns a detailed JSON payload with component‑level statuses, uptime, version, and environment.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #<issue_number>

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Removed inline health routes (/apih, /readyz, /health/detailed, /status) from backend/routes/jwt.go.
- [ ] Refactored main.go to call SetupHealthEndpoints(router, logger) before application routes.


### Checklist

Please ensure the following before submitting your PR:

- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
