### PR TITLE
fix: reduce navbar margins in InstallationPage for consistency

### DIFF
--- a/frontend/src/pages/InstallationPage.tsx
+++ b/frontend/src/pages/InstallationPage.tsx
@@ -1185,7 +1185,7 @@ const InstallationPage = () => {
           isDark ? 'border-slate-800/50 bg-slate-900/90' : 'border-gray-200/50 bg-white/90'
         }`}
       >
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-7xl px-4">
           <div className="flex h-16 items-center justify-between">
             <div className="flex items-center">
               <div className="flex items-center transition-opacity hover:opacity-90">


### PR DESCRIPTION
### Description
The InstallationPage navbar had excessive left and right margins compared to other pages (like Dashboard), causing visual inconsistency across the application.

### Related Issue

Fixes #1718 

### Solution
- Removed responsive padding classes (`sm:px-6 lg:px-8`) from navbar container
- Applied consistent `px-4` padding across all screen sizes
- Maintains proper navbar alignment with screen edges

### Changes Made
- Modified navbar container in `InstallationPage.tsx` from `px-4 sm:px-6 lg:px-8` to `px-4`
- Ensures visual consistency with dashboard and other pages

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.


