### PR TITLE
Implement download increment for every installed plugin from marketplace

### DIFF
--- a/backend/api/marketplace.go
+++ b/backend/api/marketplace.go
@@ -761,6 +761,37 @@ func InstallMarketplacePluginHandler(c *gin.Context) {
 		return
 	}
 
+	// increase download count in DB
+	err = pluginpkg.IncrementPluginDownloads(pluginID)
+
+	if err != nil {
+		log.LogError(
+			"error incrementing plugin downloads count",
+			zap.Int("plugin_id", pluginID),
+			zap.String("error", err.Error()),
+		)
+	} else {
+		log.LogInfo(
+			"successfully incremented plugin downloads count",
+			zap.Int("plugin_id", pluginID),
+		)
+
+		// increase in memory download count
+		err := marketplaceManager.IncrementDownloads(pluginID)
+		if err != nil {
+			log.LogError(
+				"error incrementing in-memory download count",
+				zap.Int("plugin_id", pluginID),
+				zap.String("error", err.Error()),
+			)
+		} else {
+			log.LogInfo(
+				"successfully incremented in-memory download count",
+				zap.Int("plugin_id", pluginID),
+			)
+		}
+	}
+
 	pluginManager := GetGlobalPluginManager()
 	if pluginManager == nil {
 		log.LogError("Plugin manager not available", zap.String("plugin", pluginKey))

--- a/backend/marketplace/manager.go
+++ b/backend/marketplace/manager.go
@@ -277,3 +277,18 @@ func (m *MarketplaceManager) SearchPlugins(keyword, sortBy, tag string) []*Marke
 
 	return results
 }
+
+func (m *MarketplaceManager) IncrementDownloads(pluginID int) error {
+
+	plugin, exists := m.plugins[pluginID]
+	if !exists {
+		return fmt.Errorf("plugin with ID %d not found", pluginID)
+	}
+
+	plugin.Downloads++
+	log.LogInfo("Increase download count for marketplace plugin",
+		zap.Int("plugin_id", pluginID),
+		zap.Int("downloads: ", plugin.Downloads))
+
+	return nil
+}

--- a/backend/pkg/plugins/store.go
+++ b/backend/pkg/plugins/store.go
@@ -545,6 +545,20 @@ func UpdateRating(pluginDetailsID int, ratingAvg float32, ratingCnt int) error {
 	return nil
 }
 
+func IncrementPluginDownloads(pluginDetailsID int) error {
+	query := `
+		UPDATE marketplace_plugins
+		SET downloads = downloads + 1
+		WHERE plugin_details_id = $1
+	`
+	_, err := database.DB.Exec(query, pluginDetailsID)
+	if err != nil {
+		return fmt.Errorf("failed to increment plugin downloads: %w", err)
+	}
+
+	return nil
+}
+
 ////////////////////////////////////////////////////////////////////////
 // FOR PLUGIN FEEDBACK TABLE QUERIES
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Description
This PR increase the download count for plugin marketplace after any plugin is installed from marketplace.

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #1894 


https://github.com/user-attachments/assets/788491f8-3e43-4d94-83c3-0ed1cd15eebd


