### PR TITLE
fix(logs):improve the clearity of caller field

### DIFF
--- a/backend/log/log.go
+++ b/backend/log/log.go
@@ -30,7 +30,6 @@ func init() {
 	cfg := zap.NewProductionConfig()
 	cfg.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
 	cfg.DisableStacktrace = true
-	zapLogger, _ := cfg.Build()
-	logger = zapLogger
-
+	baseLogger, _ := cfg.Build()
+	logger = baseLogger.WithOptions(zap.AddCallerSkip(1))
 }


### PR DESCRIPTION
### Description

This PR updates the logger implementation in log/log.go to correctly reflect the actual caller's file and line number in log output. Previously, all log entries pointed to log/log.go due to wrapper functions around zap. This enhancement uses zap.AddCallerSkip(1) to resolve the issue.

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #1299 

### Changes Made
 - update `log/log.go` , Logs now show the true origin of the log call instead of the wrapper.

### Checklist

Please ensure the following before submitting your PR:

- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)


# before
```
{"level":"info","ts":1751565962.379965,"caller":"log/log.go:8","msg":"Namespace cache miss","key":"ns_kubestellar-report_ctx_wds1_res_rbac.authorization.k8s.io_v1_roles"}
{"level":"info","ts":1751565962.574486,"caller":"log/log.go:8","msg":"Getting namespace cache","key":"ns_default_ctx_wds1_res_rbac.authorization.k8s.io_v1_roles"}
{"level":"info","ts":1751565962.5752754,"caller":"log/log.go:8","msg":"Namespace cache miss","key":"ns_default_ctx_wds1_res_rbac.authorization.k8s.io_v1_roles"}
{"level":"info","ts":1751565962.578465,"caller":"log/log.go:8","msg":"Getting namespace cache","key":"ns_kubestellar-report_ctx_wds1_res_rbac.authorization.k8s.io_v1_rolebindings"}
{"level":"info","ts":1751565962.579086,"caller":"log/log.go:8","msg":"Namespace cache miss","key":"ns_kubestellar-report_ctx_wds1_res_rbac.authorization.k8s.io_v1_rolebindings"}
```
# after 
```
{"level":"info","ts":1751566382.1373203,"caller":"redis/redis.go:21","msg":"Setting namespace cache","key":"namespace_wds1_default","expiration":5}
{"level":"info","ts":1751566382.138162,"caller":"redis/redis.go:21","msg":"Setting namespace cache","key":"namespace_data_wds1","expiration":5}
{"level":"info","ts":1751566382.139519,"caller":"redis/redis.go:35","msg":"Getting namespace cache","key":"namespace_data_wds1"}
```

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
