### PR TITLE
added Metrics Dashboard command in Command Palette

### DIFF
--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -13,6 +13,7 @@ import {
   FiBox,
   FiLogOut,
   FiUsers,
+  FiBarChart2,
 } from 'react-icons/fi';
 import { useAuthActions, useAdminCheck } from '../hooks/useAuth';
 import { useTranslation } from 'react-i18next';
@@ -181,6 +182,30 @@ const CommandPalette: React.FC = () => {
         'bp',
         'rules',
         'configuration',
+      ],
+      section: t('commandPalette.sections.navigation'),
+    },
+    {
+      id: 'metrics-dashboard',
+      type: 'navigation',
+      icon: FiBarChart2,
+      title: t('commandPalette.commands.metricsDashboard.title') || 'Metrics Dashboard',
+      description:
+        t('commandPalette.commands.metricsDashboard.description') ||
+        'Monitor system performance and metrics',
+      action: () => navigate('/metrics'),
+      keywords: [
+        'metrics',
+        'dashboard',
+        'monitoring',
+        'performance',
+        'prometheus',
+        'analytics',
+        'stats',
+        'system health',
+        'cache',
+        'runtime',
+        'cluster',
       ],
       section: t('commandPalette.sections.navigation'),
     },

--- a/frontend/src/locales/strings.en.json
+++ b/frontend/src/locales/strings.en.json
@@ -2081,6 +2081,10 @@
         "title": "Logout",
         "description": "Sign out of your account",
         "infoMessage": "You have been logged out successfully."
+      },
+      "metricsDashboard": {
+        "title": "Metrics Dashboard",
+        "description": "Monitor system performance and metrics"
       }
     },
     "sections": {


### PR DESCRIPTION
### Description

Added a new command to the Command Palette to quickly navigate to the Metrics Dashboard. This improves accessibility and discoverability of performance monitoring features for developers and users.

### Related Issue

Fixes #1483

### Changes Made

- [x] Added `metrics-dashboard` command object to `CommandPalette.tsx`
  - Type: navigation
  - Icon: `FiBarChart2` from `react-icons/fi`
  - Action: Navigates to `/metrics`
  - Keywords: ["metrics", "dashboard", "monitoring", "performance", "prometheus"]
  - Section: navigation

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

Not applicable — feature tested via Command Palette interaction.

### Additional Notes

