### PR TITLE
refactor: update marketplace's tags fetching result

### DIFF
--- a/backend/api/marketplace.go
+++ b/backend/api/marketplace.go
@@ -572,11 +572,6 @@ func GetMarketplacePluginCategoriesHandler(c *gin.Context) {
 		return
 	}
 	tags := marketplaceManager.GetAllPluginTags()
-	if tags == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "No marketplace plugins found"})
-		log.LogWarn("no marketplace plugins found", zap.String("tags", "nil"))
-		return
-	}
 	c.JSON(http.StatusOK, gin.H{
 		"message": "Marketplace plugin categories retrieved successfully",
 		"tags":    tags,

--- a/backend/marketplace/manager.go
+++ b/backend/marketplace/manager.go
@@ -199,7 +199,7 @@ func (m *MarketplaceManager) GetAllPluginTags() []string {
 			tagsMap[tag] = struct{}{}
 		}
 	}
-	var tags []string
+	tags := make([]string, 0, len(tagsMap))
 	for tag := range tagsMap {
 		tags = append(tags, tag)
 	}

--- a/backend/marketplace/storage.go
+++ b/backend/marketplace/storage.go
@@ -117,6 +117,10 @@ func ExtractTarGz(file io.Reader, dest string) error {
 
 		// clean and validate path
 		cleanedName := filepath.Clean(header.Name)
+		if cleanedName == "." {
+			continue // skip the current directory entry
+		}
+
 		targetPath := filepath.Join(dest, cleanedName)
 		if !strings.HasPrefix(targetPath, absDest+string(os.PathSeparator)) {
 			return fmt.Errorf("invalid tar entry: %s", header.Name)
@@ -139,7 +143,6 @@ func ExtractTarGz(file io.Reader, dest string) error {
 			// skip macOS metadata files
 			if strings.HasPrefix(filepath.Base(header.Name), "._") {
 				continue
-
 			}
 
 			f, err := os.Create(targetPath)


### PR DESCRIPTION
### Description

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->
I have updated the result of `GetMarketplacePluginCategoriesHandler()`, which previously returned a nil result in some cases and caused the error of no marketplace plugin found when open the Marketplace page.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #1836

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated `GetMarketplacePluginCategoriesHandler()` and `marketplace.GetAllPluginTags()` to avoid returning Nil value.

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.
