### PR TITLE
✨ Feature: Added Unit test for `Wecs` Package.

### DIFF
--- a/backend/test/wecs/exec_test.go
+++ b/backend/test/wecs/exec_test.go
@@ -1,0 +1,97 @@
+package wecs_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/kubestellar/ui/backend/wecs"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockWebSocket struct {
+	writeCount int
+	lastMsg    []byte
+	failWrite  bool
+}
+
+func (m *mockWebSocket) WriteMessage(mt int, msg []byte) error {
+	m.writeCount++
+	m.lastMsg = msg
+	if m.failWrite {
+		return errors.New("write error")
+	}
+	return nil
+}
+
+func TestSessionMap_Basic(t *testing.T) {
+	sm := &wecs.SessionMap{Sessions: make(map[string]wecs.TerminalSession)}
+	// Can't construct TerminalSession directly (unexported fields), so test map logic only
+	sm.Sessions["abc"] = wecs.TerminalSession{}
+	_ = sm.Get("abc")
+	sm.Close("abc")
+	_, ok := sm.Sessions["abc"]
+	assert.False(t, ok)
+}
+
+func TestSessionMap_Concurrent(t *testing.T) {
+	sm := &wecs.SessionMap{Sessions: make(map[string]wecs.TerminalSession)}
+	wg := sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := string(rune('a' + i))
+			sm.Set(key, wecs.TerminalSession{})
+		}(i)
+	}
+	wg.Wait()
+	for i := 0; i < 10; i++ {
+		_ = sm.Get(string(rune('a' + i)))
+	}
+}
+
+func TestGenTerminalSessionId(t *testing.T) {
+	id1, err1 := wecs.GenTerminalSessionId()
+	id2, err2 := wecs.GenTerminalSessionId()
+	assert.NoError(t, err1)
+	assert.NoError(t, err2)
+	assert.NotEqual(t, id1, id2)
+	assert.Len(t, id1, 32)
+}
+
+func TestIsValidShellCmd(t *testing.T) {
+	validShells := []string{"bash", "sh", "cmd"}
+	assert.True(t, wecs.IsValidShellCmd(validShells, "bash"))
+	assert.False(t, wecs.IsValidShellCmd(validShells, "powershell"))
+}
+
+// TestConnWriter_Write is commented out because ConnWriter expects a *websocket.Conn, which cannot be easily mocked without a real network connection.
+/*
+func TestConnWriter_Write(t *testing.T) {
+	mockWS := &mockWebSocket{}
+	cw := wecs.ConnWriter{Conn: mockWS}
+	n, err := cw.Write([]byte("hello"))
+	assert.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.Contains(t, string(mockWS.lastMsg), "hello")
+	mockWS.failWrite = true
+	_, err2 := cw.Write([]byte("fail"))
+	assert.Error(t, err2)
+}
+*/
+
+func TestGetAllPodContainersName_BadRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest("GET", "/", nil)
+	wecs.GetAllPodContainersName(c)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "no context present as query")
+}
+
+// More tests for GetAllPodContainersName with k8s client mocking would go here.

--- a/backend/test/wecs/wecs_test.go
+++ b/backend/test/wecs/wecs_test.go
@@ -1,0 +1,28 @@
+package wecs_test
+
+import (
+	"testing"
+	"github.com/kubestellar/ui/backend/wecs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResourceDataStruct(t *testing.T) {
+	r := wecs.ResourceData{
+		Name: "test",
+		Kind: "Pod",
+		Raw: []byte(`{"foo":"bar"}`),
+		ReplicaSets: nil,
+		Pods: nil,
+	}
+	assert.Equal(t, "test", r.Name)
+	assert.Equal(t, "Pod", r.Kind)
+	assert.Contains(t, string(r.Raw), "foo")
+}
+
+func TestClusterDataStruct(t *testing.T) {
+	c := wecs.ClusterData{
+		Name: "cluster1",
+		Namespaces: nil,
+	}
+	assert.Equal(t, "cluster1", c.Name)
+}

--- a/backend/test/wecs/wecs_test.go
+++ b/backend/test/wecs/wecs_test.go
@@ -1,9 +1,9 @@
 package wecs_test
 
 import (
+	"testing"
 	"github.com/kubestellar/ui/backend/wecs"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestResourceDataStruct(t *testing.T) {
@@ -22,7 +22,7 @@ func TestResourceDataStruct(t *testing.T) {
 func TestClusterDataStruct(t *testing.T) {
 	c := wecs.ClusterData{
 		Name:       "cluster1",
-		Namespaces: nil,
+		Namespaces: []wecs.NamespaceData{},
 	}
 	assert.Equal(t, "cluster1", c.Name)
 }

--- a/backend/test/wecs/wecs_test.go
+++ b/backend/test/wecs/wecs_test.go
@@ -1,18 +1,18 @@
 package wecs_test
 
 import (
-	"testing"
 	"github.com/kubestellar/ui/backend/wecs"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestResourceDataStruct(t *testing.T) {
 	r := wecs.ResourceData{
-		Name: "test",
-		Kind: "Pod",
-		Raw: []byte(`{"foo":"bar"}`),
+		Name:        "test",
+		Kind:        "Pod",
+		Raw:         []byte(`{"foo":"bar"}`),
 		ReplicaSets: nil,
-		Pods: nil,
+		Pods:        nil,
 	}
 	assert.Equal(t, "test", r.Name)
 	assert.Equal(t, "Pod", r.Kind)
@@ -21,7 +21,7 @@ func TestResourceDataStruct(t *testing.T) {
 
 func TestClusterDataStruct(t *testing.T) {
 	c := wecs.ClusterData{
-		Name: "cluster1",
+		Name:       "cluster1",
 		Namespaces: nil,
 	}
 	assert.Equal(t, "cluster1", c.Name)

--- a/backend/test/wecs/wecs_test.go
+++ b/backend/test/wecs/wecs_test.go
@@ -1,9 +1,9 @@
 package wecs_test
 
 import (
-	"testing"
 	"github.com/kubestellar/ui/backend/wecs"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestResourceDataStruct(t *testing.T) {


### PR DESCRIPTION
### Description
* Added and improved tests for `backend/wecs/exec.go` and `wecs.go` (including concurrency, shell validation, and struct checks).
* Exported `IsValidShellCmd` and `GenTerminalSessionId` so they can be tested.
* Fixed a panic in `SessionMap.Close` by adding a nil check for the socket


### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #1526 

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [ ] Fixed ...
- [x] Added tests for wecs package

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)
<img width="1271" height="752" alt="Screenshot 2025-07-18 at 2 05 13 AM" src="https://github.com/user-attachments/assets/c85fd4e8-5218-4245-9748-c575402d0c81" />

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

None.
