### PR TITLE
Add GET /api/plugins/:id/dependencies Endpoint to Fetch Plugin Dependencies

### DIFF
--- a/backend/examples/cluster-monitor/plugin.yml
+++ b/backend/examples/cluster-monitor/plugin.yml
@@ -32,3 +32,11 @@ spec:
   permissions:
     - "kubestellar:read:clusters"
     - "kubestellar:read:workloads"
+  # Plugin dependencies
+  dependencies:
+    - name: "core-logger"
+      version: ">=1.0.0"
+      optional: false
+    - name: "metrics-exporter"
+      version: ">=0.5.0"
+      optional: true

--- a/backend/pkg/plugins/manager.go
+++ b/backend/pkg/plugins/manager.go
@@ -58,6 +58,15 @@ type PluginMetadata struct {
 	Description string `yaml:"description"` // Plugin description
 }
 
+// PluginDependency describes a dependency on another plugin
+// Optional: if true, the dependency is not required for basic operation
+// Version: version constraint (e.g., ">=1.0.0")
+type PluginDependency struct {
+	Name     string `yaml:"name" json:"name"`         // Name of the dependency plugin
+	Version  string `yaml:"version" json:"version"`   // Version constraint
+	Optional bool   `yaml:"optional" json:"optional"` // Whether this dependency is optional
+}
+
 // PluginSpec contains the plugin specification
 type PluginSpec struct {
 	Wasm          *PluginWasmConfig      `yaml:"wasm,omitempty"`          // WASM binary configuration
@@ -69,6 +78,7 @@ type PluginSpec struct {
 	Widgets       []PluginWidgetConfig   `yaml:"widgets,omitempty"`       // Dashboard widgets
 	Routes        []PluginFrontendRoute  `yaml:"routes,omitempty"`        // Frontend routes
 	Configuration []PluginConfigItem     `yaml:"configuration,omitempty"` // Plugin configuration options
+	Dependencies  []PluginDependency     `yaml:"dependencies,omitempty" json:"dependencies,omitempty"` // Plugin dependencies
 }
 
 // PluginWasmConfig contains WASM binary information

--- a/backend/pkg/plugins/manager.go
+++ b/backend/pkg/plugins/manager.go
@@ -69,15 +69,15 @@ type PluginDependency struct {
 
 // PluginSpec contains the plugin specification
 type PluginSpec struct {
-	Wasm          *PluginWasmConfig      `yaml:"wasm,omitempty"`          // WASM binary configuration
-	Build         *PluginBuildConfig     `yaml:"build,omitempty"`         // Build configuration
-	Backend       *PluginBackendConfig   `yaml:"backend,omitempty"`       // Backend configuration
-	Permissions   []string               `yaml:"permissions,omitempty"`   // Required permissions - "kubestellar:read:clusters" "kubestellar:read:workloads"
-	Frontend      *PluginFrontendConfig  `yaml:"frontend,omitempty"`      // Frontend configuration
-	Navigation    []PluginNavigationItem `yaml:"navigation,omitempty"`    // Navigation integration
-	Widgets       []PluginWidgetConfig   `yaml:"widgets,omitempty"`       // Dashboard widgets
-	Routes        []PluginFrontendRoute  `yaml:"routes,omitempty"`        // Frontend routes
-	Configuration []PluginConfigItem     `yaml:"configuration,omitempty"` // Plugin configuration options
+	Wasm          *PluginWasmConfig      `yaml:"wasm,omitempty"`                                       // WASM binary configuration
+	Build         *PluginBuildConfig     `yaml:"build,omitempty"`                                      // Build configuration
+	Backend       *PluginBackendConfig   `yaml:"backend,omitempty"`                                    // Backend configuration
+	Permissions   []string               `yaml:"permissions,omitempty"`                                // Required permissions - "kubestellar:read:clusters" "kubestellar:read:workloads"
+	Frontend      *PluginFrontendConfig  `yaml:"frontend,omitempty"`                                   // Frontend configuration
+	Navigation    []PluginNavigationItem `yaml:"navigation,omitempty"`                                 // Navigation integration
+	Widgets       []PluginWidgetConfig   `yaml:"widgets,omitempty"`                                    // Dashboard widgets
+	Routes        []PluginFrontendRoute  `yaml:"routes,omitempty"`                                     // Frontend routes
+	Configuration []PluginConfigItem     `yaml:"configuration,omitempty"`                              // Plugin configuration options
 	Dependencies  []PluginDependency     `yaml:"dependencies,omitempty" json:"dependencies,omitempty"` // Plugin dependencies
 }
 

--- a/backend/routes/plugins.go
+++ b/backend/routes/plugins.go
@@ -16,6 +16,8 @@ func setupPluginRoutes(router *gin.Engine) {
 		plugins.DELETE("/:id", api.UninstallPluginHandler)
 		plugins.POST("/:id/reload", api.ReloadPluginHandler)
 		plugins.GET("/manifests", api.GetAllPluginManifestsHandler)
+		// Add the dependencies endpoint
+		plugins.GET("/:id/dependencies", api.GetPluginDependenciesHandler)
 
 		// Plugin Control
 		plugins.POST("/:id/enable", api.EnablePluginHandler)


### PR DESCRIPTION
### Description

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->

This PR introduces a new API endpoint, `GET /api/plugins/:id/dependencies`, which allows clients to retrieve the required and optional dependencies for a given plugin. The endpoint reads dependency information directly from each plugin’s manifest (`plugin.yml`), supporting both required and optional dependencies as specified by plugin authors.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #<issue_number>

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Added `dependencies` support to the `PluginSpec` struct and manifest schema.
- [x] Implemented the `GetPluginDependenciesHandler` in the backend API.
- [x] Registered the new endpoint in the plugin routes.
- [x] Updated example plugin manifest to demonstrate dependencies usage.
- [x] Ensured the endpoint returns dependencies split into `required` and `optional` arrays.


### Screenshots or Logs (if applicable)

[Screencast from 2025-07-22 02-03-34.webm](https://github.com/user-attachments/assets/cf3450b0-be03-4c1e-baa4-712cb187b9df)
