### PR TITLE
Fix: Prevent React Child Object Error for Resource Status and Labels

### DIFF
--- a/frontend/src/components/ResourceFilters.tsx
+++ b/frontend/src/components/ResourceFilters.tsx
@@ -37,13 +37,6 @@ interface ResourceFiltersProps {
   activeFilters: ResourceFilter;
 }
 
-// Utility to safely render values as strings
-function safeString(val: unknown): string {
-  if (val == null) return '';
-  if (typeof val === 'string' || typeof val === 'number') return String(val);
-  return JSON.stringify(val);
-}
-
 const ResourceFilters: React.FC<ResourceFiltersProps> = ({
   onFiltersChange,
   availableResources,
@@ -400,8 +393,8 @@ const ResourceFilters: React.FC<ResourceFiltersProps> = ({
                 </Typography>
                 {Array.from(values).map(value => (
                   <MenuItem
-                    key={`${key}-${safeString(value)}`}
-                    onClick={() => handleLabelSelect(key, value as string)}
+                    key={`${key}-${value}`}
+                    onClick={() => handleLabelSelect(key, value)}
                     selected={
                       activeFilters.label?.key === key && activeFilters.label?.value === value
                     }
@@ -430,7 +423,7 @@ const ResourceFilters: React.FC<ResourceFiltersProps> = ({
                     }}
                   >
                     <Typography variant="body2" sx={{ pl: 2 }}>
-                      {safeString(value)}
+                      {value}
                     </Typography>
                   </MenuItem>
                 ))}
@@ -519,7 +512,7 @@ const ResourceFilters: React.FC<ResourceFiltersProps> = ({
           )}
           {activeFilters.label && (
             <Chip
-              label={`${activeFilters.label.key}: ${safeString(activeFilters.label.value)}`}
+              label={`${activeFilters.label.key}: ${activeFilters.label.value}`}
               onDelete={() => handleRemoveFilter('label')}
               color="primary"
               variant="outlined"

--- a/frontend/src/components/ResourceFilters.tsx
+++ b/frontend/src/components/ResourceFilters.tsx
@@ -37,6 +37,13 @@ interface ResourceFiltersProps {
   activeFilters: ResourceFilter;
 }
 
+// Utility to safely render values as strings
+function safeString(val: unknown): string {
+  if (val == null) return '';
+  if (typeof val === 'string' || typeof val === 'number') return String(val);
+  return JSON.stringify(val);
+}
+
 const ResourceFilters: React.FC<ResourceFiltersProps> = ({
   onFiltersChange,
   availableResources,
@@ -393,8 +400,8 @@ const ResourceFilters: React.FC<ResourceFiltersProps> = ({
                 </Typography>
                 {Array.from(values).map(value => (
                   <MenuItem
-                    key={`${key}-${value}`}
-                    onClick={() => handleLabelSelect(key, value)}
+                    key={`${key}-${safeString(value)}`}
+                    onClick={() => handleLabelSelect(key, value as string)}
                     selected={
                       activeFilters.label?.key === key && activeFilters.label?.value === value
                     }
@@ -423,7 +430,7 @@ const ResourceFilters: React.FC<ResourceFiltersProps> = ({
                     }}
                   >
                     <Typography variant="body2" sx={{ pl: 2 }}>
-                      {value}
+                      {safeString(value)}
                     </Typography>
                   </MenuItem>
                 ))}
@@ -512,7 +519,7 @@ const ResourceFilters: React.FC<ResourceFiltersProps> = ({
           )}
           {activeFilters.label && (
             <Chip
-              label={`${activeFilters.label.key}: ${activeFilters.label.value}`}
+              label={`${activeFilters.label.key}: ${safeString(activeFilters.label.value)}`}
               onDelete={() => handleRemoveFilter('label')}
               color="primary"
               variant="outlined"

--- a/frontend/src/pages/ResourceFilterPage.tsx
+++ b/frontend/src/pages/ResourceFilterPage.tsx
@@ -47,6 +47,13 @@ interface Resource {
   [key: string]: unknown; // Changed from 'any' to 'unknown'
 }
 
+// Utility to safely render values as strings
+function safeString(val: unknown): string {
+  if (val == null) return '';
+  if (typeof val === 'string' || typeof val === 'number') return String(val);
+  return JSON.stringify(val);
+}
+
 const ResourceFilterPage: React.FC = () => {
   const { t } = useTranslation();
   const theme = useTheme(state => state.theme);
@@ -554,7 +561,7 @@ const ResourceFilterPage: React.FC = () => {
                               />
                               {resource.status && (
                                 <Chip
-                                  label={resourceStatus || resource.status}
+                                  label={safeString(resourceStatus || resource.status)}
                                   size="small"
                                   sx={{
                                     backgroundColor: statusColors.bg,
@@ -644,8 +651,8 @@ const ResourceFilterPage: React.FC = () => {
                                   <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
                                     {Object.entries(resource.labels).map(([key, value]) => (
                                       <Chip
-                                        key={`${key}-${value}`}
-                                        label={`${key}: ${value}`}
+                                        key={`${key}-${safeString(value)}`}
+                                        label={`${key}: ${safeString(value)}`}
                                         size="small"
                                         sx={{
                                           backgroundColor: isDark

--- a/frontend/src/pages/ResourceFilterPage.tsx
+++ b/frontend/src/pages/ResourceFilterPage.tsx
@@ -47,13 +47,6 @@ interface Resource {
   [key: string]: unknown; // Changed from 'any' to 'unknown'
 }
 
-// Utility to safely render values as strings
-function safeString(val: unknown): string {
-  if (val == null) return '';
-  if (typeof val === 'string' || typeof val === 'number') return String(val);
-  return JSON.stringify(val);
-}
-
 const ResourceFilterPage: React.FC = () => {
   const { t } = useTranslation();
   const theme = useTheme(state => state.theme);
@@ -561,7 +554,7 @@ const ResourceFilterPage: React.FC = () => {
                               />
                               {resource.status && (
                                 <Chip
-                                  label={safeString(resourceStatus || resource.status)}
+                                  label={resourceStatus || resource.status}
                                   size="small"
                                   sx={{
                                     backgroundColor: statusColors.bg,
@@ -651,8 +644,8 @@ const ResourceFilterPage: React.FC = () => {
                                   <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
                                     {Object.entries(resource.labels).map(([key, value]) => (
                                       <Chip
-                                        key={`${key}-${safeString(value)}`}
-                                        label={`${key}: ${safeString(value)}`}
+                                        key={`${key}-${value}`}
+                                        label={`${key}: ${value}`}
                                         size="small"
                                         sx={{
                                           backgroundColor: isDark


### PR DESCRIPTION
### Description

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->

This PR fixes an issue where certain Kubernetes resource fields (such as status or label values) could be objects, causing a React error:  
"Objects are not valid as a React child (found: object with keys {loadBalancer})".  
The solution ensures that all such values are safely stringified before rendering, allowing objects like {"loadBalancer":{}} to be displayed in the UI.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #1554

### ScreenShot:

[Screencast from 2025-07-20 21-18-24.webm](https://github.com/user-attachments/assets/760d8374-3c8b-48fc-8700-ca443cc74718)

