### PR TITLE
removed the duplicate env variable

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,4 +5,3 @@ DATABASE_URL=postgres://authuser:authpass123@localhost:5400/authdb?sslmode=disab
 JWT_SECRET=your-super-secret-jwt-key-change-this-in-production
 PORT=4000
 GIN_MODE=debug
-CORS_ALLOWED_ORIGIN=http://localhost:5173


### PR DESCRIPTION
### Description

Removes the duplicate env variable `CORS_ALLOWED_ORIGIN=http://localhost:5173`

Fixes #1749 

### Changes Made

- [ ] Refactored `backend/.env.example`


