### PR TITLE
Switching installed_plugin_id to plugin_details_id (global identification of plugins)

### DIFF
--- a/backend/pkg/plugins/manager.go
+++ b/backend/pkg/plugins/manager.go
@@ -446,7 +446,6 @@ func (pm *PluginManager) RegisterPlugin(plugin *Plugin, userIDAuth int) {
 		return
 	}
 
-	pluginID := plugin.ID
 	if !exist {
 		// Get userID
 		author, err := models.GetUserByUsername(plugin.Manifest.Metadata.Author)
@@ -460,33 +459,20 @@ func (pm *PluginManager) RegisterPlugin(plugin *Plugin, userIDAuth int) {
 			return
 		}
 
-		pluginID, err = AddInstalledPluginToDB(pluginID, nil, author.ID, "manual", true, "active", "/plugins/"+plugin.Manifest.Metadata.Name+"-"+strconv.Itoa(pluginID), 0)
+		_, err = AddInstalledPluginToDB(plugin.ID, nil, author.ID, "manual", true, "active", "/plugins/"+plugin.Manifest.Metadata.Name+"-"+strconv.Itoa(plugin.ID), 0)
 		if err != nil {
 			log.LogError("Failed to add plugin to installed_plugins  table in database", zap.Error(err))
 		}
-		err = UpdateInstalledPluginInstalledPath(pluginID, "/plugins/"+plugin.Manifest.Metadata.Name+"-"+strconv.Itoa(pluginID))
+		err = UpdateInstalledPluginInstalledPath(plugin.ID, "/plugins/"+plugin.Manifest.Metadata.Name+"-"+strconv.Itoa(plugin.ID))
 		if err != nil {
 			log.LogError("Failed to update installed plugin installed path in database", zap.Error(err))
 		}
 	} else {
-		exists, err := CheckInstalledPluginWithID(pluginID)
-		if err != nil {
-			log.LogError("Failed to get plugin ID", zap.Error(err))
-			return
-		}
-
-		if !exists {
-			log.LogError("Plugin not found in installed_plugins table", zap.Int("pluginID", pluginID))
-			return
-		}
-
-		err = UpdatePluginStatusDB(pluginID, "active", userIDAuth)
+		err = UpdatePluginStatusDB(plugin.ID, "active", userIDAuth)
 		if err != nil {
 			log.LogError("Failed to update plugin status in database", zap.Error(err))
 		}
 	}
-
-	plugin.ID = pluginID
 
 	// Register the plugin in the manager
 	pm.mu.Lock()

--- a/backend/pkg/plugins/store.go
+++ b/backend/pkg/plugins/store.go
@@ -217,21 +217,18 @@ func CheckPluginWithInfo(pluginName, pluginVersion, pluginDescription string, us
 }
 
 func CheckInstalledPluginWithID(pluginID int) (bool, error) {
-	fmt.Println("pluginID->>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>", pluginID)
 	query := `
 		SELECT EXISTS (
 			SELECT 1 FROM installed_plugins
-			WHERE id=$1
-		) 
+			WHERE plugin_details_id=$1
+		)
 	`
 
 	var exist bool
 	row := database.DB.QueryRow(query, pluginID)
-	fmt.Println("row->>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>", row)
 	if err := row.Scan(&exist); err != nil {
 		return false, fmt.Errorf("failed to check plugin existence: %w", err)
 	}
-	fmt.Println("exist->>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>", exist)
 
 	return exist, nil
 }
@@ -285,7 +282,7 @@ func UpdateInstalledPluginInstalledPath(installedPluginID int, installedPath str
 	query := `
 		UPDATE installed_plugins
 		SET installed_path = $1
-		WHERE id = $2
+		WHERE plugin_details_id = $2
 	`
 
 	_, err := database.DB.Exec(query, installedPath, installedPluginID)
@@ -321,7 +318,7 @@ func UpdatePluginStatusDB(pluginID int, status string, userID int) error {
 	query := `
 		UPDATE installed_plugins
 		SET status = $1
-		WHERE id = $2 AND user_id = $3
+		WHERE plugin_details_id = $2 AND user_id = $3
 	`
 
 	_, err := database.DB.Exec(query, status, pluginID, userID)
@@ -335,7 +332,7 @@ func UpdatePluginStatusDB(pluginID int, status string, userID int) error {
 func GetPluginStatusDB(pluginID int) (string, error) {
 	query := `
 		SELECT status FROM installed_plugins
-		WHERE id = $1
+		WHERE plugin_details_id = $1
 	`
 
 	var status string
@@ -355,7 +352,7 @@ func GetPluginStatusDB(pluginID int) (string, error) {
 func UninstallPluginFromDB(pluginID int, userID int) error {
 	query := `
 		DELETE FROM installed_plugins
-		WHERE id = $1 AND user_id = $2
+		WHERE plugin_details_id = $1 AND user_id = $2
 	`
 
 	_, err := database.DB.Exec(query, pluginID, userID)


### PR DESCRIPTION
### Description

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->

In this PR, I changed the identification of the installed plugins from `installed_plugin_id` to `plugin_details_id`.

The change will help us to manage the plugins more easily with the use of a common plugin identification (`plugin_details_id`) across the project.

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] `api/plugins.go`: switched pluginID -> pluginDetailsID
- [x] `pkg/plugins/store.go`: updated the following functions to follow the `plugin_details_id` logic: CheckInstalledPluginWithID(), UpdateInstalledPluginInstalledPath(), UpdatePluginStatusDB(), GetPluginStatusDB(), and UninstallPluginFromDB(). The changes mainly were about adjusting the queries with the `plugin_details_id` column instead of the `installed_plugin_id` column.
- [x] `pkg/plugins/manager.go`: RegisterPlugin: turn back to pluginID (which is the `plugin_details_id`).

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.
