### PR TITLE
Refactor backend health check API endpoint in useBackendHealthCheck hook

### DIFF
--- a/frontend/src/hooks/useBackendHealthCheck.ts
+++ b/frontend/src/hooks/useBackendHealthCheck.ts
@@ -16,7 +16,7 @@ const useBackendHealthCheck = () => {
         console.log('useBackendHealthCheck: Polling backend health...');
         try {
           // Make a lightweight request to the health endpoint
-          await api.get('/api/health');
+          await api.get('/health');
           console.log('useBackendHealthCheck: Backend health check succeeded.');
           // If successful, the Axios interceptor will handle clearing isNetworkError
           // No need to explicitly call setNetworkError(false) here


### PR DESCRIPTION
### Description

I have changed the api endpoint call from '/api/health' to '/health' from the useBackendHealthCheck.ts, which was causing error ,  as @btwshivam said me that we are not using api/health endpoint so , changed the frontend call and not updated the backend route

### Related Issue

Fixes #1620  #1704 

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
