### PR TITLE
Fixed navigation bar dialog's overlap in galaxy marketplace 

### DIFF
--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -547,7 +547,9 @@ const CommandPalette: React.FC = () => {
                   WebkitBackdropFilter: 'blur(8px)',
                   pointerEvents: 'auto',
                 }}
-              />, document.body)}
+              />,
+              document.body
+            )}
 
             {createPortal(
               <motion.div
@@ -575,178 +577,188 @@ const CommandPalette: React.FC = () => {
                         : '0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.05)',
                     }}
                   >
-                {/* Search input */}
-                <div
-                  className="shrink-0 border-b p-3"
-                  style={{
-                    borderColor: isDark ? 'rgba(75, 85, 99, 0.4)' : 'rgba(226, 232, 240, 0.8)',
-                    background: isDark ? 'rgba(31, 41, 55, 0.7)' : 'rgba(249, 250, 251, 0.7)',
-                  }}
-                >
-                  <div className="flex items-center gap-2">
-                    <FiSearch
-                      className="text-lg"
-                      style={{ color: themeStyles.colors.text.tertiary }}
-                    />
-                    <input
-                      ref={inputRef}
-                      type="text"
-                      value={searchQuery}
-                      onChange={e => {
-                        setSearchQuery(e.target.value);
-                        setSelectedIndex(0);
-                      }}
-                      onKeyDown={handleKeyDown}
-                      placeholder={t('commandPalette.searchPlaceholder')}
-                      className="w-full bg-transparent text-base focus:outline-none"
-                      style={{
-                        color: themeStyles.colors.text.primary,
-                      }}
-                      autoComplete="off"
-                    />
-                    <kbd
-                      className="hidden items-center rounded px-1.5 py-0.5 text-xs font-semibold sm:inline-flex"
-                      style={{
-                        background: isDark ? 'rgba(55, 65, 81, 0.5)' : 'rgba(229, 231, 235, 0.5)',
-                        color: themeStyles.colors.text.secondary,
-                      }}
-                    >
-                      {t('commandPalette.kbd.esc')}
-                    </kbd>
-                  </div>
-                </div>
-
-                {/* Command list - completely revised scrolling area */}
-                <div
-                  className="flex-1 overflow-y-auto overflow-x-hidden"
-                  style={{
-                    scrollbarWidth: 'thin',
-                    scrollbarColor: `${themeStyles.colors.brand.primary} transparent`,
-                    WebkitOverflowScrolling: 'touch',
-                    msOverflowStyle: 'auto',
-                  }}
-                  ref={commandListRef}
-                >
-                  {filteredCommands.length === 0 ? (
+                    {/* Search input */}
                     <div
-                      className="px-3 py-8 text-center"
-                      style={{ color: themeStyles.colors.text.tertiary }}
+                      className="shrink-0 border-b p-3"
+                      style={{
+                        borderColor: isDark ? 'rgba(75, 85, 99, 0.4)' : 'rgba(226, 232, 240, 0.8)',
+                        background: isDark ? 'rgba(31, 41, 55, 0.7)' : 'rgba(249, 250, 251, 0.7)',
+                      }}
                     >
-                      {t('commandPalette.noCommandsFound')}
+                      <div className="flex items-center gap-2">
+                        <FiSearch
+                          className="text-lg"
+                          style={{ color: themeStyles.colors.text.tertiary }}
+                        />
+                        <input
+                          ref={inputRef}
+                          type="text"
+                          value={searchQuery}
+                          onChange={e => {
+                            setSearchQuery(e.target.value);
+                            setSelectedIndex(0);
+                          }}
+                          onKeyDown={handleKeyDown}
+                          placeholder={t('commandPalette.searchPlaceholder')}
+                          className="w-full bg-transparent text-base focus:outline-none"
+                          style={{
+                            color: themeStyles.colors.text.primary,
+                          }}
+                          autoComplete="off"
+                        />
+                        <kbd
+                          className="hidden items-center rounded px-1.5 py-0.5 text-xs font-semibold sm:inline-flex"
+                          style={{
+                            background: isDark
+                              ? 'rgba(55, 65, 81, 0.5)'
+                              : 'rgba(229, 231, 235, 0.5)',
+                            color: themeStyles.colors.text.secondary,
+                          }}
+                        >
+                          {t('commandPalette.kbd.esc')}
+                        </kbd>
+                      </div>
                     </div>
-                  ) : (
-                    <div className="py-1">
-                      {searchQuery ? (
-                        // Show flat list when searching
-                        <div>
-                          {filteredCommands.map((command, index) => (
-                            <CommandListItem
-                              key={command.id}
-                              command={command}
-                              index={index}
-                              selectedIndex={selectedIndex}
-                              executeCommand={executeCommand}
-                              setSelectedIndex={setSelectedIndex}
-                              isDark={isDark}
-                              themeStyles={themeStyles}
-                              compact
-                            />
-                          ))}
+
+                    {/* Command list - completely revised scrolling area */}
+                    <div
+                      className="flex-1 overflow-y-auto overflow-x-hidden"
+                      style={{
+                        scrollbarWidth: 'thin',
+                        scrollbarColor: `${themeStyles.colors.brand.primary} transparent`,
+                        WebkitOverflowScrolling: 'touch',
+                        msOverflowStyle: 'auto',
+                      }}
+                      ref={commandListRef}
+                    >
+                      {filteredCommands.length === 0 ? (
+                        <div
+                          className="px-3 py-8 text-center"
+                          style={{ color: themeStyles.colors.text.tertiary }}
+                        >
+                          {t('commandPalette.noCommandsFound')}
                         </div>
                       ) : (
-                        // Show grouped list when not searching
-                        <div>
-                          {groupedCommands.map(([section, items]: [string, CommandItem[]]) => (
-                            <div key={section} className="relative mb-2">
-                              <div
-                                className="sticky top-0 z-10 px-3 py-1 text-xs font-semibold uppercase"
-                                style={{
-                                  color: themeStyles.colors.text.tertiary,
-                                  background: isDark
-                                    ? 'rgba(17, 24, 39, 0.95)'
-                                    : 'rgba(249, 250, 251, 0.95)',
-                                  backdropFilter: 'blur(8px)',
-                                }}
-                              >
-                                {section}
-                              </div>
-                              <div className="pb-1">
-                                {items.map((command: CommandItem) => {
-                                  const globalIdx = filteredCommands.findIndex(
-                                    c => c.id === command.id
-                                  );
-                                  return (
-                                    <CommandListItem
-                                      key={command.id}
-                                      command={command}
-                                      index={globalIdx}
-                                      selectedIndex={selectedIndex}
-                                      executeCommand={executeCommand}
-                                      setSelectedIndex={setSelectedIndex}
-                                      isDark={isDark}
-                                      themeStyles={themeStyles}
-                                      compact
-                                    />
-                                  );
-                                })}
-                              </div>
+                        <div className="py-1">
+                          {searchQuery ? (
+                            // Show flat list when searching
+                            <div>
+                              {filteredCommands.map((command, index) => (
+                                <CommandListItem
+                                  key={command.id}
+                                  command={command}
+                                  index={index}
+                                  selectedIndex={selectedIndex}
+                                  executeCommand={executeCommand}
+                                  setSelectedIndex={setSelectedIndex}
+                                  isDark={isDark}
+                                  themeStyles={themeStyles}
+                                  compact
+                                />
+                              ))}
                             </div>
-                          ))}
+                          ) : (
+                            // Show grouped list when not searching
+                            <div>
+                              {groupedCommands.map(([section, items]: [string, CommandItem[]]) => (
+                                <div key={section} className="relative mb-2">
+                                  <div
+                                    className="sticky top-0 z-10 px-3 py-1 text-xs font-semibold uppercase"
+                                    style={{
+                                      color: themeStyles.colors.text.tertiary,
+                                      background: isDark
+                                        ? 'rgba(17, 24, 39, 0.95)'
+                                        : 'rgba(249, 250, 251, 0.95)',
+                                      backdropFilter: 'blur(8px)',
+                                    }}
+                                  >
+                                    {section}
+                                  </div>
+                                  <div className="pb-1">
+                                    {items.map((command: CommandItem) => {
+                                      const globalIdx = filteredCommands.findIndex(
+                                        c => c.id === command.id
+                                      );
+                                      return (
+                                        <CommandListItem
+                                          key={command.id}
+                                          command={command}
+                                          index={globalIdx}
+                                          selectedIndex={selectedIndex}
+                                          executeCommand={executeCommand}
+                                          setSelectedIndex={setSelectedIndex}
+                                          isDark={isDark}
+                                          themeStyles={themeStyles}
+                                          compact
+                                        />
+                                      );
+                                    })}
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          )}
                         </div>
                       )}
                     </div>
-                  )}
-                </div>
 
-                {/* Footer with hints - more compact */}
-                <div
-                  className="flex shrink-0 items-center justify-between border-t px-3 py-1.5 text-xs"
-                  style={{
-                    borderColor: isDark ? 'rgba(75, 85, 99, 0.4)' : 'rgba(226, 232, 240, 0.8)',
-                    color: themeStyles.colors.text.tertiary,
-                    background: isDark ? 'rgba(31, 41, 55, 0.7)' : 'rgba(249, 250, 251, 0.7)',
-                  }}
-                >
-                  <div className="flex items-center gap-3">
-                    <div className="flex items-center gap-1">
-                      <kbd
-                        className="inline-flex min-w-4 items-center justify-center rounded px-1 py-0.5 text-xs font-semibold"
-                        style={{
-                          background: isDark ? 'rgba(55, 65, 81, 0.5)' : 'rgba(229, 231, 235, 0.5)',
-                        }}
-                      >
-                        {t('commandPalette.kbd.arrows')}
-                      </kbd>
-                      <span className="ml-0.5">{t('commandPalette.footer.navigate')}</span>
-                    </div>
-
-                    <div className="flex items-center gap-1">
-                      <kbd
-                        className="inline-flex min-w-4 items-center justify-center rounded px-1 py-0.5 text-xs font-semibold"
-                        style={{
-                          background: isDark ? 'rgba(55, 65, 81, 0.5)' : 'rgba(229, 231, 235, 0.5)',
-                        }}
-                      >
-                        {t('commandPalette.kbd.enter')}
-                      </kbd>
-                      <span className="ml-0.5">{t('commandPalette.footer.select')}</span>
-                    </div>
-                  </div>
-
-                  <div className="hidden sm:block">
-                    <kbd
-                      className="mx-1 inline-flex min-w-4 items-center justify-center rounded px-1 py-0.5 text-xs font-semibold"
+                    {/* Footer with hints - more compact */}
+                    <div
+                      className="flex shrink-0 items-center justify-between border-t px-3 py-1.5 text-xs"
                       style={{
-                        background: isDark ? 'rgba(55, 65, 81, 0.5)' : 'rgba(229, 231, 235, 0.5)',
+                        borderColor: isDark ? 'rgba(75, 85, 99, 0.4)' : 'rgba(226, 232, 240, 0.8)',
+                        color: themeStyles.colors.text.tertiary,
+                        background: isDark ? 'rgba(31, 41, 55, 0.7)' : 'rgba(249, 250, 251, 0.7)',
                       }}
                     >
-                      {t('commandPalette.footer.shortcut')}
-                    </kbd>
+                      <div className="flex items-center gap-3">
+                        <div className="flex items-center gap-1">
+                          <kbd
+                            className="inline-flex min-w-4 items-center justify-center rounded px-1 py-0.5 text-xs font-semibold"
+                            style={{
+                              background: isDark
+                                ? 'rgba(55, 65, 81, 0.5)'
+                                : 'rgba(229, 231, 235, 0.5)',
+                            }}
+                          >
+                            {t('commandPalette.kbd.arrows')}
+                          </kbd>
+                          <span className="ml-0.5">{t('commandPalette.footer.navigate')}</span>
+                        </div>
+
+                        <div className="flex items-center gap-1">
+                          <kbd
+                            className="inline-flex min-w-4 items-center justify-center rounded px-1 py-0.5 text-xs font-semibold"
+                            style={{
+                              background: isDark
+                                ? 'rgba(55, 65, 81, 0.5)'
+                                : 'rgba(229, 231, 235, 0.5)',
+                            }}
+                          >
+                            {t('commandPalette.kbd.enter')}
+                          </kbd>
+                          <span className="ml-0.5">{t('commandPalette.footer.select')}</span>
+                        </div>
+                      </div>
+
+                      <div className="hidden sm:block">
+                        <kbd
+                          className="mx-1 inline-flex min-w-4 items-center justify-center rounded px-1 py-0.5 text-xs font-semibold"
+                          style={{
+                            background: isDark
+                              ? 'rgba(55, 65, 81, 0.5)'
+                              : 'rgba(229, 231, 235, 0.5)',
+                          }}
+                        >
+                          {t('commandPalette.footer.shortcut')}
+                        </kbd>
+                      </div>
+                    </div>
                   </div>
                 </div>
-                  </div>
-                </div>
-              </motion.div>, document.body)}
+              </motion.div>,
+              document.body
+            )}
           </>
         )}
       </AnimatePresence>

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence, Variants } from 'framer-motion';
 import useTheme from '../stores/themeStore';
@@ -532,50 +533,48 @@ const CommandPalette: React.FC = () => {
       <AnimatePresence>
         {isOpen && (
           <>
-            {/* Backdrop - subtle for header dropdown style */}
-            <motion.div
-              className="fixed inset-0 z-40"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              onClick={() => setIsOpen(false)}
-              style={{
-                backgroundColor: 'rgba(0, 0, 0, 0.45)',
-                backdropFilter: 'blur(6px)',
-                WebkitBackdropFilter: 'blur(6px)',
-                pointerEvents: 'auto',
-              }}
-            />
-
-            {/* Command palette dropdown */}
-            <motion.div
-              className="absolute right-4 z-50 mt-2 w-80 origin-top-right sm:w-96 md:right-8 md:w-[30rem]"
-              style={{
-                top: '100%',
-                filter: 'drop-shadow(0 10px 15px rgba(0, 0, 0, 0.15))',
-                transformOrigin: 'top right',
-              }}
-              initial={{ opacity: 0, y: -10, scale: 0.95 }}
-              animate={{ opacity: 1, y: 0, scale: 1 }}
-              exit={{ opacity: 0, y: -5, scale: 0.95 }}
-              transition={{
-                type: 'spring',
-                stiffness: 500,
-                damping: 30,
-                mass: 0.8,
-              }}
-            >
-              <div
-                className="flex max-h-[calc(100vh-120px)] flex-col rounded-lg border"
+            {createPortal(
+              <motion.div
+                className="fixed inset-0 z-[100]"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.2, delay: 0.08 }}
+                onClick={() => setIsOpen(false)}
                 style={{
-                  background: isDark ? 'rgba(17, 24, 39, 0.85)' : 'rgba(255, 255, 255, 0.9)',
+                  backgroundColor: 'rgba(0, 0, 0, 0.45)',
                   backdropFilter: 'blur(8px)',
-                  borderColor: isDark ? 'rgba(75, 85, 99, 0.4)' : 'rgba(226, 232, 240, 0.8)',
-                  boxShadow: isDark
-                    ? '0 10px 25px -5px rgba(0, 0, 0, 0.3), 0 8px 10px -6px rgba(0, 0, 0, 0.2)'
-                    : '0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.05)',
+                  WebkitBackdropFilter: 'blur(8px)',
+                  pointerEvents: 'auto',
+                }}
+              />, document.body)}
+
+            {createPortal(
+              <motion.div
+                className="fixed inset-0 z-[110] flex justify-center md:justify-end"
+                style={{ pointerEvents: 'none' }}
+                initial={{ opacity: 0, y: -10, scale: 0.95 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                exit={{ opacity: 0, y: -5, scale: 0.95 }}
+                transition={{
+                  type: 'spring',
+                  stiffness: 500,
+                  damping: 30,
+                  mass: 0.8,
                 }}
               >
+                <div className="pointer-events-auto mt-[96px] w-80 sm:w-96 md:mr-8 md:w-[30rem]">
+                  <div
+                    className="flex max-h-[calc(100vh-160px)] flex-col rounded-lg border"
+                    style={{
+                      background: isDark ? 'rgba(17, 24, 39, 0.85)' : 'rgba(255, 255, 255, 0.9)',
+                      backdropFilter: 'blur(8px)',
+                      borderColor: isDark ? 'rgba(75, 85, 99, 0.4)' : 'rgba(226, 232, 240, 0.8)',
+                      boxShadow: isDark
+                        ? '0 10px 25px -5px rgba(0, 0, 0, 0.3), 0 8px 10px -6px rgba(0, 0, 0, 0.2)'
+                        : '0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.05)',
+                    }}
+                  >
                 {/* Search input */}
                 <div
                   className="shrink-0 border-b p-3"
@@ -745,8 +744,9 @@ const CommandPalette: React.FC = () => {
                     </kbd>
                   </div>
                 </div>
-              </div>
-            </motion.div>
+                  </div>
+                </div>
+              </motion.div>, document.body)}
           </>
         )}
       </AnimatePresence>

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -485,10 +485,13 @@ const CommandPalette: React.FC = () => {
           style={{
             color: themeStyles.colors.text.primary,
             background: themeStyles.button.secondary.background,
-            boxShadow: themeStyles.colors.shadow.sm,
+            boxShadow: isOpen
+              ? `${themeStyles.colors.shadow.sm}, 0 0 0 3px ${themeStyles.colors.brand.primary}`
+              : themeStyles.colors.shadow.sm,
             overflow: 'hidden',
           }}
           aria-label={t('commandPalette.ariaLabel')}
+          aria-expanded={isOpen}
         >
           <motion.div
             className="absolute inset-0 rounded-full"
@@ -543,8 +546,6 @@ const CommandPalette: React.FC = () => {
                 onClick={() => setIsOpen(false)}
                 style={{
                   backgroundColor: 'rgba(0, 0, 0, 0.45)',
-                  backdropFilter: 'blur(8px)',
-                  WebkitBackdropFilter: 'blur(8px)',
                   pointerEvents: 'auto',
                 }}
               />,
@@ -569,8 +570,7 @@ const CommandPalette: React.FC = () => {
                   <div
                     className="flex max-h-[calc(100vh-160px)] flex-col rounded-lg border"
                     style={{
-                      background: isDark ? 'rgba(17, 24, 39, 0.85)' : 'rgba(255, 255, 255, 0.9)',
-                      backdropFilter: 'blur(8px)',
+                      background: isDark ? 'rgba(17, 24, 39, 1)' : 'rgba(255, 255, 255, 1)',
                       borderColor: isDark ? 'rgba(75, 85, 99, 0.4)' : 'rgba(226, 232, 240, 0.8)',
                       boxShadow: isDark
                         ? '0 10px 25px -5px rgba(0, 0, 0, 0.3), 0 8px 10px -6px rgba(0, 0, 0, 0.2)'
@@ -582,7 +582,7 @@ const CommandPalette: React.FC = () => {
                       className="shrink-0 border-b p-3"
                       style={{
                         borderColor: isDark ? 'rgba(75, 85, 99, 0.4)' : 'rgba(226, 232, 240, 0.8)',
-                        background: isDark ? 'rgba(31, 41, 55, 0.7)' : 'rgba(249, 250, 251, 0.7)',
+                        background: isDark ? 'rgba(31, 41, 55, 1)' : 'rgba(249, 250, 251, 1)',
                       }}
                     >
                       <div className="flex items-center gap-2">
@@ -667,9 +667,8 @@ const CommandPalette: React.FC = () => {
                                     style={{
                                       color: themeStyles.colors.text.tertiary,
                                       background: isDark
-                                        ? 'rgba(17, 24, 39, 0.95)'
-                                        : 'rgba(249, 250, 251, 0.95)',
-                                      backdropFilter: 'blur(8px)',
+                                        ? 'rgba(17, 24, 39, 1)'
+                                        : 'rgba(249, 250, 251, 1)',
                                     }}
                                   >
                                     {section}

--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -207,134 +207,140 @@ const LanguageSwitcher = () => {
                   WebkitBackdropFilter: 'blur(8px)',
                   pointerEvents: 'auto',
                 }}
-              />, document.body)}
+              />,
+              document.body
+            )}
 
             {/* Language dropdown rendered in portal so it sits above blur */}
             {createPortal(
-            <motion.div
-              className="fixed inset-0 z-[110] flex justify-end"
-              style={{ pointerEvents: 'none' }}
-              initial={{ opacity: 0, y: -10, scale: 0.98 }}
-              animate={{ opacity: 1, y: 0, scale: 1 }}
-              exit={{ opacity: 0, y: -5, scale: 0.98 }}
-              transition={{ type: 'spring', stiffness: 500, damping: 30, mass: 0.8 }}
-            >
-              <div className="pointer-events-auto pt-[96px] pr-4 sm:pr-6 md:pr-8">
-                <div
-                  className={
-                    isLoginPage
-                      ? 'w-40 overflow-hidden rounded-md border border-white/10 bg-gradient-to-b from-blue-900/90 to-purple-900/90 shadow-lg'
-                      : `w-48 overflow-hidden rounded-lg border shadow-xl ${
-                          isDark
-                            ? 'border-gray-700 bg-gray-800 text-gray-200'
-                            : 'border-gray-200 bg-white text-gray-800'
-                        }`
-                  }
-                  role="listbox"
-                >
-              {!isLoginPage && (
-                <div
-                  className={`flex items-center justify-between border-b px-3 py-2 ${
-                    isDark ? 'border-gray-700 text-gray-400' : 'border-gray-200 text-gray-500'
-                  }`}
-                >
-                  <p className="text-xs font-medium uppercase tracking-wider">
-                    {t('header.selectLanguage')}
-                  </p>
-                  <kbd
-                    className="hidden items-center rounded px-1.5 py-0.5 text-xs font-semibold sm:inline-flex"
-                    style={{
-                      background: isDark ? 'rgba(55, 65, 81, 0.5)' : 'rgba(229, 231, 235, 0.5)',
-                      color: isDark ? 'rgba(156, 163, 175, 1)' : 'rgba(107, 114, 128, 1)',
-                    }}
-                  >
-                    ESC
-                  </kbd>
-                </div>
-              )}
-              <div className="max-h-60 overflow-auto py-1">
-                {languages.map((lang, idx) => (
-                  <button
-                    key={lang.code}
-                    ref={el => (itemRefs.current[idx] = el)}
-                    tabIndex={0}
-                    onClick={() => changeLanguage(lang.code)}
+              <motion.div
+                className="fixed inset-0 z-[110] flex justify-end"
+                style={{ pointerEvents: 'none' }}
+                initial={{ opacity: 0, y: -10, scale: 0.98 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                exit={{ opacity: 0, y: -5, scale: 0.98 }}
+                transition={{ type: 'spring', stiffness: 500, damping: 30, mass: 0.8 }}
+              >
+                <div className="pointer-events-auto pr-4 pt-[96px] sm:pr-6 md:pr-8">
+                  <div
                     className={
                       isLoginPage
-                        ? `flex w-full items-center justify-between px-4 py-2 text-left text-sm transition-colors hover:bg-blue-700/30 ${
-                            i18n.language === lang.code
-                              ? 'bg-blue-600/40 text-blue-100'
-                              : 'bg-transparent text-blue-200 hover:bg-blue-700/30'
-                          }`
-                        : `flex w-full items-center justify-between px-4 py-2.5 text-left text-sm transition-colors ${
+                        ? 'w-40 overflow-hidden rounded-md border border-white/10 bg-gradient-to-b from-blue-900/90 to-purple-900/90 shadow-lg'
+                        : `w-48 overflow-hidden rounded-lg border shadow-xl ${
                             isDark
-                              ? i18n.language === lang.code
-                                ? 'bg-blue-900/60 text-blue-200'
-                                : 'bg-gray-800 text-gray-300 hover:bg-gray-700/80'
-                              : i18n.language === lang.code
-                                ? 'bg-indigo-50 font-medium text-indigo-700'
-                                : 'bg-white text-gray-800 hover:bg-gray-100'
+                              ? 'border-gray-700 bg-gray-800 text-gray-200'
+                              : 'border-gray-200 bg-white text-gray-800'
                           }`
                     }
-                    role="option"
-                    aria-selected={i18n.language === lang.code}
+                    role="listbox"
                   >
-                    <div className="flex items-center">
-                      <span
-                        className={`mr-2.5 text-sm font-medium uppercase ${
-                          isLoginPage
-                            ? ''
-                            : isDark
-                              ? 'text-gray-500'
-                              : i18n.language === lang.code
-                                ? 'text-indigo-600'
-                                : 'text-gray-400'
+                    {!isLoginPage && (
+                      <div
+                        className={`flex items-center justify-between border-b px-3 py-2 ${
+                          isDark ? 'border-gray-700 text-gray-400' : 'border-gray-200 text-gray-500'
                         }`}
                       >
-                        {lang.code.substring(0, 2)}
-                      </span>
-                      <span>{lang.name}</span>
-                    </div>
-                    {i18n.language === lang.code && (
-                      <motion.div
-                        initial={{ scale: 0 }}
-                        animate={{ scale: 1 }}
-                        className={`flex h-5 w-5 items-center justify-center rounded-full ${
-                          isLoginPage
-                            ? 'bg-blue-600/30'
-                            : isDark
-                              ? 'bg-indigo-800/50'
-                              : 'bg-indigo-100'
-                        }`}
-                      >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          width="12"
-                          height="12"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2.5"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
+                        <p className="text-xs font-medium uppercase tracking-wider">
+                          {t('header.selectLanguage')}
+                        </p>
+                        <kbd
+                          className="hidden items-center rounded px-1.5 py-0.5 text-xs font-semibold sm:inline-flex"
+                          style={{
+                            background: isDark
+                              ? 'rgba(55, 65, 81, 0.5)'
+                              : 'rgba(229, 231, 235, 0.5)',
+                            color: isDark ? 'rgba(156, 163, 175, 1)' : 'rgba(107, 114, 128, 1)',
+                          }}
+                        >
+                          ESC
+                        </kbd>
+                      </div>
+                    )}
+                    <div className="max-h-60 overflow-auto py-1">
+                      {languages.map((lang, idx) => (
+                        <button
+                          key={lang.code}
+                          ref={el => (itemRefs.current[idx] = el)}
+                          tabIndex={0}
+                          onClick={() => changeLanguage(lang.code)}
                           className={
                             isLoginPage
-                              ? 'text-blue-300'
-                              : isDark
-                                ? 'text-indigo-300'
-                                : 'text-indigo-600'
+                              ? `flex w-full items-center justify-between px-4 py-2 text-left text-sm transition-colors hover:bg-blue-700/30 ${
+                                  i18n.language === lang.code
+                                    ? 'bg-blue-600/40 text-blue-100'
+                                    : 'bg-transparent text-blue-200 hover:bg-blue-700/30'
+                                }`
+                              : `flex w-full items-center justify-between px-4 py-2.5 text-left text-sm transition-colors ${
+                                  isDark
+                                    ? i18n.language === lang.code
+                                      ? 'bg-blue-900/60 text-blue-200'
+                                      : 'bg-gray-800 text-gray-300 hover:bg-gray-700/80'
+                                    : i18n.language === lang.code
+                                      ? 'bg-indigo-50 font-medium text-indigo-700'
+                                      : 'bg-white text-gray-800 hover:bg-gray-100'
+                                }`
                           }
+                          role="option"
+                          aria-selected={i18n.language === lang.code}
                         >
-                          <polyline points="20 6 9 17 4 12"></polyline>
-                        </svg>
-                      </motion.div>
-                    )}
-                  </button>
-                ))}
-              </div>
+                          <div className="flex items-center">
+                            <span
+                              className={`mr-2.5 text-sm font-medium uppercase ${
+                                isLoginPage
+                                  ? ''
+                                  : isDark
+                                    ? 'text-gray-500'
+                                    : i18n.language === lang.code
+                                      ? 'text-indigo-600'
+                                      : 'text-gray-400'
+                              }`}
+                            >
+                              {lang.code.substring(0, 2)}
+                            </span>
+                            <span>{lang.name}</span>
+                          </div>
+                          {i18n.language === lang.code && (
+                            <motion.div
+                              initial={{ scale: 0 }}
+                              animate={{ scale: 1 }}
+                              className={`flex h-5 w-5 items-center justify-center rounded-full ${
+                                isLoginPage
+                                  ? 'bg-blue-600/30'
+                                  : isDark
+                                    ? 'bg-indigo-800/50'
+                                    : 'bg-indigo-100'
+                              }`}
+                            >
+                              <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                width="12"
+                                height="12"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="2.5"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                className={
+                                  isLoginPage
+                                    ? 'text-blue-300'
+                                    : isDark
+                                      ? 'text-indigo-300'
+                                      : 'text-indigo-600'
+                                }
+                              >
+                                <polyline points="20 6 9 17 4 12"></polyline>
+                              </svg>
+                            </motion.div>
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
                 </div>
-              </div>
-            </motion.div>, document.body)}
+              </motion.div>,
+              document.body
+            )}
           </>
         )}
       </AnimatePresence>

--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { useState, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { motion, AnimatePresence, Variants } from 'framer-motion';
 import useTheme from '../stores/themeStore';
 import { HiLanguage } from 'react-icons/hi2';
@@ -191,43 +192,46 @@ const LanguageSwitcher = () => {
       <AnimatePresence>
         {isOpen && (
           <>
-            {/* Backdrop - subtle for header dropdown style */}
-            <motion.div
-              className="fixed inset-0 z-40"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              onClick={() => setIsOpen(false)}
-              style={{
-                backgroundColor: 'rgba(0, 0, 0, 0.45)',
-                backdropFilter: 'blur(6px)',
-                WebkitBackdropFilter: 'blur(6px)',
-                pointerEvents: 'auto',
-              }}
-            />
+            {/* Backdrop - strong blur so page content blurs */}
+            {createPortal(
+              <motion.div
+                className="fixed inset-0 z-[100]"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.2, delay: 0.08 }}
+                onClick={() => setIsOpen(false)}
+                style={{
+                  backgroundColor: 'rgba(0, 0, 0, 0.45)',
+                  backdropFilter: 'blur(8px)',
+                  WebkitBackdropFilter: 'blur(8px)',
+                  pointerEvents: 'auto',
+                }}
+              />, document.body)}
 
-            {/* Language dropdown */}
+            {/* Language dropdown rendered in portal so it sits above blur */}
+            {createPortal(
             <motion.div
-              initial={{ opacity: 0, y: -10, scale: 0.95 }}
+              className="fixed inset-0 z-[110] flex justify-end"
+              style={{ pointerEvents: 'none' }}
+              initial={{ opacity: 0, y: -10, scale: 0.98 }}
               animate={{ opacity: 1, y: 0, scale: 1 }}
-              exit={{ opacity: 0, y: -5, scale: 0.95 }}
-              transition={{
-                type: 'spring',
-                stiffness: 500,
-                damping: 30,
-                mass: 0.8,
-              }}
-              className={
-                isLoginPage
-                  ? 'absolute right-0 z-50 mt-1 w-40 overflow-hidden rounded-md border border-white/10 bg-gradient-to-b from-blue-900/90 to-purple-900/90 shadow-lg'
-                  : `absolute right-0 z-50 mt-1 w-48 overflow-hidden rounded-lg border shadow-xl ${
-                      isDark
-                        ? 'border-gray-700 bg-gray-800 text-gray-200'
-                        : 'border-gray-200 bg-white text-gray-800'
-                    }`
-              }
-              role="listbox"
+              exit={{ opacity: 0, y: -5, scale: 0.98 }}
+              transition={{ type: 'spring', stiffness: 500, damping: 30, mass: 0.8 }}
             >
+              <div className="pointer-events-auto pt-[96px] pr-4 sm:pr-6 md:pr-8">
+                <div
+                  className={
+                    isLoginPage
+                      ? 'w-40 overflow-hidden rounded-md border border-white/10 bg-gradient-to-b from-blue-900/90 to-purple-900/90 shadow-lg'
+                      : `w-48 overflow-hidden rounded-lg border shadow-xl ${
+                          isDark
+                            ? 'border-gray-700 bg-gray-800 text-gray-200'
+                            : 'border-gray-200 bg-white text-gray-800'
+                        }`
+                  }
+                  role="listbox"
+                >
               {!isLoginPage && (
                 <div
                   className={`flex items-center justify-between border-b px-3 py-2 ${
@@ -328,7 +332,9 @@ const LanguageSwitcher = () => {
                   </button>
                 ))}
               </div>
-            </motion.div>
+                </div>
+              </div>
+            </motion.div>, document.body)}
           </>
         )}
       </AnimatePresence>

--- a/frontend/src/components/ProfileSection.tsx
+++ b/frontend/src/components/ProfileSection.tsx
@@ -562,232 +562,176 @@ const ProfileSection = () => {
         </button>
       </div>
 
-      {/* User dropdown menu */}
+      {/* User dropdown menu and backdrop */}
       {showUserMenu && (
-        <div
-          ref={userMenuRef}
-          className="animate-in fade-in slide-in-from-top-5 \ absolute right-0 top-full z-50 mt-2
-            w-64 origin-top-right overflow-hidden rounded-xl duration-300 ease-out"
-          style={{
-            backgroundColor: styles.profileMenu.backgroundColor,
-            borderWidth: '1px',
-            borderStyle: 'solid',
-            borderColor: styles.profileMenu.borderColor,
-            boxShadow: styles.profileMenu.boxShadow,
-          }}
-          role="menu"
-          aria-orientation="vertical"
-          tabIndex={-1}
-        >
-          {/* User Info Section */}
-          <div
-            style={{
-              backgroundColor: styles.profileHeader.backgroundColor,
-              borderBottomWidth: '1px',
-              borderBottomStyle: 'solid',
-              borderBottomColor: styles.profileHeader.borderBottomColor,
-              background: styles.profileHeader.background,
-            }}
-            className="p-5"
-          >
-            <div className="flex items-center justify-center">
-              <div className="text-center">
-                <div
-                  className="mx-auto mb-3 flex h-16 w-16 items-center justify-center rounded-full shadow-inner"
-                  style={{
-                    backgroundColor: 'rgba(59, 130, 246, 0.1)',
-                    borderWidth: '2px',
-                    borderStyle: 'solid',
-                    borderColor: isDark ? 'rgba(59, 130, 246, 0.3)' : 'rgba(59, 130, 246, 0.2)',
-                  }}
-                >
-                  <ProfileIcon
-                    className="text-4xl"
-                    style={{ color: '#3b82f6' }} // Primary blue color
-                  />
-                </div>
-                <div
-                  className="text-xs font-medium uppercase tracking-wider"
-                  style={{
-                    color: isDark ? '#9ca3af' : '#6b7280',
-                  }}
-                >
-                  {t('profileSection.account')}
-                </div>
-                <div
-                  className="mt-1 text-lg font-semibold"
-                  style={{
-                    color: isDark ? '#f9fafb' : '#1f2937',
-                  }}
-                >
-                  {username || 'Admin'}
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Menu Items */}
-          <div className="p-2" style={{ backgroundColor: styles.menuSection.backgroundColor }}>
-            <div className="grid grid-cols-1 gap-1">
-              <button
-                onClick={() => setShowChangePasswordModal(true)}
-                className="py-3\ group flex w-full items-center rounded-lg px-4
-                  text-sm font-medium transition-colors duration-150"
-                style={{
-                  color: styles.helpButton.color,
-                  backgroundColor: styles.helpButton.backgroundColor,
-                }}
-                onMouseOver={e => {
-                  e.currentTarget.style.backgroundColor = isDark
-                    ? 'rgba(124, 58, 237, 0.1)'
-                    : '#f5f3ff';
-                }}
-                onMouseOut={e => {
-                  e.currentTarget.style.backgroundColor = isDark ? '#1f2937' : '#ffffff';
-                }}
-                role="menuitem"
-              >
-                <div className="flex w-full items-center gap-3">
-                  <div
-                    className="rounded-full p-2 transition-colors duration-200"
-                    style={{
-                      backgroundColor: isDark ? 'rgba(59, 130, 246, 0.1)' : '#e0e7ff',
-                    }}
-                  >
-                    <svg
-                      width="16"
-                      height="16"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      viewBox="0 0 24 24"
-                    >
-                      <path d="M12 17a2 2 0 1 0 0-4 2 2 0 0 0 0 4zm6-7V7a6 6 0 1 0-12 0v3m12 0H6m12 0v8a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2v-8" />
-                    </svg>
-                  </div>
-                  <span>{t('profileSection.changePassword')}</span>
-                </div>
-              </button>
-              <button
-                onClick={openRaiseIssue}
-                className="py-3\ group flex w-full items-center rounded-lg px-4
-                  text-sm font-medium transition-colors duration-150"
-                style={{
-                  color: styles.helpButton.color,
-                  backgroundColor: styles.helpButton.backgroundColor,
-                }}
-                onMouseOver={e => {
-                  e.currentTarget.style.backgroundColor = isDark
-                    ? 'rgba(124, 58, 237, 0.1)'
-                    : '#f5f3ff';
-                }}
-                onMouseOut={e => {
-                  e.currentTarget.style.backgroundColor = isDark ? '#1f2937' : '#ffffff';
-                }}
-                role="menuitem"
-              >
-                <div className="flex w-full items-center gap-3">
-                  <div
-                    className="rounded-full p-2 transition-colors duration-200"
-                    style={{
-                      backgroundColor: isDark ? 'rgba(124, 58, 237, 0.1)' : '#f5f3ff',
-                    }}
-                  >
-                    <FiExternalLink
-                      style={{
-                        color: isDark ? '#38bdf8' : '#2563eb',
-                      }}
-                      size={16}
-                    />
-                  </div>
-                  <span>{t('profileSection.raiseIssue')}</span>
-                </div>
-              </button>
-              <button
-                onClick={openDocs}
-                className="py-3\ group flex w-full items-center rounded-lg px-4
-                  text-sm font-medium transition-colors duration-150"
-                style={{
-                  color: styles.helpButton.color,
-                  backgroundColor: styles.helpButton.backgroundColor,
-                }}
-                onMouseOver={e => {
-                  e.currentTarget.style.backgroundColor = isDark
-                    ? 'rgba(124, 58, 237, 0.1)'
-                    : '#f5f3ff';
-                }}
-                onMouseOut={e => {
-                  e.currentTarget.style.backgroundColor = isDark ? '#1f2937' : '#ffffff';
-                }}
-                role="menuitem"
-              >
-                <div className="flex w-full items-center gap-3">
-                  <div
-                    className="rounded-full p-2 transition-colors duration-200"
-                    style={{
-                      backgroundColor: isDark ? 'rgba(124, 58, 237, 0.1)' : '#f5f3ff',
-                    }}
-                  >
-                    <FiHelpCircle
-                      style={{
-                        color: isDark ? '#a78bfa' : '#8b5cf6',
-                      }}
-                      size={16}
-                    />
-                  </div>
-                  <span>{t('profileSection.helpSupport')}</span>
-                </div>
-              </button>
-            </div>
-          </div>
-
-          {/* Sign Out Button */}
-          <div
-            className="border-t p-2"
-            style={{
-              backgroundColor: styles.menuSection.backgroundColor,
-              borderColor: isDark ? '#374151' : '#e5e7eb',
-            }}
-          >
-            <button
-              onClick={handleLogout}
-              className="py-3\ group flex w-full items-center rounded-lg px-4
-                text-sm font-medium transition-all duration-200"
+        <>
+          {/* Backdrop to blur background */}
+          {createPortal(
+            <div
+              className="fixed inset-0 z-[100]"
+              onClick={() => setShowUserMenu(false)}
               style={{
-                color: styles.logoutButton.color,
-                backgroundColor: styles.logoutButton.backgroundColor,
+                backgroundColor: 'rgba(0, 0, 0, 0.45)',
+                backdropFilter: 'blur(8px)',
+                WebkitBackdropFilter: 'blur(8px)',
+                transition: 'opacity 0.2s ease',
+                opacity: 1,
               }}
-              onMouseOver={e => {
-                e.currentTarget.style.backgroundColor = isDark
-                  ? 'rgba(239, 68, 68, 0.1)'
-                  : '#fee2e2';
-              }}
-              onMouseOut={e => {
-                e.currentTarget.style.backgroundColor = isDark ? '#1f2937' : '#ffffff';
-              }}
-              role="menuitem"
-            >
-              <div className="flex w-full items-center gap-3">
+            />, document.body)}
+          {createPortal(
+            <div className="fixed inset-0 z-[110] flex justify-end" style={{ pointerEvents: 'none' }}>
+              <div className="pointer-events-auto pt-[96px] pr-4 sm:pr-6 md:pr-8">
                 <div
-                  className="rounded-full p-2 transition-colors duration-200"
+                  ref={userMenuRef}
+                  className="animate-in fade-in slide-in-from-top-5 w-64 origin-top-right overflow-hidden rounded-xl duration-300 ease-out"
                   style={{
-                    backgroundColor: isDark ? 'rgba(239, 68, 68, 0.1)' : '#fee2e2',
+                    backgroundColor: styles.profileMenu.backgroundColor,
+                    borderWidth: '1px',
+                    borderStyle: 'solid',
+                    borderColor: styles.profileMenu.borderColor,
+                    boxShadow: styles.profileMenu.boxShadow,
                   }}
+                  role="menu"
+                  aria-orientation="vertical"
+                  tabIndex={-1}
                 >
-                  <FiLogOut
+                  {/* User Info Section */}
+                  <div
                     style={{
-                      color: isDark ? '#f87171' : '#ef4444',
+                      backgroundColor: styles.profileHeader.backgroundColor,
+                      borderBottomWidth: '1px',
+                      borderBottomStyle: 'solid',
+                      borderBottomColor: styles.profileHeader.borderBottomColor,
+                      background: styles.profileHeader.background,
                     }}
-                    size={16}
-                  />
+                    className="p-5"
+                  >
+                    <div className="flex items-center justify-center">
+                      <div className="text-center">
+                        <div
+                          className="mx-auto mb-3 flex h-16 w-16 items-center justify-center rounded-full shadow-inner"
+                          style={{
+                            backgroundColor: 'rgba(59, 130, 246, 0.1)',
+                            borderWidth: '2px',
+                            borderStyle: 'solid',
+                            borderColor: isDark ? 'rgba(59, 130, 246, 0.3)' : 'rgba(59, 130, 246, 0.2)',
+                          }}
+                        >
+                          <ProfileIcon
+                            className="text-4xl"
+                            style={{ color: '#3b82f6' }}
+                          />
+                        </div>
+                        <div
+                          className="text-xs font-medium uppercase tracking-wider"
+                          style={{ color: isDark ? '#9ca3af' : '#6b7280' }}
+                        >
+                          {t('profileSection.account')}
+                        </div>
+                        <div
+                          className="mt-1 text-lg font-semibold"
+                          style={{ color: isDark ? '#f9fafb' : '#1f2937' }}
+                        >
+                          {username || 'Admin'}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Menu Items */}
+                  <div className="p-2" style={{ backgroundColor: styles.menuSection.backgroundColor }}>
+                    <div className="grid grid-cols-1 gap-1">
+                      <button
+                        onClick={() => setShowChangePasswordModal(true)}
+                        className="py-3\ group flex w-full items-center rounded-lg px-4 text-sm font-medium transition-colors duration-150"
+                        style={{ color: styles.helpButton.color, backgroundColor: styles.helpButton.backgroundColor }}
+                        onMouseOver={e => {
+                          e.currentTarget.style.backgroundColor = isDark ? 'rgba(124, 58, 237, 0.1)' : '#f5f3ff';
+                        }}
+                        onMouseOut={e => {
+                          e.currentTarget.style.backgroundColor = isDark ? '#1f2937' : '#ffffff';
+                        }}
+                        role="menuitem"
+                      >
+                        <div className="flex w-full items-center gap-3">
+                          <div
+                            className="rounded-full p-2 transition-colors duration-200"
+                            style={{ backgroundColor: isDark ? 'rgba(59, 130, 246, 0.1)' : '#e0e7ff' }}
+                          >
+                            <svg width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                              <path d="M12 17a2 2 0 1 0 0-4 2 2 0 0 0 0 4zm6-7V7a6 6 0 1 0-12 0v3m12 0H6m12 0v8a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2v-8" />
+                            </svg>
+                          </div>
+                          <span>{t('profileSection.changePassword')}</span>
+                        </div>
+                      </button>
+                      <button
+                        onClick={openRaiseIssue}
+                        className="py-3\ group flex w-full items-center rounded-lg px-4 text-sm font-medium transition-colors duration-150"
+                        style={{ color: styles.helpButton.color, backgroundColor: styles.helpButton.backgroundColor }}
+                        onMouseOver={e => {
+                          e.currentTarget.style.backgroundColor = isDark ? 'rgba(124, 58, 237, 0.1)' : '#f5f3ff';
+                        }}
+                        onMouseOut={e => {
+                          e.currentTarget.style.backgroundColor = isDark ? '#1f2937' : '#ffffff';
+                        }}
+                        role="menuitem"
+                      >
+                        <div className="flex w-full items-center gap-3">
+                          <div className="rounded-full p-2 transition-colors duration-200" style={{ backgroundColor: isDark ? 'rgba(124, 58, 237, 0.1)' : '#f5f3ff' }}>
+                            <FiExternalLink style={{ color: isDark ? '#38bdf8' : '#2563eb' }} size={16} />
+                          </div>
+                          <span>{t('profileSection.raiseIssue')}</span>
+                        </div>
+                      </button>
+                      <button
+                        onClick={openDocs}
+                        className="py-3\ group flex w-full items-center rounded-lg px-4 text-sm font-medium transition-colors duration-150"
+                        style={{ color: styles.helpButton.color, backgroundColor: styles.helpButton.backgroundColor }}
+                        onMouseOver={e => {
+                          e.currentTarget.style.backgroundColor = isDark ? 'rgba(124, 58, 237, 0.1)' : '#f5f3ff';
+                        }}
+                        onMouseOut={e => {
+                          e.currentTarget.style.backgroundColor = isDark ? '#1f2937' : '#ffffff';
+                        }}
+                        role="menuitem"
+                      >
+                        <div className="flex w-full items-center gap-3">
+                          <div className="rounded-full p-2 transition-colors duration-200" style={{ backgroundColor: isDark ? 'rgba(124, 58, 237, 0.1)' : '#f5f3ff' }}>
+                            <FiHelpCircle style={{ color: isDark ? '#a78bfa' : '#8b5cf6' }} size={16} />
+                          </div>
+                          <span>{t('profileSection.helpSupport')}</span>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+
+                  {/* Sign Out Button */}
+                  <div className="border-t p-2" style={{ backgroundColor: styles.menuSection.backgroundColor, borderColor: isDark ? '#374151' : '#e5e7eb' }}>
+                    <button
+                      onClick={handleLogout}
+                      className="py-3\ group flex w-full items-center rounded-lg px-4 text-sm font-medium transition-all duration-200"
+                      style={{ color: styles.logoutButton.color, backgroundColor: styles.logoutButton.backgroundColor }}
+                      onMouseOver={e => {
+                        e.currentTarget.style.backgroundColor = isDark ? 'rgba(239, 68, 68, 0.1)' : '#fee2e2';
+                      }}
+                      onMouseOut={e => {
+                        e.currentTarget.style.backgroundColor = isDark ? '#1f2937' : '#ffffff';
+                      }}
+                      role="menuitem"
+                    >
+                      <div className="flex w-full items-center gap-3">
+                        <div className="rounded-full p-2 transition-colors duration-200" style={{ backgroundColor: isDark ? 'rgba(239, 68, 68, 0.1)' : '#fee2e2' }}>
+                          <FiLogOut style={{ color: isDark ? '#f87171' : '#ef4444' }} size={16} />
+                        </div>
+                        <span className="transition-transform duration-300 group-hover:translate-x-0.5">{t('profileSection.signOut')}</span>
+                      </div>
+                    </button>
+                  </div>
                 </div>
-                <span className="transition-transform duration-300 group-hover:translate-x-0.5">
-                  {t('profileSection.signOut')}
-                </span>
               </div>
-            </button>
-          </div>
-        </div>
+            </div>, document.body)}
+        </>
       )}
       {/* Change Password Modal */}
       {renderChangePasswordModal()}

--- a/frontend/src/components/ProfileSection.tsx
+++ b/frontend/src/components/ProfileSection.tsx
@@ -577,10 +577,15 @@ const ProfileSection = () => {
                 transition: 'opacity 0.2s ease',
                 opacity: 1,
               }}
-            />, document.body)}
+            />,
+            document.body
+          )}
           {createPortal(
-            <div className="fixed inset-0 z-[110] flex justify-end" style={{ pointerEvents: 'none' }}>
-              <div className="pointer-events-auto pt-[96px] pr-4 sm:pr-6 md:pr-8">
+            <div
+              className="fixed inset-0 z-[110] flex justify-end"
+              style={{ pointerEvents: 'none' }}
+            >
+              <div className="pointer-events-auto pr-4 pt-[96px] sm:pr-6 md:pr-8">
                 <div
                   ref={userMenuRef}
                   className="animate-in fade-in slide-in-from-top-5 w-64 origin-top-right overflow-hidden rounded-xl duration-300 ease-out"
@@ -614,13 +619,12 @@ const ProfileSection = () => {
                             backgroundColor: 'rgba(59, 130, 246, 0.1)',
                             borderWidth: '2px',
                             borderStyle: 'solid',
-                            borderColor: isDark ? 'rgba(59, 130, 246, 0.3)' : 'rgba(59, 130, 246, 0.2)',
+                            borderColor: isDark
+                              ? 'rgba(59, 130, 246, 0.3)'
+                              : 'rgba(59, 130, 246, 0.2)',
                           }}
                         >
-                          <ProfileIcon
-                            className="text-4xl"
-                            style={{ color: '#3b82f6' }}
-                          />
+                          <ProfileIcon className="text-4xl" style={{ color: '#3b82f6' }} />
                         </div>
                         <div
                           className="text-xs font-medium uppercase tracking-wider"
@@ -639,14 +643,22 @@ const ProfileSection = () => {
                   </div>
 
                   {/* Menu Items */}
-                  <div className="p-2" style={{ backgroundColor: styles.menuSection.backgroundColor }}>
+                  <div
+                    className="p-2"
+                    style={{ backgroundColor: styles.menuSection.backgroundColor }}
+                  >
                     <div className="grid grid-cols-1 gap-1">
                       <button
                         onClick={() => setShowChangePasswordModal(true)}
                         className="py-3\ group flex w-full items-center rounded-lg px-4 text-sm font-medium transition-colors duration-150"
-                        style={{ color: styles.helpButton.color, backgroundColor: styles.helpButton.backgroundColor }}
+                        style={{
+                          color: styles.helpButton.color,
+                          backgroundColor: styles.helpButton.backgroundColor,
+                        }}
                         onMouseOver={e => {
-                          e.currentTarget.style.backgroundColor = isDark ? 'rgba(124, 58, 237, 0.1)' : '#f5f3ff';
+                          e.currentTarget.style.backgroundColor = isDark
+                            ? 'rgba(124, 58, 237, 0.1)'
+                            : '#f5f3ff';
                         }}
                         onMouseOut={e => {
                           e.currentTarget.style.backgroundColor = isDark ? '#1f2937' : '#ffffff';
@@ -656,9 +668,18 @@ const ProfileSection = () => {
                         <div className="flex w-full items-center gap-3">
                           <div
                             className="rounded-full p-2 transition-colors duration-200"
-                            style={{ backgroundColor: isDark ? 'rgba(59, 130, 246, 0.1)' : '#e0e7ff' }}
+                            style={{
+                              backgroundColor: isDark ? 'rgba(59, 130, 246, 0.1)' : '#e0e7ff',
+                            }}
                           >
-                            <svg width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                            <svg
+                              width="16"
+                              height="16"
+                              fill="none"
+                              stroke="currentColor"
+                              strokeWidth="2"
+                              viewBox="0 0 24 24"
+                            >
                               <path d="M12 17a2 2 0 1 0 0-4 2 2 0 0 0 0 4zm6-7V7a6 6 0 1 0-12 0v3m12 0H6m12 0v8a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2v-8" />
                             </svg>
                           </div>
@@ -668,9 +689,14 @@ const ProfileSection = () => {
                       <button
                         onClick={openRaiseIssue}
                         className="py-3\ group flex w-full items-center rounded-lg px-4 text-sm font-medium transition-colors duration-150"
-                        style={{ color: styles.helpButton.color, backgroundColor: styles.helpButton.backgroundColor }}
+                        style={{
+                          color: styles.helpButton.color,
+                          backgroundColor: styles.helpButton.backgroundColor,
+                        }}
                         onMouseOver={e => {
-                          e.currentTarget.style.backgroundColor = isDark ? 'rgba(124, 58, 237, 0.1)' : '#f5f3ff';
+                          e.currentTarget.style.backgroundColor = isDark
+                            ? 'rgba(124, 58, 237, 0.1)'
+                            : '#f5f3ff';
                         }}
                         onMouseOut={e => {
                           e.currentTarget.style.backgroundColor = isDark ? '#1f2937' : '#ffffff';
@@ -678,8 +704,16 @@ const ProfileSection = () => {
                         role="menuitem"
                       >
                         <div className="flex w-full items-center gap-3">
-                          <div className="rounded-full p-2 transition-colors duration-200" style={{ backgroundColor: isDark ? 'rgba(124, 58, 237, 0.1)' : '#f5f3ff' }}>
-                            <FiExternalLink style={{ color: isDark ? '#38bdf8' : '#2563eb' }} size={16} />
+                          <div
+                            className="rounded-full p-2 transition-colors duration-200"
+                            style={{
+                              backgroundColor: isDark ? 'rgba(124, 58, 237, 0.1)' : '#f5f3ff',
+                            }}
+                          >
+                            <FiExternalLink
+                              style={{ color: isDark ? '#38bdf8' : '#2563eb' }}
+                              size={16}
+                            />
                           </div>
                           <span>{t('profileSection.raiseIssue')}</span>
                         </div>
@@ -687,9 +721,14 @@ const ProfileSection = () => {
                       <button
                         onClick={openDocs}
                         className="py-3\ group flex w-full items-center rounded-lg px-4 text-sm font-medium transition-colors duration-150"
-                        style={{ color: styles.helpButton.color, backgroundColor: styles.helpButton.backgroundColor }}
+                        style={{
+                          color: styles.helpButton.color,
+                          backgroundColor: styles.helpButton.backgroundColor,
+                        }}
                         onMouseOver={e => {
-                          e.currentTarget.style.backgroundColor = isDark ? 'rgba(124, 58, 237, 0.1)' : '#f5f3ff';
+                          e.currentTarget.style.backgroundColor = isDark
+                            ? 'rgba(124, 58, 237, 0.1)'
+                            : '#f5f3ff';
                         }}
                         onMouseOut={e => {
                           e.currentTarget.style.backgroundColor = isDark ? '#1f2937' : '#ffffff';
@@ -697,8 +736,16 @@ const ProfileSection = () => {
                         role="menuitem"
                       >
                         <div className="flex w-full items-center gap-3">
-                          <div className="rounded-full p-2 transition-colors duration-200" style={{ backgroundColor: isDark ? 'rgba(124, 58, 237, 0.1)' : '#f5f3ff' }}>
-                            <FiHelpCircle style={{ color: isDark ? '#a78bfa' : '#8b5cf6' }} size={16} />
+                          <div
+                            className="rounded-full p-2 transition-colors duration-200"
+                            style={{
+                              backgroundColor: isDark ? 'rgba(124, 58, 237, 0.1)' : '#f5f3ff',
+                            }}
+                          >
+                            <FiHelpCircle
+                              style={{ color: isDark ? '#a78bfa' : '#8b5cf6' }}
+                              size={16}
+                            />
                           </div>
                           <span>{t('profileSection.helpSupport')}</span>
                         </div>
@@ -707,13 +754,24 @@ const ProfileSection = () => {
                   </div>
 
                   {/* Sign Out Button */}
-                  <div className="border-t p-2" style={{ backgroundColor: styles.menuSection.backgroundColor, borderColor: isDark ? '#374151' : '#e5e7eb' }}>
+                  <div
+                    className="border-t p-2"
+                    style={{
+                      backgroundColor: styles.menuSection.backgroundColor,
+                      borderColor: isDark ? '#374151' : '#e5e7eb',
+                    }}
+                  >
                     <button
                       onClick={handleLogout}
                       className="py-3\ group flex w-full items-center rounded-lg px-4 text-sm font-medium transition-all duration-200"
-                      style={{ color: styles.logoutButton.color, backgroundColor: styles.logoutButton.backgroundColor }}
+                      style={{
+                        color: styles.logoutButton.color,
+                        backgroundColor: styles.logoutButton.backgroundColor,
+                      }}
                       onMouseOver={e => {
-                        e.currentTarget.style.backgroundColor = isDark ? 'rgba(239, 68, 68, 0.1)' : '#fee2e2';
+                        e.currentTarget.style.backgroundColor = isDark
+                          ? 'rgba(239, 68, 68, 0.1)'
+                          : '#fee2e2';
                       }}
                       onMouseOut={e => {
                         e.currentTarget.style.backgroundColor = isDark ? '#1f2937' : '#ffffff';
@@ -721,16 +779,23 @@ const ProfileSection = () => {
                       role="menuitem"
                     >
                       <div className="flex w-full items-center gap-3">
-                        <div className="rounded-full p-2 transition-colors duration-200" style={{ backgroundColor: isDark ? 'rgba(239, 68, 68, 0.1)' : '#fee2e2' }}>
+                        <div
+                          className="rounded-full p-2 transition-colors duration-200"
+                          style={{ backgroundColor: isDark ? 'rgba(239, 68, 68, 0.1)' : '#fee2e2' }}
+                        >
                           <FiLogOut style={{ color: isDark ? '#f87171' : '#ef4444' }} size={16} />
                         </div>
-                        <span className="transition-transform duration-300 group-hover:translate-x-0.5">{t('profileSection.signOut')}</span>
+                        <span className="transition-transform duration-300 group-hover:translate-x-0.5">
+                          {t('profileSection.signOut')}
+                        </span>
                       </div>
                     </button>
                   </div>
                 </div>
               </div>
-            </div>, document.body)}
+            </div>,
+            document.body
+          )}
         </>
       )}
       {/* Change Password Modal */}

--- a/frontend/src/components/ProfileSection.tsx
+++ b/frontend/src/components/ProfileSection.tsx
@@ -81,6 +81,7 @@ const ProfileSection = () => {
         !buttonRef.current.contains(event.target as Node)
       ) {
         setShowUserMenu(false);
+        setTimeout(() => buttonRef.current?.blur(), 0);
       }
     }
 
@@ -95,6 +96,13 @@ const ProfileSection = () => {
     const handleEsc = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         setShowUserMenu(false);
+        setShowChangePasswordModal(false);
+        setCurrentPassword('');
+        setNewPassword('');
+        setConfirmNewPassword('');
+        setFormError('');
+        setConfirmPasswordError('');
+        setTimeout(() => buttonRef.current?.blur(), 0);
       }
     };
 
@@ -103,6 +111,18 @@ const ProfileSection = () => {
       window.removeEventListener('keydown', handleEsc);
     };
   }, []);
+
+  // Lock body scroll when any portal overlay is open (menu or change-password modal)
+  useEffect(() => {
+    const anyOpen = showUserMenu || showChangePasswordModal;
+    if (anyOpen) {
+      const originalOverflow = document.body.style.overflow;
+      document.body.style.overflow = 'hidden';
+      return () => {
+        document.body.style.overflow = originalOverflow;
+      };
+    }
+  }, [showUserMenu, showChangePasswordModal]);
 
   const openDocs = () => {
     window.open('https://docs.kubestellar.io/latest/', '_blank', 'noopener,noreferrer');
@@ -569,11 +589,12 @@ const ProfileSection = () => {
           {createPortal(
             <div
               className="fixed inset-0 z-[100]"
-              onClick={() => setShowUserMenu(false)}
+              onClick={() => {
+                setShowUserMenu(false);
+                setTimeout(() => buttonRef.current?.blur(), 0);
+              }}
               style={{
                 backgroundColor: 'rgba(0, 0, 0, 0.45)',
-                backdropFilter: 'blur(8px)',
-                WebkitBackdropFilter: 'blur(8px)',
                 transition: 'opacity 0.2s ease',
                 opacity: 1,
               }}

--- a/frontend/src/components/marketplace/FeaturedPlugins.tsx
+++ b/frontend/src/components/marketplace/FeaturedPlugins.tsx
@@ -300,9 +300,9 @@ const FeaturedHeroCard = React.memo(
             </div>
 
             <div className="flex w-full flex-wrap justify-center gap-2">
-              {plugin.tags?.slice(0, 3).map(tag => (
-                <PluginTag key={tag} tag={tag} color={getTagColor(tag)} />
-              ))}
+              {plugin.tags
+                ?.slice(0, 3)
+                .map(tag => <PluginTag key={tag} tag={tag} color={getTagColor(tag)} />)}
             </div>
 
             <div className="mt-2 flex flex-col items-center gap-2">

--- a/frontend/src/components/marketplace/FeaturedPlugins.tsx
+++ b/frontend/src/components/marketplace/FeaturedPlugins.tsx
@@ -300,9 +300,9 @@ const FeaturedHeroCard = React.memo(
             </div>
 
             <div className="flex w-full flex-wrap justify-center gap-2">
-              {plugin.tags
-                ?.slice(0, 3)
-                .map(tag => <PluginTag key={tag} tag={tag} color={getTagColor(tag)} />)}
+              {plugin.tags?.slice(0, 3).map(tag => (
+                <PluginTag key={tag} tag={tag} color={getTagColor(tag)} />
+              ))}
             </div>
 
             <div className="mt-2 flex flex-col items-center gap-2">

--- a/frontend/src/components/marketplace/PluginDeleteModal.tsx
+++ b/frontend/src/components/marketplace/PluginDeleteModal.tsx
@@ -57,6 +57,26 @@ export const PluginDeleteModal: React.FC<PluginDeleteModalProps> = ({
     }
   }, [isOpen]);
 
+  // Close on Escape and lock body scroll while open
+  React.useEffect(() => {
+    if (!isOpen) return;
+
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && deleteStep !== 'deleting') {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = originalOverflow;
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, deleteStep, onClose]);
+
   const handleDelete = () => {
     if (!plugin || confirmText !== plugin.name) return;
 

--- a/frontend/src/components/marketplace/PluginUploadModal.tsx
+++ b/frontend/src/components/marketplace/PluginUploadModal.tsx
@@ -47,6 +47,26 @@ export const PluginUploadModal: React.FC<PluginUploadModalProps> = ({ isOpen, on
     }
   }, [isOpen]);
 
+  // Close on Escape and lock body scroll while open
+  React.useEffect(() => {
+    if (!isOpen) return;
+
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && uploadStep !== 'uploading') {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = originalOverflow;
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, uploadStep, onClose]);
+
   const handleFile = useCallback(
     (file: File) => {
       // Validate file inline to avoid dependency issues

--- a/frontend/src/pages/GalaxyMarketplace.tsx
+++ b/frontend/src/pages/GalaxyMarketplace.tsx
@@ -339,7 +339,7 @@ const GalaxyMarketplace: React.FC = () => {
       />
 
       {/* Static spaceship in background */}
-      <div className="pointer-events-none absolute bottom-[15%] right-[10%] z-[1] opacity-40">
+      <div className="pointer-events-none absolute bottom-[15%] right-[10%] z-[-1] opacity-40">
         <FaSpaceShuttle
           className="h-48 w-48 text-gray-400"
           style={{
@@ -352,14 +352,14 @@ const GalaxyMarketplace: React.FC = () => {
       </div>
 
       {/* Static decorative elements */}
-      <div className="pointer-events-none absolute right-10 top-20 z-[1] opacity-50">
+      <div className="pointer-events-none absolute right-10 top-20 z-[-1] opacity-50">
         <FaGlobeAsia className="h-12 w-12 text-purple-300" />
       </div>
 
       {/* Enhanced Header */}
       {/* Header Section */}
       <motion.div
-        className="sticky top-[72px] z-10 flex flex-col gap-4 bg-opacity-95 p-6 pb-0 backdrop-blur-md xl:top-[76px] 2xl:top-[88px]"
+        className="sticky top-[72px] z-30 flex flex-col gap-4 bg-opacity-95 p-6 pb-0 backdrop-blur-md xl:top-[76px] 2xl:top-[88px]"
         style={{
           background: isDark ? 'rgba(15, 23, 42, 0.95)' : 'rgba(255, 255, 255, 0.95)',
         }}
@@ -594,7 +594,7 @@ const GalaxyMarketplace: React.FC = () => {
       </motion.div>
 
       {/* Enhanced Main content */}
-      <div className="relative z-[1] flex-grow overflow-y-auto p-6 pt-4">
+      <div className="relative z-10 flex-grow overflow-y-auto p-6 pt-28 md:pt-28">
         {loading ? (
           <motion.div
             className="flex h-full min-h-[400px] items-center justify-center"


### PR DESCRIPTION
### Description
Improves overlay layering and interaction across key UI components by using portals, setting consistent z-index layers, adding blurred backdrops, and ensuring proper pointer events and timing so overlays appear above blurs without being obscured.

### Related Issue
Fixes #1974
Fixes #1970 

### Changes Made
1. `frontend/src/pages/GalaxyMarketplace.tsx`
   - Adjusted z-index of main content and background elements to prevent overlap and match the intended layering.

2. `frontend/src/components/marketplace/CategoryFilter.tsx`
   - Set a sensible z-index so the filter chips aren’t obscured by nearby elements.

3. `frontend/src/components/CommandPalette.tsx`
   - Added a full-screen backdrop via portal (`z-[100]`) with blur.
   - Rendered the palette dropdown in a portal above the backdrop (`z-[110]`).
   - Added a slight backdrop delay so the panel appears first, then the blur.

4. `frontend/src/components/LanguageSwitcher.tsx`
   - Added a full-screen blurred backdrop via portal (`z-[100]`).
   - Rendered the dropdown in a portal at the top-right (`z-[110]`) with pointer-events fix so it’s clickable and not covered by the backdrop.
   - Added a slight backdrop delay like the command palette.

5. `frontend/src/components/ProfileSection.tsx`
   - Added/kept a portal-based blurred backdrop (`z-[100]`) and ensured the menu sits above (`z-[110]`).

### Checklist
- [X] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [X] I have tested the changes locally and ensured they work as expected.
- [X] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)
### Screen recording — bug reproduction (before):

https://github.com/user-attachments/assets/42b02dd8-db85-4356-9de7-cccf042f42fe

---

<img width="1185" height="176" alt="Screenshot 2025-09-11 at 12 12 35 AM" src="https://github.com/user-attachments/assets/cf45e6d2-248c-4d7b-addd-547322b40acb" />




### Screen recording — fixed behavior (after): 

https://github.com/user-attachments/assets/b1ec852c-5528-4633-9c2d-0cf5dab646c8





### Additional Notes
- Portals target `document.body` to avoid clipping by parent containers and to resolve stacking context issues.
- Backdrops use blur with a small delay to reduce visual jank as panels animate in.
- Pointer events and fixed positioning ensure dropdowns/menus remain interactive above their backdrops.