### PR TITLE
fixed scroll using arrow keys

### DIFF
--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -420,10 +420,16 @@ const CommandPalette: React.FC = () => {
 
   // Scroll to ensure selected item is visible
   useEffect(() => {
-    if (commandListRef.current && filteredCommands.length > 0) {
-      const selectedElement = commandListRef.current.children[selectedIndex] as HTMLElement;
+    if (commandListRef.current && filteredCommands.length > 0 && selectedIndex >= 0) {
+      // Find all command buttons within the command list
+      const commandButtons = commandListRef.current.querySelectorAll('[data-command-index]');
+      const selectedElement = commandButtons[selectedIndex] as HTMLElement;
+
       if (selectedElement) {
-        selectedElement.scrollIntoView({ block: 'nearest' });
+        selectedElement.scrollIntoView({
+          block: 'nearest',
+          behavior: 'smooth',
+        });
       }
     }
   }, [selectedIndex, filteredCommands.length]);
@@ -839,6 +845,7 @@ const CommandListItem: React.FC<CommandListItemProps> = ({
         onClick={() => executeCommand(command)}
         onMouseEnter={() => setSelectedIndex(index)}
         whileHover={{ x: 2 }}
+        data-command-index={index}
       >
         <div
           className="flex h-8 min-w-8 items-center justify-center rounded-md"


### PR DESCRIPTION
### Description

This PR fixes the scroll issue in the command palette where arrow key navigation did not auto-scroll the selected item into view. Now, as users navigate using the arrow keys, the palette scrolls smoothly to ensure the selected item is always visible.


---

### Related Issue

Fixes #1713

---

### Changes Made

- [x] Added `data-command-index` attributes to command buttons for precise targeting
- [x] Replaced faulty scroll logic using `children[selectedIndex]` with `querySelectorAll('[data-command-index]')`
- [x] Implemented smooth scrolling using `scrollIntoView({ behavior: 'smooth', block: 'nearest' })`
- [x] Added safety checks to prevent errors when data is unavailable or indices are out of range

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).

---

### Screenshots or Logs (if applicable)

[Screencast from 02-08-25 09:58:33 PM IST.webm](https://github.com/user-attachments/assets/2d7074f5-f448-441d-8494-59ad094b8dc1)

---

### Additional Notes

This solution works reliably across both flat and grouped command modes, improving user experience with smooth and accurate navigation.
