### PR TITLE
fix: Update Redis chart version to fix CI image pull errors

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -19,8 +19,8 @@ redis:
   auth:
     enabled: false
   image:
-    repository: docker.io/bitnami/redis
-    tag: "8.0.8-debian-12-r0"
+    repository: docker.io/bitnamisecure/redis
+    tag: "latest"
 
 postgresql:
   enabled: true

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -18,7 +18,9 @@ redis:
   architecture: standalone
   auth:
     enabled: false
-  # Add more overrides as needed for the Bitnami subchart
+  image:
+    repository: docker.io/bitnami/redis
+    tag: "8.0.8-debian-12-r0"
 
 postgresql:
   enabled: true


### PR DESCRIPTION
## Summary

**Fix Redis CI Image Pull Failure**

**Problem**: Helm chart tests were failing across all PRs due to Redis image
 `docker.io/bitnami/redis:8.0.3-debian-12-r1 `not being found, causing`ImagePullBackOff` errors.

