### PR TITLE
Fixed the overlapping of header with marketplace

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -256,8 +256,12 @@ const Header = ({ isLoading, toggleMobileMenu, isMobileMenuOpen = false }: Heade
               </motion.button>
             </motion.div>
 
-            <CommandPalette />
-            <LanguageSwitcher />
+            <div className="relative z-[6]">
+              <CommandPalette />
+            </div>
+            <div className="relative z-[6]">
+              <LanguageSwitcher />
+            </div>
 
             <div className="hidden xl:flex">
               <FullScreenToggle
@@ -268,7 +272,7 @@ const Header = ({ isLoading, toggleMobileMenu, isMobileMenuOpen = false }: Heade
               />
             </div>
 
-            <div className="relative flex items-center">
+            <div className="relative z-[6] flex items-center">
               <ProfileSection />
             </div>
           </>
@@ -331,8 +335,12 @@ const Header = ({ isLoading, toggleMobileMenu, isMobileMenuOpen = false }: Heade
               </motion.button>
             </motion.div>
 
-            <CommandPalette />
-            <LanguageSwitcher />
+            <div className="relative z-[6]">
+              <CommandPalette />
+            </div>
+            <div className="relative z-[6]">
+              <LanguageSwitcher />
+            </div>
 
             <div className="hidden xl:flex">
               <FullScreenToggle

--- a/frontend/src/pages/GalaxyMarketplace.tsx
+++ b/frontend/src/pages/GalaxyMarketplace.tsx
@@ -356,7 +356,7 @@ const GalaxyMarketplace: React.FC = () => {
 
       {/* Enhanced Header */}
       <motion.div
-        className="relative z-10 flex flex-col gap-4 p-6 pb-0"
+        className="z-1 relative flex flex-col gap-4 p-6 pb-0"
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.6 }}
@@ -588,7 +588,7 @@ const GalaxyMarketplace: React.FC = () => {
       </motion.div>
 
       {/* Enhanced Main content */}
-      <div className="flex-grow overflow-y-auto p-6 pt-4">
+      <div className="z-1 relative flex-grow overflow-y-auto p-6 pt-4">
         {loading ? (
           <motion.div
             className="flex h-full min-h-[400px] items-center justify-center"
@@ -748,7 +748,7 @@ const GalaxyMarketplace: React.FC = () => {
                     ))}
                   </div>
 
-                  <div className="relative z-10">
+                  <div className="z-1 relative">
                     <motion.div
                       className="mb-6 flex justify-center"
                       animate={{ rotate: [0, 10, -10, 0] }}


### PR DESCRIPTION
### Description

This PR fixes the issue where all header dropdowns (e.g., Account menu, Filters, etc.) were being rendered **behind the floating header icons** due to a z-index conflict.  

The dropdown menus now render correctly **above** the header icons and are fully visible and accessible.  

### Related Issue

Fixes #1896  

### Changes Made

- [x] Updated dropdown menu styles to use a higher `z-index`.  
- [x] Ensured dropdowns render above all header icons for consistent UX.  
- [ ] Added comments in the code for clarity on z-index usage.  

### Checklist

- [x] I have reviewed the project's contribution guidelines.  
- [ ] I have written unit tests for the changes (not applicable for styling fix).  
- [x] I have tested the changes locally and confirmed they work as expected.  
- [x] My code follows the project's coding standards.  

### Screenshots

**Before:**  

[Screencast from 22-08-25 12:14:13 AM IST.webm](https://github.com/user-attachments/assets/6cad1e2d-500e-4c46-bde8-67c047678b09)


**After:**  
Dropdown fully visible above header icons  

[Screencast from 22-08-25 12:10:16 AM IST.webm](https://github.com/user-attachments/assets/5f9f18f8-41f3-479e-a674-2b205a265954)

### Additional Notes

