### PR TITLE
Fixes readability of cluster label chips in the UI

### DIFF
--- a/frontend/src/components/its/ClustersTable/components/LabelChip.tsx
+++ b/frontend/src/components/its/ClustersTable/components/LabelChip.tsx
@@ -23,7 +23,7 @@ const LabelChip: React.FC<LabelChipProps> = ({
   const isFiltered = filterByLabel.some(item => item.key === labelKey && item.value === value);
 
   return (
-    <Tooltip title={t('clusters.filteredByLabel')} arrow placement="top" TransitionComponent={Zoom}>
+    <Tooltip title={labelKey !== labelKey.split('/').pop() ? `${labelKey}=${value}` : t('clusters.filteredByLabel')} arrow placement="top" TransitionComponent={Zoom}>
       <span
         onClick={() => onFilterClick(labelKey, value)}
         style={{
@@ -47,7 +47,7 @@ const LabelChip: React.FC<LabelChipProps> = ({
         }}
         className="rounded-md px-2 py-1 text-xs font-medium hover:scale-105 hover:shadow-md"
       >
-        {labelKey}={value}
+        {labelKey.split('/').pop()}={value}
       </span>
     </Tooltip>
   );

--- a/frontend/src/components/its/ClustersTable/components/LabelChip.tsx
+++ b/frontend/src/components/its/ClustersTable/components/LabelChip.tsx
@@ -23,7 +23,16 @@ const LabelChip: React.FC<LabelChipProps> = ({
   const isFiltered = filterByLabel.some(item => item.key === labelKey && item.value === value);
 
   return (
-    <Tooltip title={labelKey !== labelKey.split('/').pop() ? `${labelKey}=${value}` : t('clusters.filteredByLabel')} arrow placement="top" TransitionComponent={Zoom}>
+    <Tooltip
+      title={
+        labelKey !== labelKey.split('/').pop()
+          ? `${labelKey}=${value}`
+          : t('clusters.filteredByLabel')
+      }
+      arrow
+      placement="top"
+      TransitionComponent={Zoom}
+    >
       <span
         onClick={() => onFilterClick(labelKey, value)}
         style={{


### PR DESCRIPTION
### Description

This PR improves the readability of cluster label chips in the UI. Previously, label chips displayed the **full key** (including long domain-style prefixes), which made the UI cluttered and harder to scan. We updated the rendering logic to show **only the short part** of the label key (after the last `/`), making the UI cleaner while still providing full label info on hover via a tooltip.

---

### Related Issue

Fixes #1582

---

### Changes Made

- [x] Updated `LabelChip.tsx` to extract and display only the short part of the label key.
- [x] Added tooltip to show full label key on hover for advanced users.
- [x] Improved UI readability for cluster labels.
- [ ] (Optional) Added a utility function to extract short label keys (if applicable).

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

**Before:**
cluster.open-cluster-management.io/clusterset=default

<img width="1920" height="929" alt="Screenshot from 2025-07-21 13-10-53" src="https://github.com/user-attachments/assets/3116d744-f180-4fa4-88fd-f2052b1258a3" />



**After:**
clusterset=default
(tooltip on hover shows full key)


<img width="1920" height="929" alt="image" src="https://github.com/user-attachments/assets/8046a0f0-65e9-4f3e-94f1-d1f703514e18" />

