### PR TITLE
Added GET /api/plugins/:id/versions Endpoint to Fetch Plugin Version History and Changelog

### DIFF
--- a/backend/api/plugins.go
+++ b/backend/api/plugins.go
@@ -13,15 +13,15 @@ import (
 	"sync"
 	"time"
 
+	"database/sql"
 	"github.com/gin-gonic/gin"
 	"github.com/kubestellar/ui/backend/log"
+	"github.com/kubestellar/ui/backend/models"
 	pkg "github.com/kubestellar/ui/backend/pkg/plugins"
 	"github.com/kubestellar/ui/backend/plugin"
 	"github.com/kubestellar/ui/backend/plugin/plugins"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
-	"github.com/kubestellar/ui/backend/models"
-	"database/sql"
 )
 
 // Global plugin manager and registry for dynamic plugin loading

--- a/backend/models/plugins.go
+++ b/backend/models/plugins.go
@@ -43,3 +43,11 @@ type PluginRoute struct {
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }
+
+type PluginVersionHistory struct {
+	ID        int       `json:"id"`
+	PluginID  int       `json:"plugin_id"`
+	Version   string    `json:"version"`
+	Changelog string    `json:"changelog,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+}

--- a/backend/plugin/plugins/backup_plugin.go
+++ b/backend/plugin/plugins/backup_plugin.go
@@ -131,27 +131,27 @@ func createBackupJob(c *kubernetes.Clientset) error {
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
-						corev1.Container{
+						{
 							Name:    "pg-jobc",
 							Image:   "postgres:16",
 							Command: []string{"/bin/sh", "-c"},
 							Args:    []string{"pg_dumpall -U $user -h $host  -f /mnt/backup-vol/pgdump.sql  && ls /mnt/backup-vol/"},
 							Env: []corev1.EnvVar{
-								corev1.EnvVar{
+								{
 									Name:  "PGPASSWORD",
 									Value: password,
 								},
-								corev1.EnvVar{
+								{
 									Name:  "host",
 									Value: "postgres-postgresql.kubeflex-system.svc.cluster.local",
 								},
-								corev1.EnvVar{
+								{
 									Name:  "user",
 									Value: "postgres",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
-								corev1.VolumeMount{
+								{
 									Name:      "backup-vol",
 									MountPath: "/mnt/backup-vol",
 								},
@@ -159,7 +159,7 @@ func createBackupJob(c *kubernetes.Clientset) error {
 						},
 					},
 					Volumes: []corev1.Volume{
-						corev1.Volume{
+						{
 							Name: "backup-vol",
 							VolumeSource: corev1.VolumeSource{
 								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{

--- a/backend/postgresql/migrations/000004_plugin_version_history.up.sql
+++ b/backend/postgresql/migrations/000004_plugin_version_history.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS plugin_version_history (
+    id SERIAL PRIMARY KEY,
+    plugin_id INTEGER NOT NULL REFERENCES plugin(id) ON DELETE CASCADE,
+    version VARCHAR(50) NOT NULL,
+    changelog TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_plugin_version_history_plugin_id ON plugin_version_history(plugin_id);

--- a/backend/routes/plugins.go
+++ b/backend/routes/plugins.go
@@ -16,6 +16,7 @@ func setupPluginRoutes(router *gin.Engine) {
 		plugins.DELETE("/:id", api.UninstallPluginHandler)
 		plugins.POST("/:id/reload", api.ReloadPluginHandler)
 		plugins.GET("/manifests", api.GetAllPluginManifestsHandler)
+		plugins.GET("/:id/versions", api.GetPluginVersionsHandler)
 
 		// Plugin Control
 		plugins.POST("/:id/enable", api.EnablePluginHandler)

--- a/backend/wds/common.go
+++ b/backend/wds/common.go
@@ -89,7 +89,7 @@ func ListContexts() (string, []string, error) {
 
 	// Filter contexts that contain "wds"
 	var wdsContexts []string
-	for name, _ := range config.Contexts {
+	for name := range config.Contexts {
 		if strings.Contains(name, "wds") {
 			wdsContexts = append(wdsContexts, name)
 		}


### PR DESCRIPTION
### Description

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->

This PR implements the `/api/plugins/:id/versions` endpoint, allowing clients to fetch the version history and changelog for a given plugin. It introduces a new database table for storing version history, updates the backend models, and adds the necessary API handler and route.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #<issue_number>

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Added migration for `plugin_version_history` table
- [x] Added `PluginVersionHistory` model
- [x] Implemented `GetPluginVersionsHandler` in the backend API
- [x] Registered the new route in `routes/plugins.go`
