### PR TITLE
refactor: switch from pluginName to pluginID in all handlers and API calls

### DIFF
--- a/backend/plugin/plugin.go
+++ b/backend/plugin/plugin.go
@@ -4,6 +4,8 @@ import "github.com/gin-gonic/gin"
 
 // plugin interface defines methods that a KS plugin must implement
 type Plugin interface {
+	// ID of the plugin
+	ID() int
 	// name of the plugin
 	Name() string
 	// version of your plugin

--- a/backend/plugin/plugins/backup_plugin.go
+++ b/backend/plugin/plugins/backup_plugin.go
@@ -18,6 +18,7 @@ import (
 )
 
 var (
+	pluginID      = 1
 	pluginName    = "backup-plugin"
 	pluginVersion = "0.0.1"
 )
@@ -25,6 +26,10 @@ var (
 type backupPlugin struct {
 	storageType string
 	c           *kubernetes.Clientset
+}
+
+func (p backupPlugin) ID() int {
+	return pluginID
 }
 
 func (p backupPlugin) Name() string {

--- a/backend/plugin/plugins/manager.go
+++ b/backend/plugin/plugins/manager.go
@@ -15,7 +15,7 @@ import (
 // a centralized manager that handles our plugins
 
 type pluginManager struct {
-	plugins map[string]plugin.Plugin
+	plugins map[int]plugin.Plugin
 	mx      sync.Mutex
 }
 
@@ -62,7 +62,7 @@ func (pm *pluginManager) SetupPluginsRoutes(e *gin.Engine) {
 func (pm *pluginManager) Register(p plugin.Plugin) {
 	pm.mx.Lock()
 	defer pm.mx.Unlock()
-	pm.plugins[p.Name()] = p
+	pm.plugins[p.ID()] = p
 	log.LogInfo("registered a new plugin", zap.String("NAME", p.Name()))
 }
 
@@ -70,17 +70,17 @@ func (pm *pluginManager) Register(p plugin.Plugin) {
 func (pm *pluginManager) Deregister(p plugin.Plugin) {
 	pm.mx.Lock()
 	defer pm.mx.Unlock()
-	delete(pm.plugins, p.Name())
+	delete(pm.plugins, p.ID())
 	log.LogInfo("deregistered plugin", zap.String("NAME", p.Name()))
 }
 
 // GetPlugins returns all registered plugins
-func (pm *pluginManager) GetPlugins() map[string]plugin.Plugin {
+func (pm *pluginManager) GetPlugins() map[int]plugin.Plugin {
 	pm.mx.Lock()
 	defer pm.mx.Unlock()
 
 	// Return a copy to avoid concurrent map access issues
-	pluginsCopy := make(map[string]plugin.Plugin, len(pm.plugins))
+	pluginsCopy := make(map[int]plugin.Plugin, len(pm.plugins))
 	for k, v := range pm.plugins {
 		pluginsCopy[k] = v
 	}
@@ -88,4 +88,4 @@ func (pm *pluginManager) GetPlugins() map[string]plugin.Plugin {
 	return pluginsCopy
 }
 
-var Pm *pluginManager = &pluginManager{plugins: map[string]plugin.Plugin{}}
+var Pm *pluginManager = &pluginManager{plugins: map[int]plugin.Plugin{}}

--- a/frontend/src/components/plugin/FeedbackModel.tsx
+++ b/frontend/src/components/plugin/FeedbackModel.tsx
@@ -10,13 +10,13 @@ import logo from '../../assets/logo.svg';
 import { Circle } from 'lucide-react';
 
 interface IfeedbackModalProps {
-  pluginId: string;
+  pluginId: number;
   onClose: () => void;
   pluginAPI: PluginAPI;
 }
 
 interface IFeedbackFormData {
-  pluginId: string;
+  pluginId: number;
   rating: number | null;
   comment: string;
   suggestion: string;
@@ -43,7 +43,6 @@ const FeedbackModel = ({ pluginId, pluginAPI, onClose }: IfeedbackModalProps) =>
     5: 'Excellent',
   };
 
-  console.log(pluginId);
   const handleStarClick = (starIndex: number) => {
     setFormData(prv => ({
       ...prv,

--- a/frontend/src/plugins/PluginAPI.ts
+++ b/frontend/src/plugins/PluginAPI.ts
@@ -18,8 +18,8 @@ export class PluginAPI {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async getPluginDetails(pluginName: string): Promise<any> {
-    const response = await api.get(`${this.baseURL}/${pluginName}`);
+  async getPluginDetails(pluginID: number): Promise<any> {
+    const response = await api.get(`${this.baseURL}/${pluginID}`);
     return response.data;
   }
 
@@ -35,37 +35,37 @@ export class PluginAPI {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async uninstallPlugin(pluginName: string): Promise<any> {
-    const response = await api.delete(`${this.baseURL}/${pluginName}`);
+  async uninstallPlugin(pluginID: number): Promise<any> {
+    const response = await api.delete(`${this.baseURL}/${pluginID}`);
     return response.data;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async enablePlugin(pluginName: string): Promise<any> {
-    const response = await api.post(`${this.baseURL}/${pluginName}/enable`);
+  async enablePlugin(pluginID: number): Promise<any> {
+    const response = await api.post(`${this.baseURL}/${pluginID}/enable`);
     return response.data;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async disablePlugin(pluginName: string): Promise<any> {
-    const response = await api.post(`${this.baseURL}/${pluginName}/disable`);
+  async disablePlugin(pluginID: number): Promise<any> {
+    const response = await api.post(`${this.baseURL}/${pluginID}/disable`);
     return response.data;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async reloadPlugin(pluginName: string): Promise<any> {
-    const response = await api.post(`${this.baseURL}/${pluginName}/reload`);
+  async reloadPlugin(pluginID: number): Promise<any> {
+    const response = await api.post(`${this.baseURL}/${pluginID}/reload`);
     return response.data;
   }
 
-  async getPluginStatus(pluginName: string): Promise<PluginStatus> {
-    const response = await api.get<PluginStatus>(`${this.baseURL}/${pluginName}/status`);
+  async getPluginStatus(pluginID: number): Promise<PluginStatus> {
+    const response = await api.get<PluginStatus>(`${this.baseURL}/${pluginID}/status`);
     return response.data;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async callPluginFunction(pluginName: string, functionPath: string, data?: any): Promise<any> {
-    const response = await api.post(`${this.baseURL}/${pluginName}${functionPath}`, data || {});
+  async callPluginFunction(pluginID: number, functionPath: string, data?: any): Promise<any> {
+    const response = await api.post(`${this.baseURL}/${pluginID}${functionPath}`, data || {});
     return response.data;
   }
 
@@ -94,12 +94,12 @@ export class PluginAPI {
   }
 
   // Helper method to build plugin-specific URLs
-  getPluginURL(pluginName: string, path: string = ''): string {
-    return `${this.baseURL}/${pluginName}${path}`;
+  getPluginURL(pluginID: number, path: string = ''): string {
+    return `${this.baseURL}/${pluginID}${path}`;
   }
 
   // Helper method to get plugin asset URLs
-  getPluginAssetURL(pluginName: string, assetPath: string): string {
-    return `${this.baseURL}/${pluginName}/assets${assetPath}`;
+  getPluginAssetURL(pluginID: number, assetPath: string): string {
+    return `${this.baseURL}/${pluginID}/assets${assetPath}`;
   }
 }

--- a/frontend/src/plugins/types.ts
+++ b/frontend/src/plugins/types.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export interface PluginManifest {
+  id: number;
   name: string;
   version: string;
   description: string;
@@ -52,6 +53,7 @@ export interface PluginInstance {
 }
 
 export interface PluginError {
+  pluginID: number;
   pluginName: string;
   error: Error;
   timestamp: Date;
@@ -59,6 +61,7 @@ export interface PluginError {
 }
 
 export interface PluginMetrics {
+  pluginID: number;
   pluginName: string;
   loadTime: number;
   memoryUsage: number;


### PR DESCRIPTION
### Description

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->
Switching from pluginName to pluginID to work with the plugins.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #1351

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Refactored current/old backend plugin models and methods/handlers to use the plugin's ID.
- [x] Added ID for the backupPlugin.
- [x] Make changes in the frontend API logics and types to use the plugin's ID.

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

https://github.com/user-attachments/assets/00825c5f-1a4b-4811-99fe-b41b560e3955


