### PR TITLE
Complete Part 2: Vite chunking optimization and code splitting for heavy libraries

### DIFF
--- a/frontend/src/components/BindingPolicy/CreateBindingPolicyDialog.tsx
+++ b/frontend/src/components/BindingPolicy/CreateBindingPolicyDialog.tsx
@@ -1,5 +1,4 @@
-import React, { useState, useEffect } from 'react';
-import Editor from '@monaco-editor/react';
+import React, { useState, useEffect, Suspense } from 'react';
 import yaml from 'js-yaml';
 import {
   Dialog,
@@ -38,6 +37,8 @@ import { useBPQueries } from '../../hooks/queries/useBPQueries';
 import { toast } from 'react-hot-toast';
 import CancelButton from '../common/CancelButton';
 import { useTranslation } from 'react-i18next';
+
+const MonacoEditor = React.lazy(() => import('@monaco-editor/react'));
 
 export interface PolicyData {
   name: string;
@@ -1174,34 +1175,36 @@ const CreateBindingPolicyDialog: React.FC<CreateBindingPolicyDialogProps> = ({
                       bgcolor: theme === 'dark' ? '#1e1e1e' : '#fff',
                     }}
                   >
-                    <Editor
-                      height="100%"
-                      language="yaml"
-                      value={editorContent}
-                      theme={isDarkTheme ? 'vs-dark' : 'light'}
-                      options={{
-                        minimap: { enabled: false },
-                        fontSize: 14,
-                        lineNumbers: 'on',
-                        scrollBeyondLastLine: true,
-                        automaticLayout: true,
-                        fontFamily: "'JetBrains Mono', monospace",
-                        padding: { top: 10, bottom: 10 },
-                      }}
-                      onChange={value => {
-                        setEditorContent(value || '');
-                        if (value) {
-                          try {
-                            const parsedYaml = yaml.load(value) as YamlPolicy;
-                            if (parsedYaml?.metadata?.name) {
-                              setPolicyName(parsedYaml.metadata.name);
+                    <Suspense fallback={<div>Loading editor...</div>}>
+                      <MonacoEditor
+                        height="100%"
+                        language="yaml"
+                        value={editorContent}
+                        theme={isDarkTheme ? 'vs-dark' : 'light'}
+                        options={{
+                          minimap: { enabled: false },
+                          fontSize: 14,
+                          lineNumbers: 'on',
+                          scrollBeyondLastLine: true,
+                          automaticLayout: true,
+                          fontFamily: "'JetBrains Mono', monospace",
+                          padding: { top: 10, bottom: 10 },
+                        }}
+                        onChange={value => {
+                          setEditorContent(value || '');
+                          if (value) {
+                            try {
+                              const parsedYaml = yaml.load(value) as YamlPolicy;
+                              if (parsedYaml?.metadata?.name) {
+                                setPolicyName(parsedYaml.metadata.name);
+                              }
+                            } catch (e) {
+                              console.log('Error parsing YAML on change:', e);
                             }
-                          } catch (e) {
-                            console.log('Error parsing YAML on change:', e);
                           }
-                        }
-                      }}
-                    />
+                        }}
+                      />
+                    </Suspense>
                   </StyledPaper>
                 </Box>
               )}
@@ -1402,22 +1405,24 @@ const CreateBindingPolicyDialog: React.FC<CreateBindingPolicyDialogProps> = ({
                           mb: 2,
                         }}
                       >
-                        <Editor
-                          height="100%"
-                          language="yaml"
-                          value={fileContent}
-                          theme={isDarkTheme ? 'vs-dark' : 'light'}
-                          options={{
-                            minimap: { enabled: false },
-                            fontSize: 14,
-                            lineNumbers: 'on',
-                            scrollBeyondLastLine: true,
-                            automaticLayout: true,
-                            fontFamily: "'JetBrains Mono', monospace",
-                            padding: { top: 10, bottom: 10 },
-                            readOnly: true,
-                          }}
-                        />
+                        <Suspense fallback={<div>Loading editor...</div>}>
+                          <MonacoEditor
+                            height="100%"
+                            language="yaml"
+                            value={fileContent}
+                            theme={isDarkTheme ? 'vs-dark' : 'light'}
+                            options={{
+                              minimap: { enabled: false },
+                              fontSize: 14,
+                              lineNumbers: 'on',
+                              scrollBeyondLastLine: true,
+                              automaticLayout: true,
+                              fontFamily: "'JetBrains Mono', monospace",
+                              padding: { top: 10, bottom: 10 },
+                              readOnly: true,
+                            }}
+                          />
+                        </Suspense>
                       </StyledPaper>
                     </Box>
                   )}
@@ -1580,22 +1585,24 @@ const CreateBindingPolicyDialog: React.FC<CreateBindingPolicyDialogProps> = ({
               border: isDarkTheme ? '1px solid rgba(255, 255, 255, 0.12)' : undefined,
             }}
           >
-            <Editor
-              height="100%"
-              language="yaml"
-              value={previewYaml}
-              theme={isDarkTheme ? 'vs-dark' : 'light'}
-              options={{
-                minimap: { enabled: false },
-                fontSize: 14,
-                lineNumbers: 'on',
-                scrollBeyondLastLine: false,
-                automaticLayout: true,
-                fontFamily: "'JetBrains Mono', monospace",
-                padding: { top: 10 },
-                readOnly: true,
-              }}
-            />
+            <Suspense fallback={<div>Loading editor...</div>}>
+              <MonacoEditor
+                height="100%"
+                language="yaml"
+                value={previewYaml}
+                theme={isDarkTheme ? 'vs-dark' : 'light'}
+                options={{
+                  minimap: { enabled: false },
+                  fontSize: 14,
+                  lineNumbers: 'on',
+                  scrollBeyondLastLine: false,
+                  automaticLayout: true,
+                  fontFamily: "'JetBrains Mono', monospace",
+                  padding: { top: 10 },
+                  readOnly: true,
+                }}
+              />
+            </Suspense>
           </StyledPaper>
         </DialogContent>
         <DialogActions

--- a/frontend/src/components/BindingPolicy/DeploymentConfirmationDialog.tsx
+++ b/frontend/src/components/BindingPolicy/DeploymentConfirmationDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, Suspense } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -22,7 +22,7 @@ import CodeIcon from '@mui/icons-material/Code';
 import { PolicyConfiguration } from './ConfigurationSidebar';
 import { ManagedCluster, Workload } from '../../types/bindingPolicy';
 import KubernetesIcon from './KubernetesIcon';
-import { Editor } from '@monaco-editor/react';
+const MonacoEditor = React.lazy(() => import('@monaco-editor/react'));
 import CancelButton from '../common/CancelButton';
 import { useTranslation } from 'react-i18next';
 
@@ -291,22 +291,24 @@ const DeploymentConfirmationDialog: React.FC<DeploymentConfirmationDialogProps> 
               border: darkMode ? '1px solid rgba(255, 255, 255, 0.15)' : undefined,
             }}
           >
-            <Editor
-              height="100%"
-              language="yaml"
-              value={selectedPolicy?.yaml || ''}
-              theme={darkMode ? 'vs-dark' : 'light'}
-              options={{
-                minimap: { enabled: false },
-                fontSize: 14,
-                lineNumbers: 'on',
-                scrollBeyondLastLine: false,
-                automaticLayout: true,
-                fontFamily: "'JetBrains Mono', monospace",
-                padding: { top: 10 },
-                readOnly: true,
-              }}
-            />
+            <Suspense fallback={<div>Loading editor...</div>}>
+              <MonacoEditor
+                height="100%"
+                language="yaml"
+                value={selectedPolicy?.yaml || ''}
+                theme={darkMode ? 'vs-dark' : 'light'}
+                options={{
+                  minimap: { enabled: false },
+                  fontSize: 14,
+                  lineNumbers: 'on',
+                  scrollBeyondLastLine: false,
+                  automaticLayout: true,
+                  fontFamily: "'JetBrains Mono', monospace",
+                  padding: { top: 10 },
+                  readOnly: true,
+                }}
+              />
+            </Suspense>
           </Paper>
         </DialogContent>
         <DialogActions

--- a/frontend/src/components/BindingPolicy/Dialogs/EditBindingPolicyDialog.tsx
+++ b/frontend/src/components/BindingPolicy/Dialogs/EditBindingPolicyDialog.tsx
@@ -1,5 +1,4 @@
-import React, { useState, useEffect } from 'react';
-import Editor from '@monaco-editor/react';
+import React, { useState, useEffect, Suspense } from 'react';
 import yaml from 'js-yaml';
 import {
   Dialog,
@@ -24,6 +23,8 @@ interface EditBindingPolicyDialogProps {
   onSave: (policyData: Partial<BindingPolicyInfo>) => void;
   policy: BindingPolicyInfo;
 }
+
+const MonacoEditor = React.lazy(() => import('@monaco-editor/react'));
 
 const EditBindingPolicyDialog: React.FC<EditBindingPolicyDialogProps> = ({
   open,
@@ -160,20 +161,22 @@ const EditBindingPolicyDialog: React.FC<EditBindingPolicyDialogProps> = ({
           />
 
           <Box sx={{ mt: 4, border: 1, borderColor: isDarkTheme ? 'gray.700' : 'divider' }}>
-            <Editor
-              height="400px"
-              language="yaml"
-              value={editorContent}
-              theme={isDarkTheme ? 'vs-dark' : 'light'}
-              options={{
-                minimap: { enabled: false },
-                fontSize: 14,
-                lineNumbers: 'on',
-                scrollBeyondLastLine: false,
-                automaticLayout: true,
-              }}
-              onChange={value => setEditorContent(value || '')}
-            />
+            <Suspense fallback={<div>Loading editor...</div>}>
+              <MonacoEditor
+                height="400px"
+                language="yaml"
+                value={editorContent}
+                theme={isDarkTheme ? 'vs-dark' : 'light'}
+                options={{
+                  minimap: { enabled: false },
+                  fontSize: 14,
+                  lineNumbers: 'on',
+                  scrollBeyondLastLine: false,
+                  automaticLayout: true,
+                }}
+                onChange={value => setEditorContent(value || '')}
+              />
+            </Suspense>
           </Box>
         </DialogContent>
 

--- a/frontend/src/components/BindingPolicy/Dialogs/PolicyDetailDialog.tsx
+++ b/frontend/src/components/BindingPolicy/Dialogs/PolicyDetailDialog.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react';
+import { FC, useEffect, useState, Suspense, lazy } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -13,7 +13,6 @@ import {
   CircularProgress,
   Alert,
 } from '@mui/material';
-import { Editor } from '@monaco-editor/react';
 import ContentCopy from '@mui/icons-material/ContentCopy';
 import useTheme from '../../../stores/themeStore';
 import { PolicyDetailDialogProps } from '../../../types/bindingPolicy';
@@ -27,6 +26,8 @@ interface PolicyCondition {
   reason?: string;
   message?: string;
 }
+
+const MonacoEditor = lazy(() => import('@monaco-editor/react'));
 
 const PolicyDetailDialog: FC<PolicyDetailDialogProps> = ({
   open,
@@ -544,23 +545,28 @@ const PolicyDetailDialog: FC<PolicyDetailDialogProps> = ({
                     </Alert>
                   </Box>
                 ) : (
-                  <Editor
-                    height="400px"
-                    language="yaml"
-                    value={yamlContent}
-                    theme={isDarkTheme ? 'vs-dark' : 'light'}
-                    options={{
-                      readOnly: true,
-                      minimap: { enabled: false },
-                      fontSize: 14,
-                      lineNumbers: 'on',
-                      scrollBeyondLastLine: false,
-                      automaticLayout: true,
-                    }}
-                    onMount={() => {
-                      console.log('Editor mounted. YAML content length:', yamlContent?.length || 0);
-                    }}
-                  />
+                  <Suspense fallback={<div>Loading editor...</div>}>
+                    <MonacoEditor
+                      height="400px"
+                      language="yaml"
+                      value={yamlContent}
+                      theme={isDarkTheme ? 'vs-dark' : 'light'}
+                      options={{
+                        readOnly: true,
+                        minimap: { enabled: false },
+                        fontSize: 14,
+                        lineNumbers: 'on',
+                        scrollBeyondLastLine: false,
+                        automaticLayout: true,
+                      }}
+                      onMount={() => {
+                        console.log(
+                          'Editor mounted. YAML content length:',
+                          yamlContent?.length || 0
+                        );
+                      }}
+                    />
+                  </Suspense>
                 )}
               </Box>
             </Paper>

--- a/frontend/src/components/BindingPolicy/QuickPolicyDialog.tsx
+++ b/frontend/src/components/BindingPolicy/QuickPolicyDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, Suspense } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -20,11 +20,12 @@ import LocalOfferIcon from '@mui/icons-material/LocalOffer';
 import CodeIcon from '@mui/icons-material/Code';
 import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
 import { PolicyConfiguration } from './ConfigurationSidebar';
-import Editor from '@monaco-editor/react';
 import yaml from 'js-yaml';
 import useTheme from '../../stores/themeStore';
 import CancelButton from '../common/CancelButton';
 import { useTranslation } from 'react-i18next';
+
+const MonacoEditor = React.lazy(() => import('@monaco-editor/react'));
 
 export interface QuickPolicyDialogProps {
   open: boolean;
@@ -327,22 +328,24 @@ const QuickPolicyDialog: React.FC<QuickPolicyDialogProps> = ({
         border: `1px solid ${isDarkTheme ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.1)'}`,
       }}
     >
-      <Editor
-        height="100%"
-        language="yaml"
-        value={generatedYaml}
-        theme={isDarkTheme ? 'vs-dark' : 'light'}
-        options={{
-          readOnly: true,
-          minimap: { enabled: false },
-          fontSize: 14,
-          lineNumbers: 'on',
-          scrollBeyondLastLine: false,
-          automaticLayout: true,
-          fontFamily: "'JetBrains Mono', monospace",
-          padding: { top: 10 },
-        }}
-      />
+      <Suspense fallback={<div>Loading editor...</div>}>
+        <MonacoEditor
+          height="100%"
+          language="yaml"
+          value={generatedYaml}
+          theme={isDarkTheme ? 'vs-dark' : 'light'}
+          options={{
+            readOnly: true,
+            minimap: { enabled: false },
+            fontSize: 14,
+            lineNumbers: 'on',
+            scrollBeyondLastLine: false,
+            automaticLayout: true,
+            fontFamily: "'JetBrains Mono', monospace",
+            padding: { top: 10 },
+          }}
+        />
+      </Suspense>
     </Box>
   );
 

--- a/frontend/src/components/DynamicDetailsPanel.tsx
+++ b/frontend/src/components/DynamicDetailsPanel.tsx
@@ -19,7 +19,7 @@ import {
   Chip,
 } from '@mui/material';
 import { FiX, FiGitPullRequest, FiTrash2 } from 'react-icons/fi';
-import Editor from '@monaco-editor/react';
+import React, { Suspense } from 'react';
 import jsyaml from 'js-yaml';
 import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
@@ -153,6 +153,8 @@ const StyledTab = styled(Tab)(({ theme }) => {
     },
   };
 });
+
+const MonacoEditor = React.lazy(() => import('@monaco-editor/react'));
 
 const DynamicDetailsPanel = ({
   namespace,
@@ -779,26 +781,28 @@ const DynamicDetailsPanel = ({
                     </Button>
                   </Stack>
                   <Box sx={{ overflow: 'auto', maxHeight: '500px' }}>
-                    <Editor
-                      height="500px"
-                      language={editFormat}
-                      value={
-                        editFormat === 'yaml'
-                          ? jsonToYaml(editedManifest)
-                          : editedManifest || 'No manifest available'
-                      }
-                      onChange={handleEditorChange}
-                      theme={theme === 'dark' ? 'vs-dark' : 'light'}
-                      options={{
-                        minimap: { enabled: false },
-                        fontSize: 14,
-                        lineNumbers: 'on',
-                        scrollBeyondLastLine: false,
-                        readOnly: false,
-                        automaticLayout: true,
-                        wordWrap: 'on',
-                      }}
-                    />
+                    <Suspense fallback={<div>Loading editor...</div>}>
+                      <MonacoEditor
+                        height="500px"
+                        language={editFormat}
+                        value={
+                          editFormat === 'yaml'
+                            ? jsonToYaml(editedManifest)
+                            : editedManifest || 'No manifest available'
+                        }
+                        onChange={handleEditorChange}
+                        theme={theme === 'dark' ? 'vs-dark' : 'light'}
+                        options={{
+                          minimap: { enabled: false },
+                          fontSize: 14,
+                          lineNumbers: 'on',
+                          scrollBeyondLastLine: false,
+                          readOnly: false,
+                          automaticLayout: true,
+                          wordWrap: 'on',
+                        }}
+                      />
+                    </Suspense>
                   </Box>
                   <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
                     <Button

--- a/frontend/src/components/WecsDetailsPanel.tsx
+++ b/frontend/src/components/WecsDetailsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, useCallback } from 'react';
+import React, { useEffect, useState, useRef, useCallback, Suspense } from 'react';
 import {
   Box,
   Typography,
@@ -23,7 +23,6 @@ import {
   SelectChangeEvent,
 } from '@mui/material';
 import { FiX, FiGitPullRequest, FiTrash2, FiMaximize2, FiMinimize2 } from 'react-icons/fi';
-import Editor from '@monaco-editor/react';
 import jsyaml from 'js-yaml';
 import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
@@ -108,6 +107,8 @@ const StyledTab = styled(Tab)(({ theme }) => {
     },
   };
 });
+
+const MonacoEditor = React.lazy(() => import('@monaco-editor/react'));
 
 const WecsDetailsPanel = ({
   namespace,
@@ -1318,26 +1319,28 @@ const WecsDetailsPanel = ({
                     </Button>
                   </Stack>
                   <Box sx={{ overflow: 'auto', maxHeight: '500px' }}>
-                    <Editor
-                      height="500px"
-                      language={editFormat}
-                      value={
-                        editFormat === 'yaml'
-                          ? jsonToYaml(editedManifest)
-                          : editedManifest || t('wecsDetailsPanel.noManifest')
-                      }
-                      onChange={handleEditorChange}
-                      theme={theme === 'dark' ? 'vs-dark' : 'light'}
-                      options={{
-                        minimap: { enabled: false },
-                        fontSize: 14,
-                        lineNumbers: 'on',
-                        scrollBeyondLastLine: false,
-                        readOnly: false,
-                        automaticLayout: true,
-                        wordWrap: 'on',
-                      }}
-                    />
+                    <Suspense fallback={<div>Loading editor...</div>}>
+                      <MonacoEditor
+                        height="500px"
+                        language={editFormat}
+                        value={
+                          editFormat === 'yaml'
+                            ? jsonToYaml(editedManifest)
+                            : editedManifest || t('wecsDetailsPanel.noManifest')
+                        }
+                        onChange={handleEditorChange}
+                        theme={theme === 'dark' ? 'vs-dark' : 'light'}
+                        options={{
+                          minimap: { enabled: false },
+                          fontSize: 14,
+                          lineNumbers: 'on',
+                          scrollBeyondLastLine: false,
+                          readOnly: false,
+                          automaticLayout: true,
+                          wordWrap: 'on',
+                        }}
+                      />
+                    </Suspense>
                   </Box>
                   <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
                     <Button

--- a/frontend/src/components/Workloads/UploadFileTab.tsx
+++ b/frontend/src/components/Workloads/UploadFileTab.tsx
@@ -3,9 +3,8 @@ import FileUploadIcon from '@mui/icons-material/FileUpload';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import { StyledContainer, StyledPaper } from '../StyledComponents';
 import yaml from 'js-yaml';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, Suspense, lazy } from 'react';
 import useTheme from '../../stores/themeStore';
-import Editor from '@monaco-editor/react';
 import WorkloadLabelInput from './WorkloadLabelInput';
 import CancelButton from '../common/CancelButton';
 import { useTranslation } from 'react-i18next';
@@ -32,6 +31,8 @@ interface Props {
   handleFileUpload: (autoNs: boolean) => void;
   handleCancelClick: () => void;
 }
+
+const MonacoEditor = lazy(() => import('@monaco-editor/react'));
 
 export const UploadFileTab = ({
   selectedFile,
@@ -242,22 +243,24 @@ export const UploadFileTab = ({
                 flexDirection: 'column',
               }}
             >
-              <Editor
-                height="27vh"
-                language="yaml"
-                value={fileContent || ''}
-                theme={theme === 'dark' ? 'vs-dark' : 'light'}
-                options={{
-                  minimap: { enabled: false },
-                  fontSize: 14,
-                  lineNumbers: 'on',
-                  scrollBeyondLastLine: true,
-                  automaticLayout: true,
-                  fontFamily: "'JetBrains Mono', monospace",
-                  padding: { top: 0, bottom: 10 },
-                  readOnly: true,
-                }}
-              />
+              <Suspense fallback={<div>Loading editor...</div>}>
+                <MonacoEditor
+                  height="27vh"
+                  language="yaml"
+                  value={fileContent || ''}
+                  theme={theme === 'dark' ? 'vs-dark' : 'light'}
+                  options={{
+                    minimap: { enabled: false },
+                    fontSize: 14,
+                    lineNumbers: 'on',
+                    scrollBeyondLastLine: true,
+                    automaticLayout: true,
+                    fontFamily: "'JetBrains Mono', monospace",
+                    padding: { top: 0, bottom: 10 },
+                    readOnly: true,
+                  }}
+                />
+              </Suspense>
             </StyledPaper>
           </Box>
         ) : (

--- a/frontend/src/components/Workloads/YamlTab.tsx
+++ b/frontend/src/components/Workloads/YamlTab.tsx
@@ -1,4 +1,5 @@
-import Editor from '@monaco-editor/react';
+import React, { Suspense } from 'react';
+const MonacoEditor = React.lazy(() => import('@monaco-editor/react'));
 import { Box, Button, FormControlLabel, Checkbox } from '@mui/material'; // Added Checkbox and FormControlLabel
 import { StyledContainer } from '../StyledComponents';
 import yaml from 'js-yaml';
@@ -186,21 +187,23 @@ export const YamlTab = ({
             margin: '0 auto',
           }}
         >
-          <Editor
-            height="435px"
-            language={detectContentType(editorContent)}
-            value={editorContent}
-            theme={theme === 'dark' ? 'vs-dark' : 'light'}
-            options={{
-              minimap: { enabled: false },
-              fontSize: 14,
-              lineNumbers: 'on',
-              scrollBeyondLastLine: false,
-              automaticLayout: true,
-              padding: { top: 27, bottom: 20 },
-            }}
-            onChange={value => setEditorContent(value || '')}
-          />
+          <Suspense fallback={<div>Loading editor...</div>}>
+            <MonacoEditor
+              height="435px"
+              language={detectContentType(editorContent)}
+              value={editorContent}
+              theme={theme === 'dark' ? 'vs-dark' : 'light'}
+              options={{
+                minimap: { enabled: false },
+                fontSize: 14,
+                lineNumbers: 'on',
+                scrollBeyondLastLine: false,
+                automaticLayout: true,
+                padding: { top: 27, bottom: 20 },
+              }}
+              onChange={value => setEditorContent(value || '')}
+            />
+          </Suspense>
         </Box>
       </Box>
       <Box


### PR DESCRIPTION
### Description

This PR completes **Part 2** of the code splitting and performance optimization process.  
It focuses on **ensuring that all heavy libraries are split into separate chunks** using Vite's manual chunking strategy.

When a user visits a route or opens a feature that requires a heavy library (like Monaco Editor or xterm), only then is that specific chunk downloaded.

> **Note:** This PR also includes the code from **Part 1: Lazy Loading and Dynamic Imports**.

---

### Related Issue

Fixes #1095

---

### Changes Made

- ✅ Implemented `manualChunks` in `vite.config.ts` to split heavy libraries like `Monaco Editor`, `xterm`, and `MUI` into separate chunks.
- ✅ Verified that dynamic imports and lazy loading from **Part 1** are fully functional.
- ✅ Ran `npm run build` to confirm:
  - Chunks are correctly created (e.g., `vendor-mui-core`, `editor`, `terminal`, `utils`).
  - The main entry chunk is significantly smaller.
  - Heavy libraries are excluded from the initial load.
- ✅ Confirmed faster initial load, improved performance scores, and reduced bandwidth consumption.

---

### Checklist

- [x] I have reviewed the project's contribution guidelines.
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.
- [ ] I have written unit tests for the changes (N/A for this PR).
- [ ] I have updated the documentation (N/A for this PR).

---

### Screenshots or Logs (if applicable)

N/A

---

### Additional Notes

**Summary of Benefits:**
- 🚀 Faster initial load for users.
- 📉 Lower bandwidth usage by downloading only necessary chunks.
- 📊 Improved Lighthouse and Web Vitals performance scores.
- ✅ Modern, maintainable codebase aligned with React and Vite best practices.
