### PR TITLE
Fix: Navbar width set to full in Installtion Page

### DIFF
--- a/frontend/src/pages/InstallationPage.tsx
+++ b/frontend/src/pages/InstallationPage.tsx
@@ -1065,7 +1065,7 @@ const InstallationPage = () => {
           isDark ? 'border-slate-800/50 bg-slate-900/90' : 'border-gray-200/50 bg-white/90'
         }`}
       >
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="mx-auto w-full px-4 sm:px-6 lg:px-8">
           <div className="flex h-16 items-center justify-between">
             <div className="flex items-center">
               <div className="flex items-center transition-opacity hover:opacity-90">


### PR DESCRIPTION
This PR fixes the **navbar margin issue** on the Installation Page.  
The navbar previously had unnecessary margins on the left and right, which caused inconsistency compared to the main dashboard page. 
My branch was up-to date with yours, moreover I only pushed the changed file so there wont be any issue of merge.

**Changes Made**
- Set navbar container `width:  full`
- Removed unnecessary left/right margins
- Ensured styling is consistent with the main dashboard

**Before:**  
Unnecessary margin on both sides  
<img width="1918" height="464" alt="before-nav" src="https://github.com/user-attachments/assets/d43b7b4a-eb40-4475-9e11-79a45a149db7" />



**After:**  
Fixed navbar, now spans full width  
<img width="1910" height="185" alt="after-nav" src="https://github.com/user-attachments/assets/2d0a0ca9-5d5e-4153-94ff-b0b5692e3d23" />  

**🔗 Related Issue**
Closes #1718
