### PR TITLE
Filter Out System Namespaces from Resource Explorer Namespace Dropdown

### DIFF
--- a/frontend/src/pages/ResourceFilterPage.tsx
+++ b/frontend/src/pages/ResourceFilterPage.tsx
@@ -52,8 +52,14 @@ const ResourceFilterPage: React.FC = () => {
   const theme = useTheme(state => state.theme);
   const isDark = theme === 'dark';
 
-  const { resourceKinds = [], namespaces = [], filteredResources = [], isLoading, error, applyFilters } =
-    useResourceFilters();
+  const {
+    resourceKinds = [],
+    namespaces = [],
+    filteredResources = [],
+    isLoading,
+    error,
+    applyFilters,
+  } = useResourceFilters();
 
   const [selectedKind, setSelectedKind] = useState<string>('');
   const [selectedNamespace, setSelectedNamespace] = useState<string>('');

--- a/frontend/src/pages/ResourceFilterPage.tsx
+++ b/frontend/src/pages/ResourceFilterPage.tsx
@@ -152,8 +152,9 @@ const ResourceFilterPage: React.FC = () => {
     }
   };
 
-  // Filter out system namespaces (those starting with 'kube-')
-  const filteredNamespaces = namespaces.filter(ns => !ns.name.startsWith('kube-'));
+  const filteredNamespaces = namespaces.filter(
+    ns => !ns.name.startsWith('kube-') && ns.name !== 'kubestellar-report'
+  );
 
   return (
     <Box

--- a/frontend/src/pages/ResourceFilterPage.tsx
+++ b/frontend/src/pages/ResourceFilterPage.tsx
@@ -52,7 +52,7 @@ const ResourceFilterPage: React.FC = () => {
   const theme = useTheme(state => state.theme);
   const isDark = theme === 'dark';
 
-  const { resourceKinds, namespaces, filteredResources, isLoading, error, applyFilters } =
+  const { resourceKinds = [], namespaces = [], filteredResources = [], isLoading, error, applyFilters } =
     useResourceFilters();
 
   const [selectedKind, setSelectedKind] = useState<string>('');
@@ -145,6 +145,9 @@ const ResourceFilterPage: React.FC = () => {
         };
     }
   };
+
+  // Filter out system namespaces (those starting with 'kube-')
+  const filteredNamespaces = namespaces.filter(ns => !ns.name.startsWith('kube-'));
 
   return (
     <Box
@@ -346,7 +349,7 @@ const ResourceFilterPage: React.FC = () => {
                     },
                   }}
                 >
-                  {namespaces.map(ns => (
+                  {filteredNamespaces.map(ns => (
                     <MenuItem
                       key={ns.name}
                       value={ns.name}

--- a/frontend/src/pages/ResourceFilterPage.tsx
+++ b/frontend/src/pages/ResourceFilterPage.tsx
@@ -268,7 +268,7 @@ const ResourceFilterPage: React.FC = () => {
                       component: Paper,
                       elevation: 6,
                       sx: {
-                        backgroundColor: isDark ? darkTheme.element.card : lightTheme.element.card,
+                        backgroundColor: isDark ? '#1f2937' : '#fff', // Fully opaque
                         color: isDark ? darkTheme.text.primary : lightTheme.text.primary,
                         boxShadow: isDark
                           ? '0px 5px 15px rgba(0, 0, 0, 0.4)'
@@ -278,6 +278,7 @@ const ResourceFilterPage: React.FC = () => {
                         border: isDark
                           ? '1px solid rgba(255, 255, 255, 0.1)'
                           : '1px solid rgba(0, 0, 0, 0.05)',
+                        opacity: 1,
                       },
                     },
                   }}
@@ -342,7 +343,7 @@ const ResourceFilterPage: React.FC = () => {
                       component: Paper,
                       elevation: 6,
                       sx: {
-                        backgroundColor: isDark ? darkTheme.element.card : lightTheme.element.card,
+                        backgroundColor: isDark ? '#1f2937' : '#fff', // Fully opaque
                         color: isDark ? darkTheme.text.primary : lightTheme.text.primary,
                         boxShadow: isDark
                           ? '0px 5px 15px rgba(0, 0, 0, 0.4)'
@@ -352,6 +353,7 @@ const ResourceFilterPage: React.FC = () => {
                         border: isDark
                           ? '1px solid rgba(255, 255, 255, 0.1)'
                           : '1px solid rgba(0, 0, 0, 0.05)',
+                        opacity: 1,
                       },
                     },
                   }}


### PR DESCRIPTION
## Description

This PR improves the user experience and security of the Resource Explorer by filtering out Kubernetes system namespaces from the Namespace dropdown. Only user-created namespaces and the `default` namespace are now displayed, making it easier for users to focus on their own resources and reducing clutter in the UI.

- System namespaces filtered out: any namespace starting with `kube-` (e.g., `kube-system`, `kube-public`, `kube-node-lease`).
- The dropdown now only shows relevant namespaces for resource filtering and selection.

Fixes : #1521 

**Screenshot:**

[Screencast from 2025-07-16 22-02-08.webm](https://github.com/user-attachments/assets/4dba9333-89a6-4411-a202-ea778efd092d)
