### PR TITLE
✨fix(auth): properly type Axios request config for retry logic

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+coverage/

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint';
 import eslintConfigPrettier from 'eslint-config-prettier';
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  { ignores: ['dist', 'coverage/'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended, eslintConfigPrettier],
     files: ['**/*.{ts,tsx}'],

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,6 +32,7 @@
         "i18next": "^25.2.1",
         "i18next-browser-languagedetector": "^8.1.0",
         "js-yaml": "^4.1.0",
+        "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
         "lucide-react": "^0.474.0",
         "monaco-editor": "^0.52.2",
@@ -8521,6 +8522,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
     "i18next": "^25.2.1",
     "i18next-browser-languagedetector": "^8.1.0",
     "js-yaml": "^4.1.0",
+    "jwt-decode": "^4.0.0",
     "lodash": "^4.17.21",
     "lucide-react": "^0.474.0",
     "monaco-editor": "^0.52.2",

--- a/frontend/src/components/login/tokenUtils.ts
+++ b/frontend/src/components/login/tokenUtils.ts
@@ -1,0 +1,71 @@
+// Token and refresh logic moved from src/lib/api.ts
+import axios from 'axios';
+import { toast } from 'react-hot-toast';
+import { AxiosInstance } from 'axios';
+
+const REFRESH_ENDPOINT = process.env.VITE_REFRESH_ENDPOINT || '/api/refresh';
+const ACCESS_TOKEN_KEY = 'jwtToken';
+const REFRESH_TOKEN_KEY = 'refreshToken';
+
+export function getAccessToken() {
+  return localStorage.getItem(ACCESS_TOKEN_KEY);
+}
+
+export function setAccessToken(token: string) {
+  localStorage.setItem(ACCESS_TOKEN_KEY, token);
+}
+
+export function getRefreshToken() {
+  return localStorage.getItem(REFRESH_TOKEN_KEY);
+}
+
+export function setRefreshToken(token: string) {
+  localStorage.setItem(REFRESH_TOKEN_KEY, token);
+}
+
+export function clearTokens() {
+  localStorage.removeItem(ACCESS_TOKEN_KEY);
+  localStorage.removeItem(REFRESH_TOKEN_KEY);
+}
+
+export function isTokenExpired(token: string | null): boolean {
+  if (!token) return true;
+  try {
+    const [, payload] = token.split('.');
+    const decoded = JSON.parse(atob(payload));
+    if (!decoded.exp) return true;
+    return Date.now() >= decoded.exp * 1000;
+  } catch {
+    return true;
+  }
+}
+
+let isRefreshing = false;
+let refreshPromise: Promise<string | null> | null = null;
+
+export async function refreshAccessToken(api: AxiosInstance): Promise<string | null> {
+  if (isRefreshing && refreshPromise) return refreshPromise;
+  isRefreshing = true;
+  const refreshToken = getRefreshToken();
+  if (!refreshToken) {
+    isRefreshing = false;
+    return null;
+  }
+  refreshPromise = api
+    .post(REFRESH_ENDPOINT, { refreshToken })
+    .then(res => {
+      const { token, refreshToken: newRefreshToken } = res.data;
+      if (token) setAccessToken(token);
+      if (newRefreshToken) setRefreshToken(newRefreshToken);
+      isRefreshing = false;
+      refreshPromise = null;
+      return token;
+    })
+    .catch(() => {
+      isRefreshing = false;
+      refreshPromise = null;
+      clearTokens();
+      return null;
+    });
+  return refreshPromise;
+} 

--- a/frontend/src/components/login/tokenUtils.ts
+++ b/frontend/src/components/login/tokenUtils.ts
@@ -29,7 +29,7 @@ export function clearTokens() {
 
 interface JwtPayload {
   exp?: number;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export function isTokenExpired(token: string | null): boolean {

--- a/frontend/src/components/login/tokenUtils.ts
+++ b/frontend/src/components/login/tokenUtils.ts
@@ -1,6 +1,4 @@
 // Token and refresh logic moved from src/lib/api.ts
-import axios from 'axios';
-import { toast } from 'react-hot-toast';
 import { AxiosInstance } from 'axios';
 
 const REFRESH_ENDPOINT = process.env.VITE_REFRESH_ENDPOINT || '/api/refresh';
@@ -68,4 +66,4 @@ export async function refreshAccessToken(api: AxiosInstance): Promise<string | n
       return null;
     });
   return refreshPromise;
-} 
+}

--- a/frontend/src/components/login/tokenUtils.ts
+++ b/frontend/src/components/login/tokenUtils.ts
@@ -1,7 +1,8 @@
 // Token and refresh logic moved from src/lib/api.ts
 import { AxiosInstance } from 'axios';
+import { jwtDecode } from 'jwt-decode';
 
-const REFRESH_ENDPOINT = process.env.VITE_REFRESH_ENDPOINT || '/api/refresh';
+const REFRESH_ENDPOINT = import.meta.env.VITE_REFRESH_ENDPOINT || '/api/refresh';
 const ACCESS_TOKEN_KEY = 'jwtToken';
 const REFRESH_TOKEN_KEY = 'refreshToken';
 
@@ -26,11 +27,15 @@ export function clearTokens() {
   localStorage.removeItem(REFRESH_TOKEN_KEY);
 }
 
+interface JwtPayload {
+  exp?: number;
+  [key: string]: any;
+}
+
 export function isTokenExpired(token: string | null): boolean {
   if (!token) return true;
   try {
-    const [, payload] = token.split('.');
-    const decoded = JSON.parse(atob(payload));
+    const decoded = jwtDecode<JwtPayload>(token);
     if (!decoded.exp) return true;
     return Date.now() >= decoded.exp * 1000;
   } catch {

--- a/frontend/src/hooks/queries/useLogin.ts
+++ b/frontend/src/hooks/queries/useLogin.ts
@@ -7,6 +7,7 @@ import { LoginUser } from '../../api/auth';
 import { AUTH_QUERY_KEY } from '../../api/auth/constant';
 import { useTranslation } from 'react-i18next';
 import { encryptData, secureSet, secureRemove } from '../../utils/secureStorage';
+import { setAccessToken, setRefreshToken, clearTokens } from '../../lib/api';
 
 interface LoginCredentials {
   username: string;
@@ -28,8 +29,14 @@ export const useLogin = () => {
         if (!response.token) {
           throw new Error(t('auth.login.noToken'));
         }
-
-        localStorage.setItem('jwtToken', response.token);
+        setAccessToken(response.token);
+        if (
+          'refreshToken' in response &&
+          typeof response.refreshToken === 'string' &&
+          response.refreshToken
+        ) {
+          setRefreshToken(response.refreshToken);
+        }
 
         if (rememberMe) {
           // Use secure storage with XSS protection
@@ -92,4 +99,10 @@ export const useLogin = () => {
       toast.error(errorMessage);
     },
   });
+};
+
+export const logout = () => {
+  clearTokens();
+  localStorage.setItem('tokenRemovalTime', Date.now().toString());
+  window.dispatchEvent(new Event('storage'));
 };

--- a/frontend/src/hooks/queries/useLogin.ts
+++ b/frontend/src/hooks/queries/useLogin.ts
@@ -7,7 +7,7 @@ import { LoginUser } from '../../api/auth';
 import { AUTH_QUERY_KEY } from '../../api/auth/constant';
 import { useTranslation } from 'react-i18next';
 import { encryptData, secureSet, secureRemove } from '../../utils/secureStorage';
-import { setAccessToken, setRefreshToken, clearTokens } from '../../lib/api';
+import { setAccessToken, setRefreshToken, clearTokens } from '../../components/login/tokenUtils';
 
 interface LoginCredentials {
   username: string;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -106,7 +106,7 @@ api.interceptors.response.use(
       return Promise.reject(error);
     }
 
-    const originalRequest = error.config as (AxiosRequestConfig & { _retry?: boolean });
+    const originalRequest = error.config as AxiosRequestConfig & { _retry?: boolean };
     const errorMessage =
       error.response?.data?.message || error.response?.data?.error || error.message;
     const isAuthCheck = error.config?.url?.includes('/api/me');

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,9 @@
 import axios, { AxiosRequestConfig } from 'axios';
 import { toast } from 'react-hot-toast';
 
+// Configurable refresh endpoint
+const REFRESH_ENDPOINT = process.env.VITE_REFRESH_ENDPOINT || '/api/refresh';
+
 export const api = axios.create({
   baseURL: process.env.VITE_BASE_URL,
   timeout: 60000,
@@ -61,7 +64,7 @@ async function refreshAccessToken(): Promise<string | null> {
     return null;
   }
   refreshPromise = api
-    .post('/api/refresh', { refreshToken })
+    .post(REFRESH_ENDPOINT, { refreshToken })
     .then(res => {
       const { token, refreshToken: newRefreshToken } = res.data;
       if (token) setAccessToken(token);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,16 +2,10 @@ import axios, { AxiosRequestConfig } from 'axios';
 import { toast } from 'react-hot-toast';
 import {
   getAccessToken,
-  setAccessToken,
-  getRefreshToken,
-  setRefreshToken,
   clearTokens,
   isTokenExpired,
-  refreshAccessToken
+  refreshAccessToken,
 } from '../components/login/tokenUtils';
-
-// Configurable refresh endpoint
-const REFRESH_ENDPOINT = process.env.VITE_REFRESH_ENDPOINT || '/api/refresh';
 
 export const api = axios.create({
   baseURL: process.env.VITE_BASE_URL,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError } from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 import { toast } from 'react-hot-toast';
 
 export const api = axios.create({
@@ -9,10 +9,84 @@ export const api = axios.create({
   },
 });
 
+// Helper functions for token management
+const ACCESS_TOKEN_KEY = 'jwtToken';
+const REFRESH_TOKEN_KEY = 'refreshToken';
+
+export function getAccessToken() {
+  return localStorage.getItem(ACCESS_TOKEN_KEY);
+}
+
+export function setAccessToken(token: string) {
+  localStorage.setItem(ACCESS_TOKEN_KEY, token);
+}
+
+export function getRefreshToken() {
+  return localStorage.getItem(REFRESH_TOKEN_KEY);
+}
+
+export function setRefreshToken(token: string) {
+  localStorage.setItem(REFRESH_TOKEN_KEY, token);
+}
+
+export function clearTokens() {
+  localStorage.removeItem(ACCESS_TOKEN_KEY);
+  localStorage.removeItem(REFRESH_TOKEN_KEY);
+}
+
+// Helper to decode JWT and check expiration
+function isTokenExpired(token: string | null): boolean {
+  if (!token) return true;
+  try {
+    const [, payload] = token.split('.');
+    const decoded = JSON.parse(atob(payload));
+    if (!decoded.exp) return true;
+    // exp is in seconds
+    return Date.now() >= decoded.exp * 1000;
+  } catch {
+    return true;
+  }
+}
+
+// Helper to refresh token
+let isRefreshing = false;
+let refreshPromise: Promise<string | null> | null = null;
+
+async function refreshAccessToken(): Promise<string | null> {
+  if (isRefreshing && refreshPromise) return refreshPromise;
+  isRefreshing = true;
+  const refreshToken = getRefreshToken();
+  if (!refreshToken) {
+    isRefreshing = false;
+    return null;
+  }
+  refreshPromise = api
+    .post('/api/refresh', { refreshToken })
+    .then(res => {
+      const { token, refreshToken: newRefreshToken } = res.data;
+      if (token) setAccessToken(token);
+      if (newRefreshToken) setRefreshToken(newRefreshToken);
+      isRefreshing = false;
+      refreshPromise = null;
+      return token;
+    })
+    .catch(() => {
+      isRefreshing = false;
+      refreshPromise = null;
+      clearTokens();
+      return null;
+    });
+  return refreshPromise;
+}
+
 // Add request interceptor to include JWT token in headers
 api.interceptors.request.use(
-  config => {
-    const token = localStorage.getItem('jwtToken');
+  async config => {
+    let token = getAccessToken();
+    // If token is expired, try to refresh
+    if (isTokenExpired(token)) {
+      token = await refreshAccessToken();
+    }
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
@@ -26,16 +100,32 @@ api.interceptors.request.use(
 // Add response interceptors with proper error typing
 api.interceptors.response.use(
   response => response,
-  (error: AxiosError<{ message: string; error: string }>) => {
-    // Handle global error cases
+  async (error: unknown) => {
+    if (!axios.isAxiosError(error)) {
+      toast.error('An unknown error occurred.');
+      return Promise.reject(error);
+    }
+
+    const originalRequest = error.config as (AxiosRequestConfig & { _retry?: boolean });
     const errorMessage =
       error.response?.data?.message || error.response?.data?.error || error.message;
-
-    console.error('API Error:', errorMessage);
-
-    // Don't show toast for 401 errors on verification endpoint to prevent
-    // unnecessary error messages during auth checks
     const isAuthCheck = error.config?.url?.includes('/api/me');
+
+    if (error.response?.status === 401 && !originalRequest._retry && !isAuthCheck) {
+      originalRequest._retry = true;
+      const newToken = await refreshAccessToken();
+      if (newToken) {
+        originalRequest.headers = originalRequest.headers || {};
+        originalRequest.headers.Authorization = `Bearer ${newToken}`;
+        return api(originalRequest);
+      } else {
+        clearTokens();
+        toast.error('Session expired. Please log in again.');
+        window.location.href = '/login';
+        return Promise.reject(error);
+      }
+    }
+
     if (error.response?.status === 401 && isAuthCheck) {
       console.log('Auth verification failed, ignoring toast');
     } else {


### PR DESCRIPTION
### Summary

This PR implements frontend support for automatic handling of JWT token expiration and refresh.

### Features

- 🕒 Detects when JWT token is expired before sending a request
- 🔁 Automatically refreshes token using `/api/refresh`
- ✅ Retries the original request after successful token refresh
- 🚫 If refresh fails, logs out user and redirects to login
- 🔐 Stores both access and refresh tokens securely
- 📣 Provides clear toast messages on auth-related issues
- 🔧 Fixes TypeScript `any` usage in Axios interceptor
- 🧹 Ignores `coverage/` files from eslint to reduce noise

fixes  #877 