### PR TITLE
Fix: update contributors section in README to use kubestellar/ui (#1658)

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,8 +428,8 @@ Instantly get access to our documents and meeting invites at http://kubestellar.
 <br>
 
 <center>
-<a href="https://github.com/kubestellar/kubestellar/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=kubestellar/kubestellar" />
+<a href="https://github.com/kubestellar/ui/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=kubestellar/ui" />
 </a>
 </center>
 <br>


### PR DESCRIPTION
### Description

Updated the contributors section in the README.md file to correctly reference the kubestellar/ui repository. Previously, it was displaying contributors from the main kubestellar/kubestellar repository.

### Related Issue

Fixes #1658

### Changes Made

 - [x] Updated the contributor image link in README.md to point to kubestellar/ui

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
