### PR TITLE
Fixes: Ensure EditTab renders manifest in correct format on initial load

### DIFF
--- a/frontend/src/components/wecs_details/tabs/EditTab.tsx
+++ b/frontend/src/components/wecs_details/tabs/EditTab.tsx
@@ -55,7 +55,6 @@ const EditTab: React.FC<EditTabProps> = ({
     } catch {
       // Ignore, will be caught by validation
     }
-
   }, [editFormat, editedManifest, handleEditorChange, jsonToYaml, yamlToJson]);
 
   // Validate JSON/YAML content

--- a/frontend/src/components/wecs_details/tabs/EditTab.tsx
+++ b/frontend/src/components/wecs_details/tabs/EditTab.tsx
@@ -32,28 +32,20 @@ const EditTab: React.FC<EditTabProps> = ({
   // Ensure manifest is in the correct format on mount and when editFormat/editedManifest changes
   useEffect(() => {
     if (!editedManifest || editedManifest.trim() === '') return;
-    let needsConversion = false;
     try {
       if (editFormat === 'yaml') {
-        // Try parsing as YAML, then convert to JSON and back to YAML to normalize
         const asJson = yamlToJson(editedManifest);
         const asYaml = jsonToYaml(asJson);
-        // If the YAML produced from the JSON is different, update
         if (editedManifest.trim() !== asYaml.trim()) {
-          needsConversion = true;
           handleEditorChange(asYaml);
         }
       } else if (editFormat === 'json') {
-        // Try parsing as JSON, if fails, try converting from YAML
         try {
           JSON.parse(editedManifest);
         } catch {
-          // Not valid JSON, try converting from YAML
           try {
             const asJson = yamlToJson(editedManifest);
-            // Pretty-print JSON
             const prettyJson = JSON.stringify(JSON.parse(asJson), null, 2);
-            needsConversion = true;
             handleEditorChange(prettyJson);
           } catch {
             // Ignore, will be caught by validation
@@ -63,7 +55,7 @@ const EditTab: React.FC<EditTabProps> = ({
     } catch {
       // Ignore, will be caught by validation
     }
-    // If no conversion needed, do nothing
+
   }, [editFormat, editedManifest, handleEditorChange, jsonToYaml, yamlToJson]);
 
   // Validate JSON/YAML content


### PR DESCRIPTION
### Description:
- Ensures the deployment configuration is displayed in the correct format (YAML or JSON) immediately when editing a workload.
- Adds a `useEffect` to convert and normalize the manifest content based on the selected editor mode on first load and when switching formats.
- Resolves issue where YAML mode would initially show JSON until toggled.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #1613 

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

Before : 

[Screencast from 2025-07-23 20-22-20.webm](https://github.com/user-attachments/assets/006e581f-4c8f-4ca1-9a28-5cef265b83c2)

After : 

[Screencast from 2025-07-23 20-41-44.webm](https://github.com/user-attachments/assets/136532e2-b964-4038-adef-c2dbdeb1afa8)

