### PR TITLE
fix: Add new plugin manager to GetAllPluginManifestsHandler handler

### DIFF
--- a/backend/api/plugins.go
+++ b/backend/api/plugins.go
@@ -848,11 +848,11 @@ func SubmitPluginFeedbackHandler(c *gin.Context) {
 
 // GetAllPluginManifestsHandler returns all plugin manifests
 func GetAllPluginManifestsHandler(c *gin.Context) {
-	// Get the plugin manager instance
-	pm := pkg.NewPluginManager(&gin.Engine{})
+	// Get the new plugin manager instance
+	pluginManager := GetGlobalPluginManager()
 
-	// Get all plugins
-	pluginList := pm.GetPluginList()
+	// Get all plugins from the plugin manager
+	pluginList := pluginManager.GetPluginList()
 
 	// Extract manifests
 	manifests := make([]pkg.PluginManifest, 0, len(pluginList))
@@ -862,6 +862,7 @@ func GetAllPluginManifestsHandler(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"status": "success",
+		"count":  len(manifests),
 		"data":   manifests,
 	})
 }


### PR DESCRIPTION
### Description

This PR fixs the GetAllPluginManifestsHandler to return all installed plugin manifests.

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #1585 

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- Adds new GlobalPluginManager to GetAllPluginManifestsHandler to fix the bug.
-
### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
