### PR TITLE
Plugin Installation - Avoid The Unnecessary File During The Extraction

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -234,6 +234,12 @@ func ZapMiddleware() gin.HandlerFunc {
 		responseSize := c.Writer.Size()
 		headers := c.Request.Header
 
+		// Truncate the request body length
+		maxBodyLen := 500
+		if len(requestBody) > maxBodyLen {
+			requestBody = requestBody[:maxBodyLen] + "...[truncated]"
+		}
+
 		// Log in structured JSON format
 		logger.Info("HTTP Request",
 			zap.String("method", c.Request.Method),


### PR DESCRIPTION
### Description

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->
The unnecessary AppleDouble metadata file, which was created when archiving, caused the error when we upload the plugin.tar.gz file.

This PR resolves the issue by avoiding the file during the extraction process.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #1790

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated the Extraction function by avoiding unnecessary files.

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.
