### PR TITLE
✨: Added Edit Option for Managing Cluster Labels in Remote Cluster Tree

### DIFF
--- a/frontend/src/components/WecsDetailsPanel.tsx
+++ b/frontend/src/components/WecsDetailsPanel.tsx
@@ -961,7 +961,12 @@ const WecsDetailsPanel = ({
         return;
       } catch (error: unknown) {
         let message = 'Failed to update cluster labels';
-        if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: string }).message === 'string') {
+        if (
+          error &&
+          typeof error === 'object' &&
+          'message' in error &&
+          typeof (error as { message?: string }).message === 'string'
+        ) {
           message = (error as { message?: string }).message as string;
         }
         setSnackbarMessage(message);


### PR DESCRIPTION
### Description

This PR implements an "Edit" option for managing cluster labels directly within the Remote Cluster tree view (WecsDetailsPanel).
Users can now edit cluster labels via the YAML/JSON editor, and the frontend will correctly parse and send the full set of labels to the backend, ensuring all labels (existing and new) are preserved after an update.
The UI also refetches cluster details after a successful update, so the latest labels are always displayed.


### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #465 

### Changes Made
* Added an "Edit" option for cluster labels in the Remote Cluster tree view.
* Refactored handleUpdate in `WecsDetailsPanel.tsx` to:
* Parse the edited manifest (YAML or JSON) on update.
* Extract all labels from metadata.labels.
* Send the full set of labels in the PATCH request to `/api/managedclusters/labels.`
* Show an error if the manifest is invalid.

<!-- Provide a detailed list of changes made in this PR. -->

- [X] Updated ...
- [ ] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

https://github.com/user-attachments/assets/81169a9d-a59b-4d0f-9b3a-f6941902bc5c




### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
