### PR TITLE
[Fix]: spelling mistake in log message

### DIFF
--- a/backend/wds/bp/utils.go
+++ b/backend/wds/bp/utils.go
@@ -300,7 +300,7 @@ func extractTargetClusters(bp *v1alpha1.BindingPolicy) []string {
 		}
 	}
 
-	log.LogInfo("ectractTargetCLusters - returning clusters", zap.Int("count", len(clusters)), zap.Strings("clusters", clusters))
+	log.LogInfo("extractTargetCLusters - returning clusters", zap.Int("count", len(clusters)), zap.Strings("clusters", clusters))
 	return clusters
 }
 


### PR DESCRIPTION
FIXES #1293

## Before
backend-1 | {"level":"info","ts":1751551121.9881978,"caller":"log/log.go:8","msg":"ectractTargetCLusters - returning clusters","count":1,"clusters":["name:cluster1"]}

## After
backend-1 | {"level":"info","ts":1751551121.9881978,"caller":"log/log.go:8","msg":"extractTargetCLusters - returning clusters","count":1,"clusters":["name:cluster1"]}
