### PR TITLE
Fix: Context menu actions not working in staged workloads

### DIFF
--- a/frontend/src/components/TreeViewComponent.tsx
+++ b/frontend/src/components/TreeViewComponent.tsx
@@ -35,6 +35,7 @@ const TreeViewComponent = memo<TreeViewComponentProps>(props => {
     resourceData?: TreeResourceItem;
     isGroup?: boolean;
     groupItems?: TreeResourceItem[];
+    initialTab?: number;
   } | null>(null);
   const [isCollapsed, setIsCollapsed] = useState<boolean>(false);
   const [isExpanded, setIsExpanded] = useState<boolean>(true);
@@ -53,17 +54,17 @@ const TreeViewComponent = memo<TreeViewComponentProps>(props => {
       resourceData?: TreeResourceItem;
       isGroup?: boolean;
       groupItems?: TreeResourceItem[];
+      initialTab?: number;
     }) => {
       setSelectedNode(nodeData);
     },
     []
   );
 
-  // Menu open handler - used by the actions hook
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const handleMenuOpen = useCallback((_event: React.MouseEvent, _nodeId: string) => {
-    // This will be handled by the useTreeViewActions hook
-  }, []);
+  // Temporary menu open handler - will be updated after actions hook is created
+  const [handleMenuOpen, setHandleMenuOpen] = useState<
+    ((event: React.MouseEvent, nodeId: string) => void) | null
+  >(null);
 
   // Data management hook
   const {
@@ -83,7 +84,7 @@ const TreeViewComponent = memo<TreeViewComponentProps>(props => {
     isCollapsed,
     isExpanded,
     onNodeSelect: handleNodeSelect,
-    onMenuOpen: handleMenuOpen,
+    onMenuOpen: handleMenuOpen || (() => {}),
   });
 
   // Actions management hook
@@ -94,6 +95,7 @@ const TreeViewComponent = memo<TreeViewComponentProps>(props => {
     snackbarOpen,
     snackbarMessage,
     snackbarSeverity,
+    handleMenuOpen: handleMenuOpenFromActions,
     handleMenuClose,
     handleMenuAction,
     handleDeleteConfirm,
@@ -111,7 +113,13 @@ const TreeViewComponent = memo<TreeViewComponentProps>(props => {
       // Update edges state - handled by the data hook
     },
     getDescendantEdges,
+    onNodeSelect: handleNodeSelect,
   });
+
+  // Update the menu open handler after actions hook is created
+  useEffect(() => {
+    setHandleMenuOpen(() => handleMenuOpenFromActions);
+  }, [handleMenuOpenFromActions]);
 
   // Panel close handler
   const handleClosePanel = useCallback(() => {

--- a/frontend/src/components/treeView/NodeDetailsPanel.tsx
+++ b/frontend/src/components/treeView/NodeDetailsPanel.tsx
@@ -11,6 +11,7 @@ interface NodeDetailsPanelProps {
     resourceData?: ResourceItem;
     isGroup?: boolean;
     groupItems?: ResourceItem[];
+    initialTab?: number;
   } | null;
   isOpen: boolean;
   onClose: () => void;
@@ -74,6 +75,7 @@ const NodeDetailsPanel = memo<NodeDetailsPanelProps>(
             onClose={onClose}
             isOpen={isOpen}
             onDelete={onDelete}
+            initialTab={selectedNode.initialTab}
           />
         )}
       </div>

--- a/frontend/src/components/treeView/hooks/useTreeViewActions.ts
+++ b/frontend/src/components/treeView/hooks/useTreeViewActions.ts
@@ -9,6 +9,25 @@ import {
 } from '../types';
 import { kindToPluralMap } from '../types';
 
+// Define the tab configuration - this can be easily modified if tabs are reordered
+const TAB_CONFIG = {
+  SUMMARY: 0,
+  EDIT: 1,
+  LOGS: 2,
+} as const;
+
+// Map actions to tab indices dynamically
+const getTabIndexForAction = (action: string): number => {
+  const actionToTabMap: Record<string, keyof typeof TAB_CONFIG> = {
+    Details: 'SUMMARY',
+    Edit: 'EDIT',
+    Logs: 'LOGS',
+  };
+
+  const tabKey = actionToTabMap[action];
+  return tabKey ? TAB_CONFIG[tabKey] : TAB_CONFIG.SUMMARY; // Default to summary tab
+};
+
 interface UseTreeViewActionsProps {
   nodes: CustomNode[];
   edges: CustomEdge[];
@@ -119,27 +138,7 @@ export const useTreeViewActions = ({
               setDeleteDialogOpen(true);
               break;
             case 'Details':
-              if (onNodeSelect) {
-                onNodeSelect({
-                  namespace: namespace || 'default',
-                  name: nodeName,
-                  type: nodeType,
-                  resourceData,
-                  initialTab: 0,
-                });
-              }
-              break;
             case 'Edit':
-              if (onNodeSelect) {
-                onNodeSelect({
-                  namespace: namespace || 'default',
-                  name: nodeName,
-                  type: nodeType,
-                  resourceData,
-                  initialTab: 1,
-                });
-              }
-              break;
             case 'Logs':
               if (onNodeSelect) {
                 onNodeSelect({
@@ -147,7 +146,7 @@ export const useTreeViewActions = ({
                   name: nodeName,
                   type: nodeType,
                   resourceData,
-                  initialTab: 2,
+                  initialTab: getTabIndexForAction(action),
                 });
               }
               break;


### PR DESCRIPTION


### Description

Fixed the context menu actions (Details, Edit, Logs) in staged workloads that were not working properly. The issue was that the `useTreeViewActions` hook wasn't properly connected to handle menu actions, causing the three buttons to be non-functional.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #1621 

### Changes Made


- [x] Updated `useTreeViewActions` hook to properly handle Details, Edit, and Logs actions by calling `onNodeSelect` callback
- [x] Fixed data flow in `TreeViewComponent` to connect menu click events with actions handler
- [x] Added `initialTab` support to `NodeDetailsPanel` for proper tab selection
- [x] Replaced `any` types with proper `ResourceItem` types for better type safety
- [x] Fixed circular dependency issue in hook initialization

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

https://github.com/user-attachments/assets/c9c91832-04c3-4622-bf64-2ba41d131976




### Additional Notes

This fix ensures consistent behavior between staged and deployed workloads for the three-button context menu functionality.
