### PR TITLE
Fix i18n Translation Keys in ClusterDetailDialog for Cluster Status and Capacity Resources

### DIFF
--- a/frontend/src/components/ClusterDetailDialog.tsx
+++ b/frontend/src/components/ClusterDetailDialog.tsx
@@ -310,8 +310,8 @@ const ClusterDetailDialog: React.FC<ClusterDetailDialogProps> = ({
                       }
                       label={
                         clusterDetails.available
-                          ? t('cluster.clusterDetailDialog.status.available')
-                          : t('cluster.clusterDetailDialog.status.unavailable')
+                          ? t('clusters.clusterDetailDialog.status.available')
+                          : t('clusters.clusterDetailDialog.status.unavailable')
                       }
                       sx={{
                         backgroundColor: clusterDetails.available
@@ -626,7 +626,7 @@ const ClusterDetailDialog: React.FC<ClusterDetailDialogProps> = ({
                       textShadow: isDark ? '0 1px 2px rgba(0, 0, 0, 0.5)' : 'none',
                     }}
                   >
-                    {t('cluseters.clusterDetailDialog.capacityResources')}
+                    {t('clusters.clusterDetailDialog.capacityResources')}
                   </Typography>
                 </Box>
                 <Divider


### PR DESCRIPTION
### Description

This PR fixes incorrect i18n translation keys in the `ClusterDetailDialog` component. It corrects the translation key for cluster status (available/unavailable) and the capacity resources section, ensuring that the UI displays the correct localized strings.

### Related Issue

Fixes #1443

### Screenshots or Logs (if applicable)

[Screencast from 2025-07-11 20-02-54.webm](https://github.com/user-attachments/assets/8128ff89-8956-4bf5-98cc-b5ea1c6f8a33)
