### PR TITLE
fixes bulk label error

### DIFF
--- a/frontend/src/components/its/ClustersTable/ClustersTable.tsx
+++ b/frontend/src/components/its/ClustersTable/ClustersTable.tsx
@@ -223,7 +223,7 @@ const ClustersTable: React.FC<ClustersTableProps> = ({
     deletedLabels?: string[]
   ) => {
     const isBulkOperation =
-      selectedClusters.length > 0 && clusterName.includes('selected clusters');
+      selectedClusters.length > 1 && clusterName.includes('selected clusters');
     setLoadingClusterEdit(isBulkOperation ? 'bulk' : clusterName);
 
     if (isBulkOperation) {
@@ -329,13 +329,20 @@ const ClustersTable: React.FC<ClustersTableProps> = ({
         onFilterChange={setFilter}
         hasSelectedClusters={selectedClusters.length > 0}
         selectedCount={selectedClusters.length}
-        onBulkLabels={() =>
+        onBulkLabels={() => {
+          if (selectedClusters.length <= 1) {
+            toast.error('Bulk labeling requires multiple clusters to be selected', {
+              icon: '⚠️',
+              duration: 4000,
+            });
+            return;
+          }
           handleEditLabels({
             name: `${selectedClusters.length} selected clusters`,
             context: 'bulk-operation',
             labels: {},
-          })
-        }
+          });
+        }}
         onShowCreateOptions={() => {
           setShowCreateOptions(true);
           setActiveOption('quickconnect');

--- a/frontend/src/components/its/ClustersTable/ClustersTable.tsx
+++ b/frontend/src/components/its/ClustersTable/ClustersTable.tsx
@@ -330,13 +330,6 @@ const ClustersTable: React.FC<ClustersTableProps> = ({
         hasSelectedClusters={selectedClusters.length > 0}
         selectedCount={selectedClusters.length}
         onBulkLabels={() => {
-          if (selectedClusters.length <= 1) {
-            toast.error('Bulk labeling requires multiple clusters to be selected', {
-              icon: '⚠️',
-              duration: 4000,
-            });
-            return;
-          }
           handleEditLabels({
             name: `${selectedClusters.length} selected clusters`,
             context: 'bulk-operation',

--- a/frontend/src/components/its/ClustersTable/ClustersTable.tsx
+++ b/frontend/src/components/its/ClustersTable/ClustersTable.tsx
@@ -223,7 +223,7 @@ const ClustersTable: React.FC<ClustersTableProps> = ({
     deletedLabels?: string[]
   ) => {
     const isBulkOperation =
-      selectedClusters.length > 1 && clusterName.includes('selected clusters');
+      selectedClusters.length > 0 && clusterName.includes('selected clusters');
     setLoadingClusterEdit(isBulkOperation ? 'bulk' : clusterName);
 
     if (isBulkOperation) {

--- a/frontend/src/components/its/ClustersTable/components/TableHeader.tsx
+++ b/frontend/src/components/its/ClustersTable/components/TableHeader.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Button, Box, Menu, MenuItem, ListItemIcon, ListItemText } from '@mui/material';
+import { Button, Box, Menu, MenuItem, ListItemIcon, ListItemText, Tooltip } from '@mui/material';
 import { Filter, Plus, Tag } from 'lucide-react';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import PostAddIcon from '@mui/icons-material/PostAdd';
@@ -158,59 +158,70 @@ const TableHeader: React.FC<TableHeaderProps> = ({
 
           {hasSelectedClusters && (
             <div className="ml-auto flex">
-              <Button
-                variant="outlined"
-                startIcon={<Tag size={16} />}
-                endIcon={<KeyboardArrowDownIcon />}
-                onClick={selectedCount > 1 ? handleBulkLabelsClick : onBulkLabels}
-                sx={{
-                  color: selectedCount > 1 ? colors.primary : colors.disabled,
-                  borderColor: selectedCount > 1 ? colors.border : colors.disabled,
-                  backgroundColor: isDark ? 'rgba(47, 134, 255, 0.05)' : 'transparent',
-                  opacity: selectedCount <= 1 ? 0.6 : 1,
-                  cursor: selectedCount <= 1 ? 'not-allowed' : 'pointer',
-                  '&:hover': {
-                    borderColor: selectedCount > 1 ? colors.primary : colors.disabled,
-                    backgroundColor:
-                      selectedCount > 1
-                        ? isDark
-                          ? 'rgba(47, 134, 255, 0.1)'
-                          : 'rgba(47, 134, 255, 0.05)'
-                        : 'transparent',
-                    transform: selectedCount > 1 ? 'translateY(-2px)' : 'none',
-                    boxShadow:
-                      selectedCount > 1 ? '0 4px 8px -2px rgba(47, 134, 255, 0.2)' : 'none',
-                    cursor: selectedCount <= 1 ? 'not-allowed' : 'pointer',
-                  },
-                  textTransform: 'none',
-                  fontWeight: '500',
-                  borderRadius: '10px',
-                  padding: '8px 16px',
-                  height: '45px',
-                  transition: 'all 0.2s ease',
-                }}
+              <Tooltip
+                title={
+                  selectedCount <= 1
+                    ? t('clusters.labels.bulkTooltipDisabled')
+                    : t('clusters.labels.bulkTooltipEnabled')
+                }
+                arrow
+                placement="top"
               >
-                {t('clusters.labels.manage')}
-                <Box
-                  component="span"
-                  sx={{
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    minWidth: '22px',
-                    height: '22px',
-                    borderRadius: '11px',
-                    backgroundColor: colors.primary,
-                    color: 'white',
-                    fontSize: '12px',
-                    fontWeight: 'bold',
-                    ml: 1,
-                    padding: '0 6px',
-                  }}
-                >
-                  {selectedCount}
-                </Box>
-              </Button>
+                <span>
+                  <Button
+                    variant="outlined"
+                    startIcon={<Tag size={16} />}
+                    endIcon={<KeyboardArrowDownIcon />}
+                    onClick={selectedCount > 1 ? handleBulkLabelsClick : undefined}
+                    disabled={selectedCount <= 1}
+                    sx={{
+                      color: colors.primary,
+                      borderColor: colors.border,
+                      backgroundColor: isDark ? 'rgba(47, 134, 255, 0.05)' : 'transparent',
+                      '&:hover': {
+                        borderColor: colors.primary,
+                        backgroundColor: isDark
+                          ? 'rgba(47, 134, 255, 0.1)'
+                          : 'rgba(47, 134, 255, 0.05)',
+                        transform: 'translateY(-2px)',
+                        boxShadow: '0 4px 8px -2px rgba(47, 134, 255, 0.2)',
+                      },
+                      '&.Mui-disabled': {
+                        color: colors.disabled,
+                        borderColor: colors.disabled,
+                        opacity: 0.6,
+                      },
+                      textTransform: 'none',
+                      fontWeight: '500',
+                      borderRadius: '10px',
+                      padding: '8px 16px',
+                      height: '45px',
+                      transition: 'all 0.2s ease',
+                    }}
+                  >
+                    {t('clusters.labels.manage')}
+                    <Box
+                      component="span"
+                      sx={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        minWidth: '22px',
+                        height: '22px',
+                        borderRadius: '11px',
+                        backgroundColor: colors.primary,
+                        color: 'white',
+                        fontSize: '12px',
+                        fontWeight: 'bold',
+                        ml: 1,
+                        padding: '0 6px',
+                      }}
+                    >
+                      {selectedCount}
+                    </Box>
+                  </Button>
+                </span>
+              </Tooltip>
               {selectedCount > 1 && (
                 <Menu
                   anchorEl={bulkLabelsAnchorEl}

--- a/frontend/src/components/its/ClustersTable/components/TableHeader.tsx
+++ b/frontend/src/components/its/ClustersTable/components/TableHeader.tsx
@@ -162,18 +162,25 @@ const TableHeader: React.FC<TableHeaderProps> = ({
                 variant="outlined"
                 startIcon={<Tag size={16} />}
                 endIcon={<KeyboardArrowDownIcon />}
-                onClick={handleBulkLabelsClick}
+                onClick={selectedCount > 1 ? handleBulkLabelsClick : onBulkLabels}
                 sx={{
-                  color: colors.primary,
-                  borderColor: colors.border,
+                  color: selectedCount > 1 ? colors.primary : colors.disabled,
+                  borderColor: selectedCount > 1 ? colors.border : colors.disabled,
                   backgroundColor: isDark ? 'rgba(47, 134, 255, 0.05)' : 'transparent',
+                  opacity: selectedCount <= 1 ? 0.6 : 1,
+                  cursor: selectedCount <= 1 ? 'not-allowed' : 'pointer',
                   '&:hover': {
-                    borderColor: colors.primary,
-                    backgroundColor: isDark
-                      ? 'rgba(47, 134, 255, 0.1)'
-                      : 'rgba(47, 134, 255, 0.05)',
-                    transform: 'translateY(-2px)',
-                    boxShadow: '0 4px 8px -2px rgba(47, 134, 255, 0.2)',
+                    borderColor: selectedCount > 1 ? colors.primary : colors.disabled,
+                    backgroundColor:
+                      selectedCount > 1
+                        ? isDark
+                          ? 'rgba(47, 134, 255, 0.1)'
+                          : 'rgba(47, 134, 255, 0.05)'
+                        : 'transparent',
+                    transform: selectedCount > 1 ? 'translateY(-2px)' : 'none',
+                    boxShadow:
+                      selectedCount > 1 ? '0 4px 8px -2px rgba(47, 134, 255, 0.2)' : 'none',
+                    cursor: selectedCount <= 1 ? 'not-allowed' : 'pointer',
                   },
                   textTransform: 'none',
                   fontWeight: '500',
@@ -204,38 +211,40 @@ const TableHeader: React.FC<TableHeaderProps> = ({
                   {selectedCount}
                 </Box>
               </Button>
-              <Menu
-                anchorEl={bulkLabelsAnchorEl}
-                open={Boolean(bulkLabelsAnchorEl)}
-                onClose={handleBulkLabelsClose}
-                MenuListProps={{
-                  'aria-labelledby': 'bulk-labels-button',
-                }}
-                PaperProps={{
-                  sx: {
-                    mt: 1,
-                    boxShadow: isDark
-                      ? '0 10px 25px -5px rgba(0, 0, 0, 0.3)'
-                      : '0 10px 25px -5px rgba(0, 0, 0, 0.1)',
-                    backgroundColor: colors.paper,
-                    border: `1px solid ${colors.border}`,
-                    borderRadius: '8px',
-                  },
-                }}
-              >
-                <MenuItem
-                  onClick={() => {
-                    onBulkLabels();
-                    handleBulkLabelsClose();
+              {selectedCount > 1 && (
+                <Menu
+                  anchorEl={bulkLabelsAnchorEl}
+                  open={Boolean(bulkLabelsAnchorEl)}
+                  onClose={handleBulkLabelsClose}
+                  MenuListProps={{
+                    'aria-labelledby': 'bulk-labels-button',
                   }}
-                  sx={{ color: colors.text }}
+                  PaperProps={{
+                    sx: {
+                      mt: 1,
+                      boxShadow: isDark
+                        ? '0 10px 25px -5px rgba(0, 0, 0, 0.3)'
+                        : '0 10px 25px -5px rgba(0, 0, 0, 0.1)',
+                      backgroundColor: colors.paper,
+                      border: `1px solid ${colors.border}`,
+                      borderRadius: '8px',
+                    },
+                  }}
                 >
-                  <ListItemIcon>
-                    <PostAddIcon fontSize="small" style={{ color: colors.primary }} />
-                  </ListItemIcon>
-                  <ListItemText>{t('clusters.labels.bulkLabels')}</ListItemText>
-                </MenuItem>
-              </Menu>
+                  <MenuItem
+                    onClick={() => {
+                      onBulkLabels();
+                      handleBulkLabelsClose();
+                    }}
+                    sx={{ color: colors.text }}
+                  >
+                    <ListItemIcon>
+                      <PostAddIcon fontSize="small" style={{ color: colors.primary }} />
+                    </ListItemIcon>
+                    <ListItemText>{t('clusters.labels.bulkLabels')}</ListItemText>
+                  </MenuItem>
+                </Menu>
+              )}
             </div>
           )}
 

--- a/frontend/src/locales/strings.en.json
+++ b/frontend/src/locales/strings.en.json
@@ -442,6 +442,8 @@
       "label": "Label",
       "editvalue": "Both key and value are required",
       "manage": "Manage Labels",
+      "bulkTooltipDisabled": "Select at least 2 clusters to enable bulk labeling",
+      "bulkTooltipEnabled": "Manage labels for selected clusters",
       "clearFilter": "Clear Filter",
       "searchLabelsPlaceholder": "Search labels...",
       "bulkEditTitle": "Edit Labels for {{count}} Clusters",


### PR DESCRIPTION
### Description

This PR fixes a bug where trying to bulk assign labels to only **one cluster** caused a `500 Internal Server Error`. The issue was due to incorrect bulk operation detection logic in the frontend. The previous condition checked for `selectedClusters.length > 1`, which failed for single cluster selections even though the frontend still generated a virtual cluster name like `"1 selected clusters"`.

The fix ensures that the app treats any selection (1 or more clusters) as a bulk operation when the `clusterName` contains `"selected clusters"`.

### Related Issue

Fixes #1655

### Changes Made

- Updated `isBulkOperation` condition in `ClustersTable.tsx` to support single-cluster bulk actions:
  ```ts
  const isBulkOperation = selectedClusters.length > 0 && clusterName.includes('selected clusters');
  
  - Ensured the selected cluster names are correctly passed to the backend
  - Verified that single and multiple cluster selections both use the correct bulk assignment logic
### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.


### Screencast : - 

[Screencast from 26-07-25 11:06:38 PM IST.webm](https://github.com/user-attachments/assets/de2d5f9c-4f1a-4294-9e13-7fda6f076d8e)

