### PR TITLE
feat: add WASM plugin into card to plugin manager

### DIFF
--- a/frontend/src/components/PluginManager.tsx
+++ b/frontend/src/components/PluginManager.tsx
@@ -672,14 +672,20 @@ export const PluginManager: React.FC = () => {
 
                   {/* Plugin Install Time */}
                   {plugin.createdAt && (
-                    <div className="mb-1 text-xs" style={{ color: themeStyles.colors.text.secondary }}>
+                    <div
+                      className="mb-1 text-xs"
+                      style={{ color: themeStyles.colors.text.secondary }}
+                    >
                       Installed: {new Date(plugin.createdAt).toLocaleString()}
                     </div>
                   )}
 
                   {/* Plugin Routes */}
                   {plugin.routes && plugin.routes.length > 0 && (
-                    <div className="mb-1 text-xs" style={{ color: themeStyles.colors.text.secondary }}>
+                    <div
+                      className="mb-1 text-xs"
+                      style={{ color: themeStyles.colors.text.secondary }}
+                    >
                       Routes:
                       <ul className="ml-2 list-disc">
                         {plugin.routes.map((route, idx) => (
@@ -691,7 +697,10 @@ export const PluginManager: React.FC = () => {
 
                   {/* Last Security Scan */}
                   {plugin.lastScanned && (
-                    <div className="mb-2 text-xs" style={{ color: themeStyles.colors.text.secondary }}>
+                    <div
+                      className="mb-2 text-xs"
+                      style={{ color: themeStyles.colors.text.secondary }}
+                    >
                       Last Scan: {new Date(plugin.lastScanned).toLocaleString()}
                     </div>
                   )}

--- a/frontend/src/components/PluginManager.tsx
+++ b/frontend/src/components/PluginManager.tsx
@@ -34,6 +34,8 @@ interface Plugin {
   loadTime?: Date;
   routes?: string[];
   id: number;
+  createdAt?: Date;
+  lastScanned?: Date;
 }
 
 export const PluginManager: React.FC = () => {
@@ -662,11 +664,37 @@ export const PluginManager: React.FC = () => {
 
                   {/* Plugin Description */}
                   <p
-                    className="mb-4 line-clamp-2 text-sm"
+                    className="mb-2 line-clamp-2 text-sm"
                     style={{ color: themeStyles.colors.text.secondary }}
                   >
                     {plugin.description}
                   </p>
+
+                  {/* Plugin Install Time */}
+                  {plugin.createdAt && (
+                    <div className="mb-1 text-xs" style={{ color: themeStyles.colors.text.secondary }}>
+                      Installed: {new Date(plugin.createdAt).toLocaleString()}
+                    </div>
+                  )}
+
+                  {/* Plugin Routes */}
+                  {plugin.routes && plugin.routes.length > 0 && (
+                    <div className="mb-1 text-xs" style={{ color: themeStyles.colors.text.secondary }}>
+                      Routes:
+                      <ul className="ml-2 list-disc">
+                        {plugin.routes.map((route, idx) => (
+                          <li key={idx}>{route}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+
+                  {/* Last Security Scan */}
+                  {plugin.lastScanned && (
+                    <div className="mb-2 text-xs" style={{ color: themeStyles.colors.text.secondary }}>
+                      Last Scan: {new Date(plugin.lastScanned).toLocaleString()}
+                    </div>
+                  )}
 
                   {/* Plugin Actions */}
                   <div className="mt-auto grid w-full grid-cols-1 gap-2 sm:grid-cols-2">


### PR DESCRIPTION
Description

This PR adds support for displaying a card in the Plugin Manager after installing a WASM plugin. The card shows details such as the plugin’s description, install time, available routes, and the timestamp of the last security scan.

The card will be removed automatically if the plugin is deleted.

fixes #1478 