### PR TITLE
Fix: Toggle button colors in dark mode for edge style controls

### DIFF
--- a/frontend/src/components/wds_topology/ZoomControls.tsx
+++ b/frontend/src/components/wds_topology/ZoomControls.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from 'react-i18next';
 import useZoomStore, { zoomPresets } from '../../stores/zoomStore';
 import useEdgeTypeStore from '../../stores/edgeTypeStore';
 
+
 interface ZoomControlsProps {
   theme: string;
   onToggleCollapse: () => void;
@@ -23,6 +24,7 @@ interface ZoomControlsProps {
   onCollapseAll: () => void;
 }
 
+
 export const ZoomControls = memo<ZoomControlsProps>(
   ({ theme, onToggleCollapse, isCollapsed, onExpandAll, onCollapseAll }) => {
     const { t } = useTranslation();
@@ -30,13 +32,16 @@ export const ZoomControls = memo<ZoomControlsProps>(
     const [zoomLevel, setZoomLevel] = useState<number>(120);
     const [presetMenuAnchor, setPresetMenuAnchor] = useState<null | HTMLElement>(null);
 
+
     const { setZoom } = useZoomStore();
     const { edgeType, setEdgeType } = useEdgeTypeStore();
+
 
     const snapToStep = useCallback((zoom: number) => {
       const step = 10;
       return Math.round(zoom / step) * step;
     }, []);
+
 
     useEffect(() => {
       const updateZoomLevel = () => {
@@ -46,12 +51,16 @@ export const ZoomControls = memo<ZoomControlsProps>(
         setZoom(getZoom());
       };
 
+
       updateZoomLevel();
+
 
       const interval = setInterval(updateZoomLevel, 100);
 
+
       return () => clearInterval(interval);
     }, [getZoom, snapToStep, setViewport, setZoom]);
+
 
     const animateZoom = useCallback(
       (targetZoom: number, duration: number = 200) => {
@@ -59,16 +68,19 @@ export const ZoomControls = memo<ZoomControlsProps>(
         const currentViewport = getViewport();
         const startTime = performance.now();
 
+
         const step = (currentTime: number) => {
           const elapsed = currentTime - startTime;
           const progress = Math.min(elapsed / duration, 1);
           const newZoom = startZoom + (targetZoom - startZoom) * progress;
+
 
           setViewport({
             zoom: newZoom,
             x: currentViewport.x,
             y: currentViewport.y,
           });
+
 
           if (progress < 1) {
             requestAnimationFrame(step);
@@ -78,10 +90,12 @@ export const ZoomControls = memo<ZoomControlsProps>(
           }
         };
 
+
         requestAnimationFrame(step);
       },
       [getZoom, getViewport, setViewport, snapToStep, setZoom]
     );
+
 
     const handleZoomIn = useCallback(() => {
       const currentZoom = getZoom();
@@ -89,10 +103,12 @@ export const ZoomControls = memo<ZoomControlsProps>(
       const newZoomPercentage = Math.min(snapToStep(currentZoomPercentage + 10), 200);
       const newZoom = newZoomPercentage / 100;
 
+
       if (Math.abs(newZoom - currentZoom) > 0.01) {
         animateZoom(newZoom);
       }
     }, [animateZoom, getZoom, snapToStep]);
+
 
     const handleZoomOut = useCallback(() => {
       const currentZoom = getZoom();
@@ -100,10 +116,12 @@ export const ZoomControls = memo<ZoomControlsProps>(
       const newZoomPercentage = Math.max(snapToStep(currentZoomPercentage - 10), 10);
       const newZoom = newZoomPercentage / 100;
 
+
       if (Math.abs(newZoom - currentZoom) > 0.01) {
         animateZoom(newZoom);
       }
     }, [animateZoom, getZoom, snapToStep]);
+
 
     const handlePresetClick = useCallback(
       (preset: (typeof zoomPresets)[0]) => {
@@ -113,19 +131,23 @@ export const ZoomControls = memo<ZoomControlsProps>(
       [animateZoom]
     );
 
+
     const handlePresetMenuOpen = useCallback((event: React.MouseEvent<HTMLElement>) => {
       setPresetMenuAnchor(event.currentTarget);
     }, []);
 
+
     const handlePresetMenuClose = useCallback(() => {
       setPresetMenuAnchor(null);
     }, []);
+
 
     const handleResetZoom = useCallback(() => {
       setViewport({ ...getViewport(), zoom: 1 }, { duration: 200 });
       setZoomLevel(100);
       setZoom(1);
     }, [setViewport, getViewport, setZoom]);
+
 
     return (
       <Box
@@ -253,6 +275,7 @@ export const ZoomControls = memo<ZoomControlsProps>(
           {zoomLevel}%
         </Typography>
 
+
         <Menu
           anchorEl={presetMenuAnchor}
           open={Boolean(presetMenuAnchor)}
@@ -295,7 +318,23 @@ export const ZoomControls = memo<ZoomControlsProps>(
             size="small"
             color="primary"
             aria-label="Edge Type"
-            sx={{ ml: 2 }}
+            sx={{ 
+              ml: 2,
+              '& .MuiToggleButton-root': {
+                color: theme === 'dark' ? '#fff' : '#6d7f8b',
+                borderColor: theme === 'dark' ? '#555' : '#e0e0e0',
+                '&:hover': {
+                  backgroundColor: theme === 'dark' ? '#555' : '#e3f2fd',
+                },
+                '&.Mui-selected': {
+                  color: theme === 'dark' ? '#fff' : '#1976d2',
+                  backgroundColor: theme === 'dark' ? '#555' : '#e3f2fd',
+                  '&:hover': {
+                    backgroundColor: theme === 'dark' ? '#666' : '#bbdefb',
+                  },
+                },
+              },
+            }}
           >
             <ToggleButton value="bezier" aria-label="Curvy">
               Curvy

--- a/frontend/src/components/wds_topology/ZoomControls.tsx
+++ b/frontend/src/components/wds_topology/ZoomControls.tsx
@@ -15,7 +15,6 @@ import { useTranslation } from 'react-i18next';
 import useZoomStore, { zoomPresets } from '../../stores/zoomStore';
 import useEdgeTypeStore from '../../stores/edgeTypeStore';
 
-
 interface ZoomControlsProps {
   theme: string;
   onToggleCollapse: () => void;
@@ -24,7 +23,6 @@ interface ZoomControlsProps {
   onCollapseAll: () => void;
 }
 
-
 export const ZoomControls = memo<ZoomControlsProps>(
   ({ theme, onToggleCollapse, isCollapsed, onExpandAll, onCollapseAll }) => {
     const { t } = useTranslation();
@@ -32,16 +30,13 @@ export const ZoomControls = memo<ZoomControlsProps>(
     const [zoomLevel, setZoomLevel] = useState<number>(120);
     const [presetMenuAnchor, setPresetMenuAnchor] = useState<null | HTMLElement>(null);
 
-
     const { setZoom } = useZoomStore();
     const { edgeType, setEdgeType } = useEdgeTypeStore();
-
 
     const snapToStep = useCallback((zoom: number) => {
       const step = 10;
       return Math.round(zoom / step) * step;
     }, []);
-
 
     useEffect(() => {
       const updateZoomLevel = () => {
@@ -51,16 +46,12 @@ export const ZoomControls = memo<ZoomControlsProps>(
         setZoom(getZoom());
       };
 
-
       updateZoomLevel();
-
 
       const interval = setInterval(updateZoomLevel, 100);
 
-
       return () => clearInterval(interval);
     }, [getZoom, snapToStep, setViewport, setZoom]);
-
 
     const animateZoom = useCallback(
       (targetZoom: number, duration: number = 200) => {
@@ -68,19 +59,16 @@ export const ZoomControls = memo<ZoomControlsProps>(
         const currentViewport = getViewport();
         const startTime = performance.now();
 
-
         const step = (currentTime: number) => {
           const elapsed = currentTime - startTime;
           const progress = Math.min(elapsed / duration, 1);
           const newZoom = startZoom + (targetZoom - startZoom) * progress;
-
 
           setViewport({
             zoom: newZoom,
             x: currentViewport.x,
             y: currentViewport.y,
           });
-
 
           if (progress < 1) {
             requestAnimationFrame(step);
@@ -90,12 +78,10 @@ export const ZoomControls = memo<ZoomControlsProps>(
           }
         };
 
-
         requestAnimationFrame(step);
       },
       [getZoom, getViewport, setViewport, snapToStep, setZoom]
     );
-
 
     const handleZoomIn = useCallback(() => {
       const currentZoom = getZoom();
@@ -103,12 +89,10 @@ export const ZoomControls = memo<ZoomControlsProps>(
       const newZoomPercentage = Math.min(snapToStep(currentZoomPercentage + 10), 200);
       const newZoom = newZoomPercentage / 100;
 
-
       if (Math.abs(newZoom - currentZoom) > 0.01) {
         animateZoom(newZoom);
       }
     }, [animateZoom, getZoom, snapToStep]);
-
 
     const handleZoomOut = useCallback(() => {
       const currentZoom = getZoom();
@@ -116,12 +100,10 @@ export const ZoomControls = memo<ZoomControlsProps>(
       const newZoomPercentage = Math.max(snapToStep(currentZoomPercentage - 10), 10);
       const newZoom = newZoomPercentage / 100;
 
-
       if (Math.abs(newZoom - currentZoom) > 0.01) {
         animateZoom(newZoom);
       }
     }, [animateZoom, getZoom, snapToStep]);
-
 
     const handlePresetClick = useCallback(
       (preset: (typeof zoomPresets)[0]) => {
@@ -131,23 +113,19 @@ export const ZoomControls = memo<ZoomControlsProps>(
       [animateZoom]
     );
 
-
     const handlePresetMenuOpen = useCallback((event: React.MouseEvent<HTMLElement>) => {
       setPresetMenuAnchor(event.currentTarget);
     }, []);
 
-
     const handlePresetMenuClose = useCallback(() => {
       setPresetMenuAnchor(null);
     }, []);
-
 
     const handleResetZoom = useCallback(() => {
       setViewport({ ...getViewport(), zoom: 1 }, { duration: 200 });
       setZoomLevel(100);
       setZoom(1);
     }, [setViewport, getViewport, setZoom]);
-
 
     return (
       <Box
@@ -275,7 +253,6 @@ export const ZoomControls = memo<ZoomControlsProps>(
           {zoomLevel}%
         </Typography>
 
-
         <Menu
           anchorEl={presetMenuAnchor}
           open={Boolean(presetMenuAnchor)}
@@ -318,7 +295,7 @@ export const ZoomControls = memo<ZoomControlsProps>(
             size="small"
             color="primary"
             aria-label="Edge Type"
-            sx={{ 
+            sx={{
               ml: 2,
               '& .MuiToggleButton-root': {
                 color: theme === 'dark' ? '#fff' : '#6d7f8b',


### PR DESCRIPTION
Fixes #1668

## Problem
The edge style toggle buttons (Curvy/Square) in the zoom controls toolbar were displaying with black text on dark background in dark mode, making them unreadable while other controls properly showed white text.

## Solution
- Added proper theming to `ToggleButtonGroup` component
- Applied consistent color scheme to match other controls in the zoom toolbar
- Ensured proper contrast for both hover and selected states

## Changes
- Updated `ZoomControls.tsx` to include dark mode styling for toggle buttons
- Added theme-aware colors for normal, hover, and selected states

## Testing
- Verified buttons show white text in dark mode
- Confirmed no regression in light mode
- Tested hover and selected states work properly

## Screenshots
<img width="661" height="164" alt="Screenshot from 2025-07-28 17-21-48" src="https://github.com/user-attachments/assets/8aee0907-59b8-4e1f-924b-707e1b18e678" />
