### PR TITLE
Fixes: Persist Metrics Dashboard auto-refresh preferences in localStorage and Removed Hardcoded Prometheus URLs

### DIFF
--- a/frontend/src/components/MetricsDashboard.tsx
+++ b/frontend/src/components/MetricsDashboard.tsx
@@ -219,8 +219,14 @@ const MetricsDashboard = () => {
     useMetricsQueries();
 
   // State for dashboard controls
-  const [autoRefresh, setAutoRefresh] = useState(true);
-  const [refreshInterval, setRefreshInterval] = useState(30);
+  const [autoRefresh, setAutoRefresh] = useState(() => {
+    const saved = localStorage.getItem('metrics-auto-refresh');
+    return saved !== null ? JSON.parse(saved) : true;
+  });
+  const [refreshInterval, setRefreshInterval] = useState(() => {
+    const saved = localStorage.getItem('metrics-refresh-interval');
+    return saved !== null ? parseInt(saved, 10) : 30;
+  });
   const [visibleSections] = useState({
     cache: true,
     cluster: true,
@@ -334,6 +340,16 @@ const MetricsDashboard = () => {
     refetchRuntime,
     refetchSummary,
   ]);
+
+  // Save auto-refresh preference to localStorage
+  useEffect(() => {
+    localStorage.setItem('metrics-auto-refresh', JSON.stringify(autoRefresh));
+  }, [autoRefresh]);
+
+  // Save refresh interval preference to localStorage
+  useEffect(() => {
+    localStorage.setItem('metrics-refresh-interval', refreshInterval.toString());
+  }, [refreshInterval]);
 
   // Auto-refresh effect
   useEffect(() => {

--- a/frontend/src/components/MetricsDashboard.tsx
+++ b/frontend/src/components/MetricsDashboard.tsx
@@ -220,12 +220,21 @@ const MetricsDashboard = () => {
 
   // State for dashboard controls
   const [autoRefresh, setAutoRefresh] = useState(() => {
-    const saved = localStorage.getItem('metrics-auto-refresh');
-    return saved !== null ? JSON.parse(saved) : true;
+    try {
+      const saved = localStorage.getItem('metrics-auto-refresh');
+      if (typeof saved === 'string') {
+        const parsed = JSON.parse(saved);
+        return typeof parsed === 'boolean' ? parsed : true;
+      }
+    } catch {
+      // ignore
+    }
+    return true;
   });
   const [refreshInterval, setRefreshInterval] = useState(() => {
     const saved = localStorage.getItem('metrics-refresh-interval');
-    return saved !== null ? parseInt(saved, 10) : 30;
+    const parsed = parseInt(saved ?? '', 10);
+    return !isNaN(parsed) && parsed > 0 ? parsed : 30;
   });
   const [visibleSections] = useState({
     cache: true,

--- a/frontend/src/hooks/queries/useMetricsQueries.ts
+++ b/frontend/src/hooks/queries/useMetricsQueries.ts
@@ -76,9 +76,7 @@ const fetchClusterMetrics = async (): Promise<ClusterMetrics> => {
       api.get<PrometheusResponse>(
         `${prometheusUrl}/api/v1/query?query=cluster_onboarding_duration_seconds`
       ),
-      api.get<PrometheusResponse>(
-        `${prometheusUrl}/api/v1/query?query=kubectl_operations_total`
-      ),
+      api.get<PrometheusResponse>(`${prometheusUrl}/api/v1/query?query=kubectl_operations_total`),
     ]);
 
     return {

--- a/frontend/src/hooks/queries/useMetricsQueries.ts
+++ b/frontend/src/hooks/queries/useMetricsQueries.ts
@@ -3,7 +3,8 @@ import { api } from '../../lib/api';
 
 // Get Prometheus URL from environment variable with fallback
 const getPrometheusUrl = () => {
-  return import.meta.env.VITE_PROMETHEUS_URL || 'http://localhost:9090';
+  const url = import.meta.env.VITE_PROMETHEUS_URL;
+  return url ? url : 'http://localhost:9090';
 };
 
 // Prometheus API response types

--- a/frontend/src/hooks/queries/useMetricsQueries.ts
+++ b/frontend/src/hooks/queries/useMetricsQueries.ts
@@ -1,6 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { api } from '../../lib/api';
 
+// Get Prometheus URL from environment variable with fallback
+const getPrometheusUrl = () => {
+  return import.meta.env.VITE_PROMETHEUS_URL || 'http://localhost:9090';
+};
+
 // Prometheus API response types
 export interface PrometheusMetric {
   metric: Record<string, string>;
@@ -43,12 +48,13 @@ export interface MetricsSummary {
 // Fetch cache metrics from Prometheus
 const fetchCacheMetrics = async (): Promise<CacheMetrics> => {
   try {
+    const prometheusUrl = getPrometheusUrl();
     const [hitsResponse, missesResponse] = await Promise.all([
       api.get<PrometheusResponse>(
-        'http://localhost:9090/api/v1/query?query=kubestellar_binding_policy_cache_hits_total'
+        `${prometheusUrl}/api/v1/query?query=kubestellar_binding_policy_cache_hits_total`
       ),
       api.get<PrometheusResponse>(
-        'http://localhost:9090/api/v1/query?query=kubestellar_binding_policy_cache_misses_total'
+        `${prometheusUrl}/api/v1/query?query=kubestellar_binding_policy_cache_misses_total`
       ),
     ]);
 
@@ -65,12 +71,13 @@ const fetchCacheMetrics = async (): Promise<CacheMetrics> => {
 // Fetch cluster metrics from Prometheus
 const fetchClusterMetrics = async (): Promise<ClusterMetrics> => {
   try {
+    const prometheusUrl = getPrometheusUrl();
     const [onboardingResponse, kubectlResponse] = await Promise.all([
       api.get<PrometheusResponse>(
-        'http://localhost:9090/api/v1/query?query=cluster_onboarding_duration_seconds'
+        `${prometheusUrl}/api/v1/query?query=cluster_onboarding_duration_seconds`
       ),
       api.get<PrometheusResponse>(
-        'http://localhost:9090/api/v1/query?query=kubectl_operations_total'
+        `${prometheusUrl}/api/v1/query?query=kubectl_operations_total`
       ),
     ]);
 
@@ -87,8 +94,9 @@ const fetchClusterMetrics = async (): Promise<ClusterMetrics> => {
 // Fetch runtime metrics from Prometheus
 const fetchRuntimeMetrics = async (): Promise<RuntimeMetrics> => {
   try {
+    const prometheusUrl = getPrometheusUrl();
     const response = await api.get<PrometheusResponse>(
-      'http://localhost:9090/api/v1/query?query=go_goroutines'
+      `${prometheusUrl}/api/v1/query?query=go_goroutines`
     );
 
     return {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     // Enables access to base URL and git commit hash across the application
     EnvironmentPlugin({
       VITE_BASE_URL: process.env.VITE_BASE_URL || 'http://localhost:4000',
+      VITE_PROMETHEUS_URL: process.env.VITE_PROMETHEUS_URL || 'http://localhost:9090',
       VITE_GIT_COMMIT_HASH: getGitCommitHash(),
     }),
   ],


### PR DESCRIPTION
### Description

This PR fixes a user experience issue in the Metrics Dashboard where auto-refresh preferences were not persisted across page refreshes. Previously, when users disabled auto-refresh and refreshed the page, the setting would automatically re-enable, causing confusion and poor UX. This fix ensures that user preferences for auto-refresh and refresh interval are saved to localStorage and restored on component mount.

### Related Issue

Fixes #1474 

### Screenshots or Logs (if applicable)

[Screencast from 2025-07-13 09-40-49.webm](https://github.com/user-attachments/assets/5a71b7c4-9d3e-48cc-854e-7a0face3d26e)
