### PR TITLE
Fixes workloads.helm.userCharts (en) key returned object instead of string

### DIFF
--- a/frontend/src/components/Workloads/HelmTab/HelmTab.tsx
+++ b/frontend/src/components/Workloads/HelmTab/HelmTab.tsx
@@ -192,7 +192,7 @@ export const HelmTab = ({
             <FormControlLabel
               value="userCharts"
               control={<Radio />}
-              label={t('workloads.helm.userCharts')} // Instead of "List of user created Charts"
+              label={t('workloads.helm.prevCharts')} // Instead of "List of user created Charts"
               sx={{
                 '& .MuiTypography-root': {
                   color: theme === 'dark' ? '#d4d4d4' : '#333',

--- a/frontend/src/locales/strings.en.json
+++ b/frontend/src/locales/strings.en.json
@@ -1393,6 +1393,7 @@
     "helm": {
       "createOwn": "Create your own Helm chart",
       "popularCharts": "Deploy from popular Helm charts",
+      "prevCharts": "Previously Deployed Helm Charts",
       "form": {
         "repositoryName": "Repository Name *",
         "repositoryNameTip": "Specify the name of the Helm repository",

--- a/frontend/src/locales/strings.es.json
+++ b/frontend/src/locales/strings.es.json
@@ -1386,6 +1386,7 @@
     "helm": {
       "createOwn": "Crea tu propio chart de Helm",
       "popularCharts": "Implementa desde charts populares de Helm",
+      "prevCharts": "Lista de charts creados por el usuario",
       "form": {
         "repositoryName": "Nombre del repositorio *",
         "repositoryNameTip": "Especifica el nombre del repositorio de Helm",

--- a/frontend/src/locales/strings.fr.json
+++ b/frontend/src/locales/strings.fr.json
@@ -1388,6 +1388,7 @@
     "helm": {
       "createOwn": "Créez votre propre chart Helm",
       "popularCharts": "Déployer à partir de charts Helm populaires",
+      "prevCharts": "Liste des charts créés par l'utilisateur",
       "form": {
         "repositoryName": "Nom du Dépôt *",
         "repositoryNameTip": "Spécifiez le nom du dépôt Helm",

--- a/frontend/src/locales/strings.ja.json
+++ b/frontend/src/locales/strings.ja.json
@@ -1387,6 +1387,7 @@
     "helm": {
       "createOwn": "独自の Helm チャートを作成",
       "popularCharts": "人気の Helm チャートからデプロイ",
+      "prevCharts": "ユーザー作成チャート一覧",
       "form": {
         "repositoryName": "リポジトリ名 *",
         "repositoryNameTip": "Helm リポジトリの名前を指定してください",


### PR DESCRIPTION
### Description
Changes workloads.helm.userCharts key returned object instead of string to Previously Deployed Helm Charts

### Related Issue

Fixes #1264 

### Screenshots or Logs (if applicable)
![Screenshot from 2025-07-02 22-36-05](https://github.com/user-attachments/assets/508b2517-2f56-4138-8c76-a7d60d325b1d)

