### PR TITLE
fixed docker compose up --build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,6 +15,7 @@ RUN git rev-parse HEAD | cut -c1-7 > commit_hash.txt 2>/dev/null || echo "unknow
 
 # Copy package files for caching
 COPY frontend/package.json frontend/package-lock.json ./
+RUN rm -rf node_modules package-lock.json || true
 RUN npm install --legacy-peer-deps
 
 # Accept build arguments


### PR DESCRIPTION
**Description:**

This PR fixes the frontend build failure caused by the Rollup optional dependency error on ARM64 (@rollup/rollup-linux-arm64-gnu). The `docker compose up --build` command was failing because npm install in the Dockerfile was not properly handling optional dependencies on ARM architectures.

**Changes:**

Removed node_modules and package-lock.json before npm install in the Dockerfile to force a clean install.

Fixes #1893 

Please ensure the following before submitting your PR:

- [X] I have reviewed the project's contribution guidelines.
- [X] I have written unit tests for the changes (if applicable).
- [X] I have updated the documentation (if applicable).
- [X] I have tested the changes locally and ensured they work as expected.
- [X] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<img width="749" height="109" alt="Screenshot 2025-08-22 at 2 40 06 PM" src="https://github.com/user-attachments/assets/fdca1973-69fc-440c-bf56-30bd542cbcde" />

