### PR TITLE
Updated Docker ignore

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -6,7 +6,6 @@
 *.a
 
 # Ignore Go modules cache
-/pkg/
 vendor/
 
 # Ignore dependency files (if using Go modules, only go.mod & go.sum are needed)

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/kubestellar/kubestellar v0.26.0
 	github.com/lib/pq v1.10.9
 	github.com/prometheus/client_golang v1.22.0
+	github.com/prometheus/client_model v0.6.1
+	github.com/prometheus/common v0.62.0
 	github.com/redis/go-redis/v9 v9.7.3
 	github.com/stretchr/testify v1.10.0
 	github.com/tetratelabs/wazero v1.9.0
@@ -88,8 +90,6 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.1 // indirect
-	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rubenv/sql-migrate v1.7.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect


### PR DESCRIPTION
 Changes made to the Docker ignore file and updates the Go module dependencies in the `backend` project. The most notable changes include modifying the `.dockerignore` file to stop ignoring the `/pkg/` directory and adjusting the `go.mod` file to promote certain Prometheus-related dependencies from indirect to direct dependencies.


### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

