### PR TITLE
fix: remove extra cruft from sidebar toggle button (#1356) + alignment issues with menu button 

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -148,6 +148,9 @@ export function Layout() {
                   boxShadow: isDark
                     ? '0 4px 10px rgba(37, 99, 235, 0.4)'
                     : '0 4px 10px rgba(37, 99, 235, 0.2)',
+                  outline: 'none', // Remove default focus outline
+                  WebkitTapHighlightColor: 'transparent', // Remove mobile tap highlight
+  
                 }}
                 whileHover={{
                   scale: 1.05,
@@ -157,6 +160,16 @@ export function Layout() {
                 }}
                 aria-label={isSidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
                 whileTap={{ scale: 0.9 }}
+                  onFocus={(e) => {
+                    e.currentTarget.style.boxShadow = isDark
+                        ? '0 0 0 3px rgba(96, 165, 250, 0.3)'
+                        : '0 0 0 3px rgba(59, 130, 246, 0.3)';
+                }}
+                onBlur={(e) => {
+                e.currentTarget.style.boxShadow = isDark
+                    ? '0 4px 10px rgba(37, 99, 235, 0.4)'
+                    : '0 4px 10px rgba(37, 99, 235, 0.2)';
+                  }}
               >
                 <div
                   className="flex h-5 w-5 items-center justify-center"

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -139,7 +139,7 @@ export function Layout() {
             <div className="mb-3 flex justify-end">
               <motion.button
                 onClick={toggleSidebar}
-                className={`rounded-lg border-2 p-2 shadow-md transition-all duration-200 hover:shadow-lg active:scale-95 ${isSidebarCollapsed ? "mr-2": ""}`}
+                className={`rounded-lg border-2 p-2 shadow-md transition-all duration-200 hover:shadow-lg active:scale-95 ${isSidebarCollapsed ? 'mr-2' : ''}`}
                 style={{
                   background: isDark
                     ? 'linear-gradient(to bottom right, #3b82f6, #2563eb)'
@@ -150,7 +150,6 @@ export function Layout() {
                     : '0 4px 10px rgba(37, 99, 235, 0.2)',
                   outline: 'none', // Remove default focus outline
                   WebkitTapHighlightColor: 'transparent', // Remove mobile tap highlight
-  
                 }}
                 whileHover={{
                   scale: 1.05,
@@ -160,16 +159,16 @@ export function Layout() {
                 }}
                 aria-label={isSidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
                 whileTap={{ scale: 0.9 }}
-                  onFocus={(e) => {
-                    e.currentTarget.style.boxShadow = isDark
-                        ? '0 0 0 3px rgba(96, 165, 250, 0.3)'
-                        : '0 0 0 3px rgba(59, 130, 246, 0.3)';
+                onFocus={e => {
+                  e.currentTarget.style.boxShadow = isDark
+                    ? '0 0 0 3px rgba(96, 165, 250, 0.3)'
+                    : '0 0 0 3px rgba(59, 130, 246, 0.3)';
                 }}
-                onBlur={(e) => {
-                e.currentTarget.style.boxShadow = isDark
+                onBlur={e => {
+                  e.currentTarget.style.boxShadow = isDark
                     ? '0 4px 10px rgba(37, 99, 235, 0.4)'
                     : '0 4px 10px rgba(37, 99, 235, 0.2)';
-                  }}
+                }}
               >
                 <div
                   className="flex h-5 w-5 items-center justify-center"

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -139,7 +139,7 @@ export function Layout() {
             <div className="mb-3 flex justify-end">
               <motion.button
                 onClick={toggleSidebar}
-                className="rounded-lg border-2 p-2 shadow-md transition-all duration-200 hover:shadow-lg active:scale-95"
+                className={`rounded-lg border-2 p-2 shadow-md transition-all duration-200 hover:shadow-lg active:scale-95 ${isSidebarCollapsed ? "mr-2": ""}`}
                 style={{
                   background: isDark
                     ? 'linear-gradient(to bottom right, #3b82f6, #2563eb)'


### PR DESCRIPTION
fix: Extra cruft on expand/contract menu button (#1356)

Also fixed alignment of the menu button 

before : 
<img width="113" height="142" alt="fixxx" src="https://github.com/user-attachments/assets/9917e308-1074-4787-ad7d-e14c9a8d2e0c" />


after : 
<img width="314" height="384" alt="Screenshot 2025-07-11 at 4 31 54 AM" src="https://github.com/user-attachments/assets/05c63cec-a765-4187-b78e-7c29e8cf95d0" />



Fixes #<issue_number>#1356

before : 
<img width="113" height="142" alt="fixed" src="https://github.com/user-attachments/assets/a79e41e3-c93d-47e7-b156-d5000fbe5b30" />


after : 
<img width="1470" height="956" alt="Screenshot 2025-07-11 at 4 22 38 AM" src="https://github.com/user-attachments/assets/5e192bf6-e2f4-4759-89fe-fd36229c4e03" />



