### PR TITLE
fix: alphabetically sort object type dropdown in resource explore

### DIFF
--- a/frontend/src/pages/ResourceFilterPage.tsx
+++ b/frontend/src/pages/ResourceFilterPage.tsx
@@ -257,7 +257,11 @@ const ResourceFilterPage: React.FC = () => {
           <Grid container spacing={2} alignItems="center">
             <Grid item xs={12} sm={6} md={4}>
               <Autocomplete
-                options={resourceKinds as ResourceKind[]}
+                options={
+                  resourceKinds
+                    ? [...resourceKinds].sort((a, b) => a.kind.localeCompare(b.kind))
+                    : []
+                }
                 getOptionLabel={option => option.kind}
                 value={selectedKind}
                 onChange={handleKindChange}


### PR DESCRIPTION
[Screencast From 2025-08-19 19-31-11.webm](https://github.com/user-attachments/assets/28bdf0be-5814-437d-9b59-62e227eaacfa)



Fixed #1831 