### PR TITLE
fix: update Change Password modal to support theme-aware styling

### DIFF
--- a/frontend/src/components/ProfileSection.tsx
+++ b/frontend/src/components/ProfileSection.tsx
@@ -198,7 +198,7 @@ const ProfileSection = () => {
         <div
           className="relative flex w-full max-w-lg flex-col"
           style={{
-            background: isDark ? '#1f2937' : '#fff',
+            background: isDark ? '#232f3e' : '#fff',
             borderRadius: '18px',
             boxShadow: themeStyles.colors.shadow.lg,
             border: `1.5px solid ${themeStyles.effects.glassMorphism.borderColor}`,

--- a/frontend/src/components/ProfileSection.tsx
+++ b/frontend/src/components/ProfileSection.tsx
@@ -11,6 +11,7 @@ import { Eye, EyeOff } from 'lucide-react';
 import { CheckCircle, XCircle } from 'lucide-react';
 import CloseIcon from '@mui/icons-material/Close';
 import { createPortal } from 'react-dom';
+import getThemeStyles from '../lib/theme-utils';
 
 // Array of profile icon components to randomly select from
 const profileIcons = [
@@ -27,6 +28,7 @@ const ProfileSection = () => {
   const navigate = useNavigate();
   const { theme } = useTheme();
   const isDark = theme === 'dark';
+  const themeStyles = getThemeStyles(isDark);
 
   const { data: authData } = useAuth();
   const { logout } = useAuthActions();
@@ -196,11 +198,10 @@ const ProfileSection = () => {
         <div
           className="relative flex w-full max-w-lg flex-col"
           style={{
-            background: '#232f3e',
-            backgroundColor: '#232f3e',
+            background: isDark ? '#1f2937' : '#fff',
             borderRadius: '18px',
-            boxShadow: '0 8px 32px 0 rgba(0,0,0,0.65)',
-            border: '1.5px solid #2d3748',
+            boxShadow: themeStyles.colors.shadow.lg,
+            border: `1.5px solid ${themeStyles.effects.glassMorphism.borderColor}`,
             minWidth: 0,
             width: '100%',
             maxWidth: 480,
@@ -211,7 +212,8 @@ const ProfileSection = () => {
           <button
             type="button"
             aria-label="Close change password dialog"
-            className="absolute right-5 top-5 z-10 rounded-full p-1 text-gray-400 transition-colors hover:text-gray-200 focus:outline-none focus:ring-2 focus:ring-primary"
+            className="absolute right-5 top-5 z-10 rounded-full p-1 transition-colors hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-primary dark:hover:bg-gray-700"
+            style={{ color: themeStyles.colors.text.secondary, background: 'transparent' }}
             onClick={() => {
               setShowChangePasswordModal(false);
               setCurrentPassword('');
@@ -226,7 +228,7 @@ const ProfileSection = () => {
           <div style={{ padding: '2.5rem 2.5rem 2rem 2.5rem', width: '100%' }}>
             <h2
               style={{
-                color: '#fff',
+                color: themeStyles.colors.text.primary,
                 fontWeight: 700,
                 fontSize: 24,
                 marginBottom: '0.5rem',
@@ -237,7 +239,12 @@ const ProfileSection = () => {
               {t('profileSection.changePassword')}
             </h2>
             <div
-              style={{ color: '#cbd5e1', fontSize: 16, marginBottom: '2rem', textAlign: 'left' }}
+              style={{
+                color: themeStyles.colors.text.secondary,
+                fontSize: 16,
+                marginBottom: '2rem',
+                textAlign: 'left',
+              }}
             >
               {t('profileSection.changePasswordSubtitle')}
             </div>
@@ -246,7 +253,7 @@ const ProfileSection = () => {
                 <label
                   className="mb-2 block text-sm font-semibold"
                   htmlFor="current-password"
-                  style={{ color: '#fff', fontSize: 15 }}
+                  style={{ color: themeStyles.colors.text.primary, fontSize: 15 }}
                 >
                   {t('profileSection.currentPassword')}
                 </label>
@@ -257,11 +264,11 @@ const ProfileSection = () => {
                     style={{
                       width: '100%',
                       borderRadius: 10,
-                      background: '#2d3748',
-                      color: '#fff',
+                      background: themeStyles.input.background,
+                      color: themeStyles.input.color,
                       fontSize: 16,
                       padding: '1rem',
-                      border: 'none',
+                      border: `1px solid ${themeStyles.input.borderColor}`,
                       outline: 'none',
                       marginBottom: 0,
                     }}
@@ -280,7 +287,7 @@ const ProfileSection = () => {
                         ? t('login.form.hidePassword')
                         : t('login.form.showPassword')
                     }
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200 focus:outline-none"
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-700 focus:outline-none dark:hover:text-gray-200"
                     onClick={() => setShowCurrentPassword(v => !v)}
                     style={{ background: 'none', border: 'none', padding: 0, margin: 0 }}
                   >
@@ -292,7 +299,7 @@ const ProfileSection = () => {
                 <label
                   className="mb-2 block text-sm font-semibold"
                   htmlFor="new-password"
-                  style={{ color: '#fff', fontSize: 15 }}
+                  style={{ color: themeStyles.colors.text.primary, fontSize: 15 }}
                 >
                   {t('profileSection.newPassword')}
                 </label>
@@ -303,11 +310,11 @@ const ProfileSection = () => {
                     style={{
                       width: '100%',
                       borderRadius: 10,
-                      background: '#2d3748',
-                      color: '#fff',
+                      background: themeStyles.input.background,
+                      color: themeStyles.input.color,
                       fontSize: 16,
                       padding: '1rem',
-                      border: 'none',
+                      border: `1px solid ${themeStyles.input.borderColor}`,
                       outline: 'none',
                       marginBottom: 0,
                     }}
@@ -324,7 +331,7 @@ const ProfileSection = () => {
                     aria-label={
                       showNewPassword ? t('login.form.hidePassword') : t('login.form.showPassword')
                     }
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200 focus:outline-none"
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-700 focus:outline-none dark:hover:text-gray-200"
                     onClick={() => setShowNewPassword(v => !v)}
                     style={{ background: 'none', border: 'none', padding: 0, margin: 0 }}
                   >
@@ -336,7 +343,7 @@ const ProfileSection = () => {
                 <label
                   className="mb-2 block text-sm font-semibold"
                   htmlFor="confirm-new-password"
-                  style={{ color: '#fff', fontSize: 15 }}
+                  style={{ color: themeStyles.colors.text.primary, fontSize: 15 }}
                 >
                   {t('profileSection.confirmNewPassword')}
                 </label>
@@ -347,11 +354,11 @@ const ProfileSection = () => {
                     style={{
                       width: '100%',
                       borderRadius: 10,
-                      background: '#2d3748',
-                      color: '#fff',
+                      background: themeStyles.input.background,
+                      color: themeStyles.input.color,
                       fontSize: 16,
                       padding: '1rem',
-                      border: 'none',
+                      border: `1px solid ${themeStyles.input.borderColor}`,
                       outline: 'none',
                       marginBottom: 0,
                     }}
@@ -370,14 +377,9 @@ const ProfileSection = () => {
                         ? t('login.form.hidePassword')
                         : t('login.form.showPassword')
                     }
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200 focus:outline-none"
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-700 focus:outline-none dark:hover:text-gray-200"
                     onClick={() => setShowConfirmNewPassword(v => !v)}
-                    style={{
-                      background: 'none',
-                      border: 'none',
-                      padding: 0,
-                      margin: 0,
-                    }}
+                    style={{ background: 'none', border: 'none', padding: 0, margin: 0 }}
                   >
                     {showConfirmNewPassword ? <EyeOff size={22} /> : <Eye size={22} />}
                   </button>
@@ -392,7 +394,7 @@ const ProfileSection = () => {
                     style={{
                       display: 'flex',
                       alignItems: 'center',
-                      color: '#4ade80', // green-400
+                      color: themeStyles.colors.status.success,
                       fontSize: 14,
                       marginTop: '0.3rem',
                       marginBottom: '0.5rem',
@@ -411,7 +413,7 @@ const ProfileSection = () => {
                   style={{
                     display: 'flex',
                     alignItems: 'center',
-                    color: '#e57373', // red-400
+                    color: themeStyles.colors.status.error,
                     fontSize: 14,
                     marginTop: '0.3rem',
                     marginBottom: '0.5rem',
@@ -430,8 +432,8 @@ const ProfileSection = () => {
                   formError !== t('profileSection.passwordsDoNotMatch')) && (
                   <div
                     style={{
-                      background: '#2d2323',
-                      color: '#e57373',
+                      background: isDark ? 'rgba(239, 68, 68, 0.1)' : 'rgba(254, 226, 226, 0.5)',
+                      color: themeStyles.colors.status.error,
                       borderRadius: 8,
                       fontSize: 16,
                       padding: '0.7rem 1rem',
@@ -450,15 +452,19 @@ const ProfileSection = () => {
                     flex: 1,
                     height: 48,
                     borderRadius: 8,
-                    background: '#374151',
-                    color: '#fff',
+                    background: isDark ? '#374151' : '#f3f4f6',
+                    color: isDark ? '#fff' : '#1e293b',
                     fontWeight: 600,
                     fontSize: 16,
                     border: 'none',
                     transition: 'background 0.2s',
                   }}
-                  onMouseOver={e => (e.currentTarget.style.background = '#27303f')}
-                  onMouseOut={e => (e.currentTarget.style.background = '#374151')}
+                  onMouseOver={e =>
+                    (e.currentTarget.style.background = isDark ? '#27303f' : '#e5e7eb')
+                  }
+                  onMouseOut={e =>
+                    (e.currentTarget.style.background = isDark ? '#374151' : '#f3f4f6')
+                  }
                   onClick={() => {
                     setShowChangePasswordModal(false);
                     setCurrentPassword('');


### PR DESCRIPTION
### Description

Fixed the theming issue in the **Change Password modal** where it always appeared in dark mode, even when the app was in light mode.  
The modal now correctly adapts to both light and dark themes using theme-aware styles.

### Related Issue

Fixes #1322

### Changes Made

- [x] Updated the Change Password modal to use theme-aware styles.
- [x] Fixed the modal background to correctly switch based on the selected theme.
- [x] Ensured visual consistency across both light and dark modes.

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

[Screencast from 04-07-25 05:39:00 PM IST.webm](https://github.com/user-attachments/assets/6cef22fd-59dc-4895-aba5-459d9b4936b8)


### Additional Notes

