### PR TITLE
Added GET /api/plugins/categories API endpoint and manifest support

### DIFF
--- a/backend/pkg/plugins/manager.go
+++ b/backend/pkg/plugins/manager.go
@@ -69,7 +69,7 @@ type PluginSpec struct {
 	Widgets       []PluginWidgetConfig   `yaml:"widgets,omitempty"`       // Dashboard widgets
 	Routes        []PluginFrontendRoute  `yaml:"routes,omitempty"`        // Frontend routes
 	Configuration []PluginConfigItem     `yaml:"configuration,omitempty"` // Plugin configuration options
-	Categories    []string               `yaml:"categories,omitempty"` // Plugin categories (enabled for testing)
+	Categories    []string               `yaml:"categories,omitempty"`    // Plugin categories (enabled for testing)
 	// To enable plugin categories, uncomment the above line and update extractCategoriesFromManifest in api/plugins.go
 }
 

--- a/backend/pkg/plugins/manager.go
+++ b/backend/pkg/plugins/manager.go
@@ -69,6 +69,8 @@ type PluginSpec struct {
 	Widgets       []PluginWidgetConfig   `yaml:"widgets,omitempty"`       // Dashboard widgets
 	Routes        []PluginFrontendRoute  `yaml:"routes,omitempty"`        // Frontend routes
 	Configuration []PluginConfigItem     `yaml:"configuration,omitempty"` // Plugin configuration options
+	Categories    []string               `yaml:"categories,omitempty"` // Plugin categories (enabled for testing)
+	// To enable plugin categories, uncomment the above line and update extractCategoriesFromManifest in api/plugins.go
 }
 
 // PluginWasmConfig contains WASM binary information

--- a/backend/routes/plugins.go
+++ b/backend/routes/plugins.go
@@ -11,6 +11,7 @@ func setupPluginRoutes(router *gin.Engine) {
 	{
 		// Plugin Management
 		plugins.GET("", api.ListPluginsHandler)
+		plugins.GET("/categories", api.ListPluginCategoriesHandler)
 		plugins.GET("/:id", api.GetPluginDetailsHandler)
 		plugins.POST("/install", api.InstallPluginHandler)
 		plugins.DELETE("/:id", api.UninstallPluginHandler)


### PR DESCRIPTION
### Description

This PR introduces a new backend API endpoint to dynamically list all unique plugin categories, based on the `categories` field in each plugin’s manifest. This enables the UI and other consumers to retrieve a standardized set of plugin categories for filtering, grouping, or display.  
The implementation is backward-compatible: plugins without a `categories` field are safely ignored, and the endpoint returns an empty array if no plugins define categories.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #<issue_number>


### Screenshots or Logs (if applicable)

[Screencast from 2025-07-22 00-11-07.webm](https://github.com/user-attachments/assets/23e125a8-fa60-41db-980e-1f44c807aa93)
