### PR TITLE
Added localization for zoom controls and hide controls in multiple lanuages

### DIFF
--- a/frontend/src/locales/strings.en.json
+++ b/frontend/src/locales/strings.en.json
@@ -966,6 +966,10 @@
       "fullscreen": "Enter Fullscreen",
       "exitFullscreen": "Exit Fullscreen"
     },
+    "hideControls": {
+      "show": "Show Controls",
+      "hide": "Hide Controls"
+    },
     "contextMenu": {
       "details": "Details",
       "delete": "Delete",

--- a/frontend/src/locales/strings.es.json
+++ b/frontend/src/locales/strings.es.json
@@ -729,7 +729,13 @@
       "expandAll": "Expandir todos los nodos hijos de todos los nodos padre",
       "collapseAll": "Colapsar todos los nodos hijos de todos los nodos padre",
       "zoomIn": "Acercar",
-      "zoomOut": "Alejar"
+      "zoomOut": "Alejar",
+      "resetZoom": "Restablecer Zoom",
+      "edgeStyle": "Estilo de Borde",
+      "curvy": "Curvado",
+      "square": "Cuadrado",
+      "fullscreen": "Pantalla Completa",
+      "exitFullscreen": "Salir de Pantalla Completa"
     },
     "nodeLabel": {
       "labels": "Etiquetas:",
@@ -813,6 +819,23 @@
     },
     "fullscreen": {
       "toggle": "Alternar vista de pantalla completa"
+    },
+    "zoomControls": {
+      "groupByResource": "Agrupar por Recurso/Tipo",
+      "expandAll": "Expandir todos los nodos hijos de todos los nodos padre",
+      "collapseAll": "Colapsar todos los nodos hijos de todos los nodos padre",
+      "zoomIn": "Acercar",
+      "zoomOut": "Alejar",
+      "resetZoom": "Restablecer Zoom",
+      "edgeStyle": "Estilo de Borde",
+      "curvy": "Curvado",
+      "square": "Cuadrado",
+      "fullscreen": "Pantalla Completa",
+      "exitFullscreen": "Salir de Pantalla Completa"
+    },
+    "hideControls": {
+      "show": "Mostrar Controles",
+      "hide": "Ocultar Controles"
     },
     "contextMenu": {
       "details": "Detalles",

--- a/frontend/src/locales/strings.es.json
+++ b/frontend/src/locales/strings.es.json
@@ -820,6 +820,19 @@
     "fullscreen": {
       "toggle": "Alternar vista de pantalla completa"
     },
+    "zoomControls": {
+      "groupByResource": "Agrupar por Recurso/Tipo",
+      "expandAll": "Expandir todos los nodos hijos de todos los nodos padre",
+      "collapseAll": "Colapsar todos los nodos hijos de todos los nodos padre",
+      "zoomIn": "Acercar",
+      "zoomOut": "Alejar",
+      "resetZoom": "Restablecer Zoom",
+      "edgeStyle": "Estilo de Borde",
+      "curvy": "Curvado",
+      "square": "Cuadrado",
+      "fullscreen": "Pantalla Completa",
+      "exitFullscreen": "Salir de Pantalla Completa"
+    },
     "hideControls": {
       "show": "Mostrar Controles",
       "hide": "Ocultar Controles"

--- a/frontend/src/locales/strings.es.json
+++ b/frontend/src/locales/strings.es.json
@@ -820,19 +820,6 @@
     "fullscreen": {
       "toggle": "Alternar vista de pantalla completa"
     },
-    "zoomControls": {
-      "groupByResource": "Agrupar por Recurso/Tipo",
-      "expandAll": "Expandir todos los nodos hijos de todos los nodos padre",
-      "collapseAll": "Colapsar todos los nodos hijos de todos los nodos padre",
-      "zoomIn": "Acercar",
-      "zoomOut": "Alejar",
-      "resetZoom": "Restablecer Zoom",
-      "edgeStyle": "Estilo de Borde",
-      "curvy": "Curvado",
-      "square": "Cuadrado",
-      "fullscreen": "Pantalla Completa",
-      "exitFullscreen": "Salir de Pantalla Completa"
-    },
     "hideControls": {
       "show": "Mostrar Controles",
       "hide": "Ocultar Controles"

--- a/frontend/src/locales/strings.fr.json
+++ b/frontend/src/locales/strings.fr.json
@@ -730,7 +730,13 @@
       "expandAll": "Développer tous les nœuds enfants de tous les nœuds parents",
       "collapseAll": "Réduire tous les nœuds enfants de tous les nœuds parents",
       "zoomIn": "Agrandir",
-      "zoomOut": "Rétrécir"
+      "zoomOut": "Rétrécir",
+      "resetZoom": "Réinitialiser le Zoom",
+      "edgeStyle": "Style de Bordure",
+      "curvy": "Courbe",
+      "square": "Carré",
+      "fullscreen": "Plein Écran",
+      "exitFullscreen": "Quitter le Plein Écran"
     },
     "nodeLabel": {
       "labels": "Étiquettes :",
@@ -814,6 +820,23 @@
     },
     "fullscreen": {
       "toggle": "Basculer en mode plein écran"
+    },
+    "zoomControls": {
+      "groupByResource": "Grouper par ressource/type",
+      "expandAll": "Développer tous les nœuds enfants de tous les nœuds parents",
+      "collapseAll": "Réduire tous les nœuds enfants de tous les nœuds parents",
+      "zoomIn": "Agrandir",
+      "zoomOut": "Rétrécir",
+      "resetZoom": "Réinitialiser le Zoom",
+      "edgeStyle": "Style de Bordure",
+      "curvy": "Courbe",
+      "square": "Carré",
+      "fullscreen": "Plein Écran",
+      "exitFullscreen": "Quitter le Plein Écran"
+    },
+    "hideControls": {
+      "show": "Afficher les Contrôles",
+      "hide": "Masquer les Contrôles"
     },
     "contextMenu": {
       "details": "Détails",

--- a/frontend/src/locales/strings.hi.json
+++ b/frontend/src/locales/strings.hi.json
@@ -953,17 +953,6 @@
     "fullscreen": {
       "toggle": "पूर्ण स्क्रीन view टॉगल करें"
     },
-    "contextMenu": {
-      "details": "विवरण",
-      "delete": "हटाएं",
-      "edit": "संपादित करें",
-      "logs": "लॉग्स"
-    },
-    "deleteDialog": {
-      "title": "संसाधन हटाने की पुष्टि करें",
-      "message": "क्या आप वाकई \"{{name}}\" को हटाना चाहते हैं? यह क्रिया पूर्ववत नहीं की जा सकती।",
-      "confirm": "हाँ, हटाएं"
-    },
     "zoomControls": {
       "groupByResource": "Resource/Kind द्वारा समूहीकृत करें",
       "expandAll": "सभी parent nodes के सभी child nodes को विस्तृत करें",
@@ -976,6 +965,21 @@
       "square": "वर्गाकार",
       "fullscreen": "पूर्ण स्क्रीन में जाएं",
       "exitFullscreen": "पूर्ण स्क्रीन से बाहर निकलें"
+    },
+    "hideControls": {
+      "show": "नियंत्रण दिखाएं",
+      "hide": "नियंत्रण छुपाएं"
+    },
+    "contextMenu": {
+      "details": "विवरण",
+      "delete": "हटाएं",
+      "edit": "संपादित करें",
+      "logs": "लॉग्स"
+    },
+    "deleteDialog": {
+      "title": "संसाधन हटाने की पुष्टि करें",
+      "message": "क्या आप वाकई \"{{name}}\" को हटाना चाहते हैं? यह क्रिया पूर्ववत नहीं की जा सकती।",
+      "confirm": "हाँ, हटाएं"
     }
   },
   "quickConnect": {

--- a/frontend/src/locales/strings.it.json
+++ b/frontend/src/locales/strings.it.json
@@ -826,7 +826,13 @@
       "expandAll": "Espandi tutti i nodi figli",
       "collapseAll": "Comprimi tutti i nodi figli",
       "zoomIn": "Ingrandisci",
-      "zoomOut": "Rimpicciolisci"
+      "zoomOut": "Rimpicciolisci",
+      "resetZoom": "Reimposta Zoom",
+      "edgeStyle": "Stile Bordo",
+      "curvy": "Curvato",
+      "square": "Quadrato",
+      "fullscreen": "Schermo Intero",
+      "exitFullscreen": "Esci da Schermo Intero"
     },
     "nodeLabel": {
       "labels": "Etichette:",
@@ -916,6 +922,23 @@
     },
     "fullscreen": {
       "toggle": "Attiva/disattiva vista a schermo intero"
+    },
+    "zoomControls": {
+      "groupByResource": "Raggruppa per risorsa/tipo",
+      "expandAll": "Espandi tutti i nodi figli",
+      "collapseAll": "Comprimi tutti i nodi figli",
+      "zoomIn": "Ingrandisci",
+      "zoomOut": "Rimpicciolisci",
+      "resetZoom": "Reimposta Zoom",
+      "edgeStyle": "Stile Bordo",
+      "curvy": "Curvato",
+      "square": "Quadrato",
+      "fullscreen": "Schermo Intero",
+      "exitFullscreen": "Esci da Schermo Intero"
+    },
+    "hideControls": {
+      "show": "Mostra Controlli",
+      "hide": "Nascondi Controlli"
     },
     "contextMenu": {
       "details": "Dettagli",

--- a/frontend/src/locales/strings.ja.json
+++ b/frontend/src/locales/strings.ja.json
@@ -826,7 +826,13 @@
       "expandAll": "すべての親ノードの子ノードを展開",
       "collapseAll": "すべての親ノードの子ノードを折りたたむ",
       "zoomIn": "ズームイン",
-      "zoomOut": "ズームアウト"
+      "zoomOut": "ズームアウト",
+      "resetZoom": "ズームリセット",
+      "edgeStyle": "エッジスタイル",
+      "curvy": "曲線",
+      "square": "四角",
+      "fullscreen": "フルスクリーン",
+      "exitFullscreen": "フルスクリーン終了"
     },
     "nodeLabel": {
       "labels": "ラベル：",
@@ -910,6 +916,23 @@
     },
     "fullscreen": {
       "toggle": "全画面表示の切り替え"
+    },
+    "zoomControls": {
+      "groupByResource": "リソース／種類ごとにグループ化",
+      "expandAll": "すべての親ノードの子ノードを展開",
+      "collapseAll": "すべての親ノードの子ノードを折りたたむ",
+      "zoomIn": "ズームイン",
+      "zoomOut": "ズームアウト",
+      "resetZoom": "ズームリセット",
+      "edgeStyle": "エッジスタイル",
+      "curvy": "曲線",
+      "square": "四角",
+      "fullscreen": "フルスクリーン",
+      "exitFullscreen": "フルスクリーン終了"
+    },
+    "hideControls": {
+      "show": "コントロール表示",
+      "hide": "コントロール非表示"
     },
     "contextMenu": {
       "details": "詳細",

--- a/frontend/src/locales/strings.zh-Hans.json
+++ b/frontend/src/locales/strings.zh-Hans.json
@@ -897,7 +897,13 @@
       "expandAll": "展开所有父节点的子节点",
       "collapseAll": "折叠所有父节点的子节点",
       "zoomIn": "放大",
-      "zoomOut": "缩小"
+      "zoomOut": "缩小",
+      "resetZoom": "重置缩放",
+      "edgeStyle": "边样式",
+      "curvy": "曲线",
+      "square": "方形",
+      "fullscreen": "全屏",
+      "exitFullscreen": "退出全屏"
     },
     "nodeLabel": {
       "labels": "标签：",
@@ -981,6 +987,23 @@
     },
     "fullscreen": {
       "toggle": "切换全屏视图"
+    },
+    "zoomControls": {
+      "groupByResource": "按资源/类型分组",
+      "expandAll": "展开所有父节点的子节点",
+      "collapseAll": "折叠所有父节点的子节点",
+      "zoomIn": "放大",
+      "zoomOut": "缩小",
+      "resetZoom": "重置缩放",
+      "edgeStyle": "边样式",
+      "curvy": "曲线",
+      "square": "方形",
+      "fullscreen": "全屏",
+      "exitFullscreen": "退出全屏"
+    },
+    "hideControls": {
+      "show": "显示控制",
+      "hide": "隐藏控制"
     },
     "contextMenu": {
       "details": "详情",


### PR DESCRIPTION
### Description

Fixed translation issue in the Remote-Cluster Treeview interface where the toggle controls button was displaying raw translation keys (`treeView.hideControls.show`) instead of proper translated text.

### Related Issue

Fixes #1968 

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
