### PR TITLE
fix(animation):fix the sidebar animation sudden jerk 

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -200,10 +200,11 @@ export function Layout() {
                 </div>
               </motion.button>
             </div>
-
-            <Suspense fallback={<LoadingPlaceholder />}>
-              <Menu collapsed={isSidebarCollapsed} />
-            </Suspense>
+            <motion.div key={isSidebarCollapsed ? 'collapsed' : 'expanded'}>
+              <Suspense fallback={<LoadingPlaceholder />}>
+                <Menu collapsed={isSidebarCollapsed} />
+              </Suspense>
+            </motion.div>
           </motion.aside>
 
           {/* Mobile Menu - Overlay */}

--- a/frontend/src/components/menu/MenuItem.tsx
+++ b/frontend/src/components/menu/MenuItem.tsx
@@ -226,7 +226,7 @@ const MenuItem: React.FC<MenuItemProps> = ({
                       {/* Text label */}
                       {!collapsed && (
                         <motion.span
-                          className="ml-3 text-sm font-medium"
+                          className="ml-3 whitespace-nowrap text-sm font-medium"
                           style={{
                             color: isActive
                               ? isDark
@@ -300,7 +300,7 @@ const MenuItem: React.FC<MenuItemProps> = ({
 
                 {!collapsed && (
                   <motion.span
-                    className="ml-3 text-sm font-medium"
+                    className="ml-3 whitespace-nowrap text-sm  font-medium "
                     style={{
                       color:
                         hoveredItem === index


### PR DESCRIPTION
### Description
- The sidebar jerks during the animation. The issue is, the parent should be inside a motion.div, else it will create  random animation issue 
<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #1296 

### Changes Made
- wrap the sidebar by `<motion.div>`
- add no wrap to the lables , which create the sudden jerk during expansion

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)
## Before
[Screencast from 2025-07-03 20-51-48.webm](https://github.com/user-attachments/assets/2bbc144c-a48a-4d52-aefc-9fbd588b9733)
## after 
[Screencast from 2025-07-03 21-25-46.webm](https://github.com/user-attachments/assets/bcddd2d7-933f-4bcc-b63a-6627dd6d1a7c)



<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
