### PR TITLE
✨feat: add unit tests for Cluster, Namespace, and User models

### DIFF
--- a/backend/test/models/cluster_test.go
+++ b/backend/test/models/cluster_test.go
@@ -1,0 +1,110 @@
+package models_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kubestellar/ui/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClusterStructInitialization(t *testing.T) {
+	c := models.Cluster{
+		Name:   "test-cluster",
+		Region: "us-east-1",
+		Value:  []string{"v1", "v2"},
+		Node:   "node-1",
+	}
+	assert.Equal(t, "test-cluster", c.Name)
+	assert.Equal(t, "us-east-1", c.Region)
+	assert.Equal(t, []string{"v1", "v2"}, c.Value)
+	assert.Equal(t, "node-1", c.Node)
+}
+
+func TestClusterStatusJSONMarshaling(t *testing.T) {
+	status := models.ClusterStatus{
+		ClusterName: "clusterA",
+		Status:      models.StatusOnboarded,
+	}
+	data, err := json.Marshal(status)
+	assert.NoError(t, err)
+
+	jsonStr := string(data)
+	assert.Contains(t, jsonStr, "clusterName", "JSON should contain 'clusterName' key")
+
+	var unmarshaled models.ClusterStatus
+	err = json.Unmarshal(data, &unmarshaled)
+	assert.NoError(t, err)
+	assert.Equal(t, status, unmarshaled)
+}
+
+func TestOnboardingLogsResponseJSONMarshaling(t *testing.T) {
+	logs := []models.OnboardingEvent{
+		{
+			ClusterName: "clusterA",
+			Status:      models.StatusOnboarded,
+			Message:     "Onboarded successfully",
+			Timestamp:   models.OnboardingEvent{}.Timestamp, // zero value is fine for this test
+		},
+	}
+	resp := models.OnboardingLogsResponse{
+		ClusterName: "clusterA",
+		Status:      models.StatusOnboarded,
+		Logs:        logs,
+		Count:       1,
+	}
+	data, err := json.Marshal(resp)
+	assert.NoError(t, err)
+
+	// Unmarshal to a map to check the logs array keys
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+
+	logsArr, ok := result["logs"].([]interface{})
+	assert.True(t, ok, "logs should be an array")
+	for _, entry := range logsArr {
+		logEntry, ok := entry.(map[string]interface{})
+		assert.True(t, ok, "each log entry should be a map")
+		_, hasClusterName := logEntry["clusterName"]
+		assert.True(t, hasClusterName, "each log entry should have 'clusterName' key")
+	}
+}
+
+func TestOnboardingResponseJSONMarshaling(t *testing.T) {
+	resp := models.OnboardingResponse{
+		Message:           "Success",
+		Status:            models.StatusSuccess,
+		LogsEndpoint:      "/logs",
+		WebsocketEndpoint: "/ws",
+	}
+	data, err := json.Marshal(resp)
+	assert.NoError(t, err)
+
+	var unmarshaled models.OnboardingResponse
+	err = json.Unmarshal(data, &unmarshaled)
+	assert.NoError(t, err)
+	assert.Equal(t, resp, unmarshaled)
+
+	jsonStr := string(data)
+	assert.Contains(t, jsonStr, "logsEndpoint", "JSON should contain 'logsEndpoint' key")
+	assert.Contains(t, jsonStr, "websocketEndpoint", "JSON should contain 'websocketEndpoint' key")
+}
+
+func TestStatusResponseJSONMarshaling(t *testing.T) {
+	resp := models.StatusResponse{
+		ClusterName: "clusterA",
+		Status:      models.StatusOnboarded,
+	}
+	data, err := json.Marshal(resp)
+	assert.NoError(t, err)
+
+	var unmarshaled models.StatusResponse
+	err = json.Unmarshal(data, &unmarshaled)
+	assert.NoError(t, err)
+	assert.Equal(t, resp, unmarshaled)
+
+	jsonStr := string(data)
+	assert.Contains(t, jsonStr, "clusterName", "JSON should contain 'clusterName' key")
+	assert.Contains(t, jsonStr, "status", "JSON should contain 'status' key")
+}

--- a/backend/test/models/namespace_test.go
+++ b/backend/test/models/namespace_test.go
@@ -1,0 +1,54 @@
+package models_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kubestellar/ui/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNamespaceStructInitialization(t *testing.T) {
+	ns := models.Namespace{
+		Name:        "test-ns",
+		Status:      "Active",
+		Labels:      map[string]string{"env": "prod"},
+		Pods:        []string{"pod1", "pod2"},
+		Deployments: []string{"deploy1"},
+		Services:    []string{"svc1"},
+	}
+	assert.Equal(t, "test-ns", ns.Name)
+	assert.Equal(t, "Active", ns.Status)
+	assert.Equal(t, map[string]string{"env": "prod"}, ns.Labels)
+	assert.Equal(t, []string{"pod1", "pod2"}, ns.Pods)
+	assert.Equal(t, []string{"deploy1"}, ns.Deployments)
+	assert.Equal(t, []string{"svc1"}, ns.Services)
+}
+
+func TestNamespaceJSONMarshaling(t *testing.T) {
+	ns := models.Namespace{
+		Name:        "test-ns",
+		Status:      "Active",
+		Labels:      map[string]string{"env": "prod"},
+		Pods:        []string{"pod1", "pod2"},
+		Deployments: []string{"deploy1"},
+		Services:    []string{"svc1"},
+	}
+	data, err := json.Marshal(ns)
+	assert.NoError(t, err)
+
+	// Unmarshal to a map to check for the correct key
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+
+	_, hasName := result["name"]
+	_, hasNamespaceName := result["namespaceName"]
+	assert.True(t, hasName, "JSON should contain 'name' key")
+	assert.False(t, hasNamespaceName, "JSON should not contain 'namespaceName' key")
+
+	var unmarshaled models.Namespace
+	err = json.Unmarshal(data, &unmarshaled)
+	assert.NoError(t, err)
+	assert.Equal(t, ns, unmarshaled)
+}

--- a/backend/test/models/user_test.go
+++ b/backend/test/models/user_test.go
@@ -1,0 +1,18 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/kubestellar/ui/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHashAndCheckPassword(t *testing.T) {
+	password := "mysecret"
+	hash, err := models.HashPassword(password)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, hash)
+
+	assert.True(t, models.CheckPasswordHash(password, hash))
+	assert.False(t, models.CheckPasswordHash("wrongpassword", hash))
+} 

--- a/backend/test/models/user_test.go
+++ b/backend/test/models/user_test.go
@@ -15,4 +15,4 @@ func TestHashAndCheckPassword(t *testing.T) {
 
 	assert.True(t, models.CheckPasswordHash(password, hash))
 	assert.False(t, models.CheckPasswordHash("wrongpassword", hash))
-} 
+}


### PR DESCRIPTION
### Description

Added unit tests for all backend model structs (`User`, `Cluster`, `Namespace`) in the `models` package. These tests cover struct initialization, JSON marshaling/unmarshaling, and password hashing logic. This ensures data integrity, catches accidental changes to struct fields or tags, and improves maintainability.

### Related Issue

Fixes #1007 

### Changes Made
- Added `user_test.go`, `cluster_test.go`, and `namespace_test.go` in `backend/test/models/`.
- Tests verify:
   - Struct field correctness and initialization.
   - JSON serialization/deserialization and tag consistency.
   - Password hashing and verification logic.
   - Nested struct and API contract validation.

---
- [ ] Updated ...
- [ ] Refactored ...
- [ ] Fixed ...
- [x] Added tests for `Models Package`

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<img width="526" alt="Screenshot 2025-07-02 at 2 45 29 PM" src="https://github.com/user-attachments/assets/8c2814f5-e4e4-42f3-9905-2992fe700afe" />

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
