### PR TITLE
refactor: add length limit for the HTTP Request Body being printed out

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -234,6 +234,12 @@ func ZapMiddleware() gin.HandlerFunc {
 		responseSize := c.Writer.Size()
 		headers := c.Request.Header
 
+		// Truncate the request body length
+		maxBodyLen := 500
+		if len(requestBody) > maxBodyLen {
+			requestBody = requestBody[:maxBodyLen] + "...[truncated]"
+		}
+
 		// Log in structured JSON format
 		logger.Info("HTTP Request",
 			zap.String("method", c.Request.Method),


### PR DESCRIPTION
### Description

Limit the length of the HTTP request body being printed out by the logger.

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #1787

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Added request body's length limitation.

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)
<img width="1217" height="894" alt="Screenshot 2025-08-09 at 18 51 32" src="https://github.com/user-attachments/assets/b41ed4d5-3309-4d1e-a1a9-998b6e20730b" />

