### PR TITLE
fix: reset processing state when user form modal is opened

### DIFF
--- a/frontend/src/components/admin/UserFormModal.tsx
+++ b/frontend/src/components/admin/UserFormModal.tsx
@@ -58,6 +58,12 @@ const UserFormModal: React.FC<UserFormModalProps> = ({
     }
   }, [isAdmin, permissionComponents, setPermissionChange, permissions]);
 
+  useEffect(() => {
+    if (isOpen) {
+      setFormSubmitted(false);
+    }
+  }, [isOpen]);
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setFormSubmitted(true);


### PR DESCRIPTION
### Description

This PR fixes a bug in the user edit modal where the processing state (`formSubmitted`) was not reset after the form was submitted and the modal was closed. As a result, when reopening the modal, the submit button would remain disabled and show a spinner. The fix ensures that the processing state is reset every time the modal is opened, allowing for proper user interaction.

### Related Issue

Fixes #1486 

### Screenshots or Logs (if applicable)

[Screencast from 2025-07-14 12-06-44.webm](https://github.com/user-attachments/assets/f266786a-55b4-44fb-aed9-041c8031deb4)

