### PR TITLE
Add missing hideControls translation keys for toggle controls in Remote-Cluster Treeview

### DIFF
--- a/frontend/src/locales/strings.en.json
+++ b/frontend/src/locales/strings.en.json
@@ -851,6 +851,10 @@
       "fullscreen": "Enter Fullscreen",
       "exitFullscreen": "Exit Fullscreen"
     },
+    "hideControls": {
+      "hide": "Hide Controls",
+      "show": "Show Controls"
+    },
     "nodeLabel": {
       "labels": "Labels:",
       "noLabels": "No labels"
@@ -965,6 +969,10 @@
       "square": "Square",
       "fullscreen": "Enter Fullscreen",
       "exitFullscreen": "Exit Fullscreen"
+    },
+    "hideControls": {
+      "hide": "Hide Controls",
+      "show": "Show Controls"
     },
     "contextMenu": {
       "details": "Details",


### PR DESCRIPTION
### Description
Fixed missing translation keys for toggle controls in Remote-Cluster Treeview interface. The debug label showing 'wecsTopology.hideControls.show' was appearing instead of proper translated text due to missing localization entries.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #1968 

### Changes Made
- [ ] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

https://github.com/user-attachments/assets/96b3d834-d9be-410c-ab10-fcc4842cc175



### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
