### PR TITLE
Implemented GET /api/plugins/search api endpoint with filtering, sorting, and pagination

### DIFF
--- a/backend/routes/plugins.go
+++ b/backend/routes/plugins.go
@@ -16,6 +16,7 @@ func setupPluginRoutes(router *gin.Engine) {
 		plugins.DELETE("/:id", api.UninstallPluginHandler)
 		plugins.POST("/:id/reload", api.ReloadPluginHandler)
 		plugins.GET("/manifests", api.GetAllPluginManifestsHandler)
+		plugins.GET("/search", api.SearchPluginsHandler)
 
 		// Plugin Control
 		plugins.POST("/:id/enable", api.EnablePluginHandler)


### PR DESCRIPTION
**Description**  
This PR introduces a new backend API endpoint to enable advanced search for plugins, supporting filtering, sorting, and pagination via query parameters. This allows the UI and other consumers to efficiently search and browse plugins based on various criteria, improving scalability and user experience.

**Key features:**
- Adds `GET /api/plugins/search` endpoint to return plugins with support for:
  - **Filtering** by name and enabled status
  - **Sorting** by name, createdAt, or updatedAt (ascending/descending)
  - **Pagination** via `limit` and `offset` query parameters
- The implementation is backward-compatible: existing plugin listing remains available at `GET /api/plugins`.
- Query parameters are optional; if omitted, all plugins are returned with default sorting and pagination.

**Example usage:**
```bash
/api/plugins/search?name=monitor&enabled=true&sort_by=name&order=asc&limit=10&offset=0
```

**Related Issue**  
Fixes #<issue_number>

**Test Output**  
All relevant tests pass, confirming the endpoint works as expected:
```bash
pranjal@PranjalLappyx:~/Desktop/Github Repo/ui$ cd backend
go test ./test/api/plugins_test.go
ok      command-line-arguments  0.058s
```

