### PR TITLE
Fix: Sidebar Toggle Not Opening on Small Screens on manage cluster page

### DIFF
--- a/frontend/src/pages/ITS.tsx
+++ b/frontend/src/pages/ITS.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useClusterQueries } from '../hooks/queries/useClusterQueries';
 import ClustersTable from '../components/ClustersTable';
-import Header from '../components/Header';
 import { useLocation } from 'react-router-dom';
 
 const ITS = () => {
@@ -61,7 +60,6 @@ const ITS = () => {
 
   return (
     <div className="w-full p-4">
-      <Header isLoading={isLoading} />
       <div className="overflow-hidden rounded-lg bg-base-100 shadow-xl">
         <div className="p-4">
           <ClustersTable


### PR DESCRIPTION
### Description

This PR fixes a bug where the sidebar toggle icon (hamburger icon) was not opening the sidebar in responsive/small screen viewports on /its route aka manage cluster page

### Related Issue

Fixes #1531 

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

### Checklist

- [x ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

https://github.com/user-attachments/assets/a81b31f6-e285-43d3-af50-40027f1ca69d


