### PR TITLE
Added GET /api/plugins/featured API endpoint for Featured Plugins

### DIFF
--- a/backend/routes/plugins.go
+++ b/backend/routes/plugins.go
@@ -29,5 +29,8 @@ func setupPluginRoutes(router *gin.Engine) {
 
 		// Feedback
 		plugins.POST("/feedback", api.SubmitPluginFeedbackHandler)
+
+		// Featured Plugins
+		plugins.GET("/featured", api.GetFeaturedPluginsHandler)
 	}
 }


### PR DESCRIPTION
## Description

This PR introduces a new backend API endpoint to dynamically list all featured plugins, based on the `featured` field in each plugin’s manifest. This enables the UI and other consumers to retrieve a curated set of featured plugins for display or recommendation, without any hardcoded lists or separate config files.

**Key features:**
- Adds `GET /api/plugins/featured` endpoint to return all plugins with `metadata.featured: true` in their `plugin.yml`.
- The implementation is backward-compatible: plugins without the `featured` field are safely ignored, and the endpoint returns an empty array if no plugins are marked as featured.
- To feature a plugin, simply add `featured: true` under the `metadata` section of its manifest.

**Example manifest:**
```yaml
metadata:
  name: "cluster-monitor"
  version: "1.0.0"
  author: "developer@company.com"
  description: "Simple cluster monitoring dashboard"
  featured: true
```

**Related Issue**  
Fixes #<issue_number>

---

**Screenshots or Logs (if applicable)**

[Screencast from 2025-07-22 00-32-06.webm](https://github.com/user-attachments/assets/7a83a0f7-fb37-44e9-81d0-44df8f3f6388)
