### PR TITLE
Update workload label to 'Resources' in English localization strings

### DIFF
--- a/frontend/src/locales/strings.en.json
+++ b/frontend/src/locales/strings.en.json
@@ -1110,7 +1110,7 @@
     "table": {
       "name": "Binding Policy Name",
       "clusters": "Clusters",
-      "workload": "Workload",
+      "workload": "Resources",
       "creationDate": "Creation Date",
       "status": "Status",
       "actions": "Actions",


### PR DESCRIPTION
### Description

Updated workload label to Resources

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #1740 

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<img width="1471" height="491" alt="image" src="https://github.com/user-attachments/assets/1513cee6-ca66-4aac-b85f-d5fac3d9f7a4" />

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
