### PR TITLE
FIX : currentContext card to hold big names.

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -395,9 +395,9 @@ const StatCard = ({
         </div>
 
         <div className="mt-1 flex items-end justify-between">
-          <div className="flex-grow">
+          <div className="min-w-0 flex-grow">
             <div className="flex items-center">
-              <h3 className="text-3xl font-bold text-gray-900 transition-colors dark:text-gray-50">
+              <h3 className="truncate text-3xl font-bold text-gray-900 transition-colors dark:text-gray-50">
                 {value}
               </h3>
               {isContext && (


### PR DESCRIPTION
### Description

Fix the current context card ui to handle big text names.

### Related Issue

#1634 

Fixes #1634 

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

  - Added truncate attribute to the `<h3>` tag which is responsible for current context name rendering. This is a Tailwind CSS utility that automatically adds multiple dots at the end to any text that is too long to fit within the component.
- Added  min-w-0 attribute to the container div around the text. This is a minor flexbox fix. It prevents the long text from meshing with other components around it.


### Checklist

Please ensure the following before submitting your PR:

- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

Before : 
<img width="2559" height="1413" alt="image" src="https://github.com/user-attachments/assets/7cb9eb77-037d-4e44-aee8-89d84922c241" />
After: 
<img width="2548" height="1385" alt="image" src="https://github.com/user-attachments/assets/1ee1d19e-044b-4b77-9d5e-84ecee51a973" />


### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
