### PR TITLE
chore: Update PostgreSQL initialization path in docker-compose.yml to use migrations directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,7 @@ services:
       - '5400:5432'
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./postgres/init:/docker-entrypoint-initdb.d:ro
+      - ./backend/postgresql/migrations:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U authuser -d authdb"]
       interval: 10s


### PR DESCRIPTION


### Description

It fixes the bug in docker compose file , while building the postgres volumes where incorect therefore it wasn't initialising the users table 

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #1710 

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
