### PR TITLE
Widen dashboard page to match full width of other main pages

### DIFF
--- a/frontend/src/components/Clusters.tsx
+++ b/frontend/src/components/Clusters.tsx
@@ -1587,7 +1587,7 @@ const K8sInfo = () => {
 
   return (
     <motion.div
-      className="mx-auto w-full max-w-7xl p-4 md:p-6"
+      className="mx-auto w-full p-4 md:p-6"
       variants={pageAnimationVariant}
       initial="initial"
       animate="animate"


### PR DESCRIPTION
### Description

This PR widens the dashboard page to match the full width of other main pages in the application. Previously, the dashboard was constrained by a `max-w-7xl` class, making it appear narrower than other pages. By removing this constraint, the dashboard now utilizes the available horizontal space, providing a more consistent and visually appealing layout across the app.

### Related Issue

Fixes #1338

### Screenshots or Logs (if applicable)

[Dashboard](https://github.com/user-attachments/assets/33e76cce-2822-4c6e-95d3-11e7b0f8e422)
