### PR TITLE
[refactor]: command palette detection logic and associated styles

### DIFF
--- a/frontend/src/components/marketplace/FeaturedPlugins.tsx
+++ b/frontend/src/components/marketplace/FeaturedPlugins.tsx
@@ -300,9 +300,9 @@ const FeaturedHeroCard = React.memo(
             </div>
 
             <div className="flex w-full flex-wrap justify-center gap-2">
-              {plugin.tags?.slice(0, 3).map(tag => (
-                <PluginTag key={tag} tag={tag} color={getTagColor(tag)} />
-              ))}
+              {plugin.tags
+                ?.slice(0, 3)
+                .map(tag => <PluginTag key={tag} tag={tag} color={getTagColor(tag)} />)}
             </div>
 
             <div className="mt-2 flex flex-col items-center gap-2">

--- a/frontend/src/components/marketplace/FeaturedPlugins.tsx
+++ b/frontend/src/components/marketplace/FeaturedPlugins.tsx
@@ -300,9 +300,9 @@ const FeaturedHeroCard = React.memo(
             </div>
 
             <div className="flex w-full flex-wrap justify-center gap-2">
-              {plugin.tags
-                ?.slice(0, 3)
-                .map(tag => <PluginTag key={tag} tag={tag} color={getTagColor(tag)} />)}
+              {plugin.tags?.slice(0, 3).map(tag => (
+                <PluginTag key={tag} tag={tag} color={getTagColor(tag)} />
+              ))}
             </div>
 
             <div className="mt-2 flex flex-col items-center gap-2">

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -43,7 +43,6 @@ const ClusterDetailDialog = lazy(
 
 // Health indicator component
 const HealthIndicator = ({ value }: { value: number }) => {
-
   // Memoize the color calculation to avoid recalculating on every render
   const { color, bgGradient } = useMemo(() => {
     if (value >= 90) {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -43,26 +43,6 @@ const ClusterDetailDialog = lazy(
 
 // Health indicator component
 const HealthIndicator = ({ value }: { value: number }) => {
-  const [isCommandPaletteOpen, setIsCommandPaletteOpen] = useState(false);
-
-  // Check for command palette by detecting body overflow hidden
-  useEffect(() => {
-    const checkCommandPalette = () => {
-      setIsCommandPaletteOpen(document.body.style.overflow === 'hidden');
-    };
-
-    // Initial check
-    checkCommandPalette();
-
-    // Watch for body style changes
-    const observer = new MutationObserver(checkCommandPalette);
-    observer.observe(document.body, {
-      attributes: true,
-      attributeFilter: ['style'],
-    });
-
-    return () => observer.disconnect();
-  }, []);
 
   // Memoize the color calculation to avoid recalculating on every render
   const { color, bgGradient } = useMemo(() => {
@@ -97,10 +77,6 @@ const HealthIndicator = ({ value }: { value: number }) => {
   return (
     <div
       className={`inline-flex items-center rounded-full px-2 py-1 ${color} relative overflow-hidden shadow-sm transition-all duration-200`}
-      style={{
-        filter: isCommandPaletteOpen ? 'blur(5px)' : 'none',
-        pointerEvents: isCommandPaletteOpen ? 'none' : 'auto',
-      }}
     >
       {/* Pulse effect without animation loop */}
       <span


### PR DESCRIPTION
### Description

Fixed an issue where percentage values in the Resource Utilization dashboard section were getting blurred when the command palette was opened. The HealthIndicator component was incorrectly applying a blur filter when detecting that the command palette was active, making the CPU Usage, Memory Usage, and Pod Health percentages unreadable.


### Related Issue

Fixes #2029

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] **Fixed HealthIndicator component blur effect** - Removed the command palette detection logic that was causing percentage values to be blurred
- [x] **Removed unnecessary state management** - Eliminated `isCommandPaletteOpen` state and related `useEffect` hook that monitored `document.body.style.overflow`
- [x] **Cleaned up styling** - Removed `filter: blur(5px)` and `pointerEvents: none` styles that were applied when command palette was open
- [x] **Improved user experience** - Dashboard metrics now remain fully visible and readable when command palette is accessed


### Checklist

Please ensure the following before submitting your PR:

- [X] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [X] I have tested the changes locally and ensured they work as expected.
- [X] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)


https://github.com/user-attachments/assets/7525b413-e9b9-4284-99f5-29358cd47b0c



### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
