### PR TITLE
Fix bug in TreeView (issue #1739): adjust z-index

### DIFF
--- a/frontend/src/components/TreeViewComponent.tsx
+++ b/frontend/src/components/TreeViewComponent.tsx
@@ -188,7 +188,7 @@ const TreeViewComponent = memo<TreeViewComponentProps>(props => {
         position: isFullscreen ? 'fixed' : 'relative',
         top: isFullscreen ? 0 : 'auto',
         left: isFullscreen ? 0 : 'auto',
-        zIndex: isFullscreen ? 9999 : 'auto',
+        zIndex: isFullscreen ? 1300 : 'auto',
         backgroundColor: isFullscreen ? (theme === 'dark' ? '#0f172a' : '#ffffff') : 'transparent',
       }}
     >


### PR DESCRIPTION
### Description

The TreeView Component does not works the same in fullscreen mode (inside workloads/manage)

### Related Issue

Label hover (hover styles or effects) does not trigger
Zoom control buttons are not clickable or responsive

Fixes #1739

### Changes Made

- [x] Fixed Label Hover
- [x] Zoom control button (click)
- In TreeViewComponent.tsx changed the z-index from 9999 to 1300 in line 191 . Only z-index below or 1300 solves the above problem .

### Screenshot

<img width="1920" height="1200" alt="Zoom Control" src="https://github.com/user-attachments/assets/2bf72c75-fba6-48a0-b762-6714fea87e88" />

<img width="1920" height="1200" alt="Label Hover" src="https://github.com/user-attachments/assets/7feff18c-3243-450c-bbcf-b2d1d046ce89" />