### PR TITLE
fix: resolve marketplace heading overflow with navbar

### DIFF
--- a/frontend/src/components/marketplace/CategoryFilter.tsx
+++ b/frontend/src/components/marketplace/CategoryFilter.tsx
@@ -24,7 +24,7 @@ export const CategoryFilter: React.FC<CategoryFilterProps> = React.memo(
         </div>
 
         <div className="relative">
-          <div className="z-1 relative flex flex-wrap gap-2 overflow-x-auto p-2">
+          <div className="relative z-[1] flex flex-wrap gap-2 overflow-x-auto p-2">
             {categories.map(category => (
               <button
                 key={category.id}

--- a/frontend/src/pages/GalaxyMarketplace.tsx
+++ b/frontend/src/pages/GalaxyMarketplace.tsx
@@ -337,7 +337,7 @@ const GalaxyMarketplace: React.FC = () => {
       />
 
       {/* Static spaceship in background */}
-      <div className="z-1 pointer-events-none absolute bottom-[15%] right-[10%] opacity-40">
+      <div className="pointer-events-none absolute bottom-[15%] right-[10%] z-[1] opacity-40">
         <FaSpaceShuttle
           className="h-48 w-48 text-gray-400"
           style={{
@@ -350,16 +350,20 @@ const GalaxyMarketplace: React.FC = () => {
       </div>
 
       {/* Static decorative elements */}
-      <div className="z-1 pointer-events-none absolute right-10 top-20 opacity-50">
+      <div className="pointer-events-none absolute right-10 top-20 z-[1] opacity-50">
         <FaGlobeAsia className="h-12 w-12 text-purple-300" />
       </div>
 
       {/* Enhanced Header */}
+      {/* Header Section */}
       <motion.div
-        className="z-1 relative flex flex-col gap-4 p-6 pb-0"
+        className="sticky top-[72px] z-10 flex flex-col gap-4 bg-opacity-95 p-6 pb-0 backdrop-blur-md xl:top-[76px] 2xl:top-[88px]"
+        style={{
+          background: isDark ? 'rgba(15, 23, 42, 0.95)' : 'rgba(255, 255, 255, 0.95)',
+        }}
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.6 }}
+        transition={{ duration: 0.8 }}
       >
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-4">
@@ -588,7 +592,7 @@ const GalaxyMarketplace: React.FC = () => {
       </motion.div>
 
       {/* Enhanced Main content */}
-      <div className="z-1 relative flex-grow overflow-y-auto p-6 pt-4">
+      <div className="relative z-[1] flex-grow overflow-y-auto p-6 pt-4">
         {loading ? (
           <motion.div
             className="flex h-full min-h-[400px] items-center justify-center"
@@ -748,7 +752,7 @@ const GalaxyMarketplace: React.FC = () => {
                     ))}
                   </div>
 
-                  <div className="z-1 relative">
+                  <div className="relative z-[1]">
                     <motion.div
                       className="mb-6 flex justify-center"
                       animate={{ rotate: [0, 10, -10, 0] }}


### PR DESCRIPTION
### Description

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->

- Resolves the issue where the marketplace heading overflows with the navbar.
- Improves the UI and z-index handling for the marketplace header and category filter.
- Only changes GalaxyMarketplace.tsx and CategoryFilter.tsx.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #1877 

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

https://github.com/user-attachments/assets/70c3ec0b-72c5-40e3-a623-af728325b1f9


### Additional Notes

Marketplace heading no longer overflow with Navbar
