### PR TITLE
fix(i18n): Correct language codes for Chinese translations

### DIFF
--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -23,8 +23,8 @@ const LanguageSwitcher = () => {
     { code: 'de', name: 'Deutsch' },
     { code: 'fr', name: 'Français' },
     { code: 'it', name: 'Italiano' },
-    { code: 'zh-Hans', name: '简体中文' },
-    { code: 'zh-Hant', name: '繁體中文' },
+    { code: 'SC', name: '简体中文' },
+    { code: 'TC', name: '繁體中文' },
     { code: 'pt', name: 'Português' },
   ];
 

--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -23,8 +23,8 @@ const LanguageSwitcher = () => {
     { code: 'de', name: 'Deutsch' },
     { code: 'fr', name: 'Français' },
     { code: 'it', name: 'Italiano' },
-    { code: 'SC', name: '简体中文' },
-    { code: 'TC', name: '繁體中文' },
+    { code: 'SC', name: '简体中文' }, // zh-Hans
+    { code: 'TC', name: '繁體中文' }, // zh-Hant
     { code: 'pt', name: 'Português' },
   ];
 


### PR DESCRIPTION
### Description

This PR fixes a bug where the bubble icon on the translation button was not displaying the correct language code for Simplified and Traditional Chinese.

### Related Issue

Fixes #1699

### Changes Made

- Updated the language codes for Simplified and Traditional Chinese in `frontend/src/components/LanguageSwitcher.tsx` from `zh-Hans` and `zh-Hant` to `SC` and `TC` respectively.

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

**Before:**
[
![Image](https://private-user-images.githubusercontent.com/407614/472980036-f35a6dcd-bc54-4a51-a3a6-5f3e476077a5.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTQwNTYyOTgsIm5iZiI6MTc1NDA1NTk5OCwicGF0aCI6Ii80MDc2MTQvNDcyOTgwMDM2LWYzNWE2ZGNkLWJjNTQtNGE1MS1hM2E2LTVmM2U0NzYwNzdhNS5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUwODAxJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MDgwMVQxMzQ2MzhaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1kYmE2MjkzZmI2ZGEyMDU5NzYwMzEzNzZjOTdjNGE1NGMyZWQ3NDJiODQ4YmNkMzM3ZGE5OGZjMmNkNzI2M2MzJlgtQW1zLVNpZ25lZEhlYWRlcnM9aG9zdCJ9.OrgUZTjy8Zahk0mN7ykUdfcjYCUztPO42gTre8JR7fU)](https://private-user-images.githubusercontent.com/407614/472980036-f35a6dcd-bc54-4a51-a3a6-5f3e476077a5.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTQwNTY0OTEsIm5iZiI6MTc1NDA1NjE5MSwicGF0aCI6Ii80MDc2MTQvNDcyOTgwMDM2LWYzNWE2ZGNkLWJjNTQtNGE1MS1hM2E2LTVmM2U0NzYwNzdhNS5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUwODAxJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MDgwMVQxMzQ5NTFaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1hOWVmYTVlOTEwYzQ1NjE4YWJiYmE2N2UyYjZlNGZlYzBkYzBhMGEyNzFlYWY5NGI3NjIxMWU5NTZkMzE5OGE2JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.GZA3ZVtWgCuxrNMwc9zLxijguMa31eAq8CcEUoa9PtI)

**After:**

<img width="152" height="78" alt="image" src="https://github.com/user-attachments/assets/87ffd41e-89cd-4406-a972-d655eb3f3b07" />

### Additional Notes

This change aligns the displayed language codes with the expected behavior, improving the user experience for Chinese-speaking users.
