### PR TITLE
Minor Bugs in Installation Page

### DIFF
--- a/frontend/src/pages/InstallationPage.tsx
+++ b/frontend/src/pages/InstallationPage.tsx
@@ -449,9 +449,7 @@ const PrerequisiteCard = ({
         <div className={`border-t p-4 pt-0 ${isDark ? 'border-slate-800/60' : 'border-gray-200'}`}>
           {prerequisite.status === PrereqStatus.Error && (
             <div className="mb-4">
-              <h4
-                className={`mb-2 mt-2 text-sm font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}
-              >
+              <h4 className={`mb-2 text-sm font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
                 {t('installationPage.errorSection.title')}
               </h4>
               {prerequisite.installCommand && (

--- a/frontend/src/pages/InstallationPage.tsx
+++ b/frontend/src/pages/InstallationPage.tsx
@@ -449,7 +449,9 @@ const PrerequisiteCard = ({
         <div className={`border-t p-4 pt-0 ${isDark ? 'border-slate-800/60' : 'border-gray-200'}`}>
           {prerequisite.status === PrereqStatus.Error && (
             <div className="mb-4">
-              <h4 className={`mb-2 text-sm font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              <h4
+                className={`mb-2 mt-2 text-sm font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}
+              >
                 {t('installationPage.errorSection.title')}
               </h4>
               {prerequisite.installCommand && (
@@ -498,7 +500,7 @@ const PrerequisiteCard = ({
 
           {prerequisite.status === PrereqStatus.Success && (
             <div
-              className={`flex items-start rounded-md border p-3 ${
+              className={`mt-4 flex items-start rounded-md border p-3 ${
                 isDark
                   ? 'border-emerald-800/30 bg-emerald-950/20'
                   : 'border-emerald-200 bg-emerald-50'
@@ -1141,7 +1143,7 @@ const InstallationPage = () => {
                 href="https://kubestellar.io"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex transform items-center rounded-lg bg-gradient-to-r from-blue-600 to-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-lg transition-all hover:scale-105 hover:from-blue-500 hover:to-indigo-500 hover:shadow-indigo-500/25"
+                className="flex transform items-center rounded-lg bg-gradient-to-r from-blue-600 to-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-lg transition-all hover:scale-105 hover:from-blue-500 hover:to-indigo-500 hover:text-white hover:shadow-indigo-500/25"
               >
                 <Globe size={16} className="mr-1.5" />
                 {t('common.help')}
@@ -1616,7 +1618,7 @@ const InstallationPage = () => {
                             href="https://docs.kubestellar.io/release-0.27.2/direct/pre-reqs/"
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="inline-flex items-center rounded-md bg-blue-600 px-4 py-2 text-white transition-colors hover:bg-blue-500"
+                            className="inline-flex items-center rounded-md bg-blue-600 px-4 py-2 text-white transition-colors hover:bg-blue-500 hover:text-white"
                           >
                             <Book size={16} className="mr-2" />
                             {t('installationPage.installation.installPrerequisitesFirst.button')}


### PR DESCRIPTION
### Description


http://localhost:5173/install
after hovering the violet color is not visible with blue backgroud color

there should be margin top above "Installation Instructions" and "kubectl is correctly installed and meets the version requirements."


Fixes #1729

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated ...
- [x] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...


### Screenshots or Logs (if applicable)

### Current Behavior

after hovering the violet color is not visible with blue backgroud color

https://github.com/user-attachments/assets/9bc44fdc-57a2-4e10-adf4-963e53debb71

https://github.com/user-attachments/assets/defcd95d-f214-4d72-a37e-6897bd9c7b2c

there should be margin top above "Installation Instructions" and "kubectl is correctly installed and meets the version requirements."

![Image](https://github.com/user-attachments/assets/fb3e40da-40d8-4346-b79f-40b6eb50a23f)

![Image](https://github.com/user-attachments/assets/705c6321-b41c-4f1a-a991-01152c96b214)


### After changes

https://github.com/user-attachments/assets/cff447ec-bddf-4d6b-a929-a46f12e2ba64
https://github.com/user-attachments/assets/b226dbca-a716-454b-a38d-1e71b0eac91e
https://github.com/user-attachments/assets/1241329a-e40a-4d36-bbff-d69e5d05bcf5





