### PR TITLE
Internationalized all hardcoded strings from the Object Explorer components

### DIFF
--- a/frontend/src/components/ResourceCard.tsx
+++ b/frontend/src/components/ResourceCard.tsx
@@ -177,9 +177,9 @@ const ResourceCard = memo<ResourceCardProps>(
       const now = new Date();
       const diffInHours = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60));
 
-      if (diffInHours < 1) return 'Just now';
-      if (diffInHours < 24) return `${diffInHours}h ago`;
-      if (diffInHours < 168) return `${Math.floor(diffInHours / 24)}d ago`;
+      if (diffInHours < 1) return t('resources.time.justNow');
+      if (diffInHours < 24) return t('resources.time.hoursAgo', { count: diffInHours });
+      if (diffInHours < 168) return t('resources.time.daysAgo', { count: Math.floor(diffInHours / 24) });
       return date.toLocaleDateString();
     };
 

--- a/frontend/src/components/ResourceCard.tsx
+++ b/frontend/src/components/ResourceCard.tsx
@@ -179,7 +179,8 @@ const ResourceCard = memo<ResourceCardProps>(
 
       if (diffInHours < 1) return t('resources.time.justNow');
       if (diffInHours < 24) return t('resources.time.hoursAgo', { count: diffInHours });
-      if (diffInHours < 168) return t('resources.time.daysAgo', { count: Math.floor(diffInHours / 24) });
+      if (diffInHours < 168)
+        return t('resources.time.daysAgo', { count: Math.floor(diffInHours / 24) });
       return date.toLocaleDateString();
     };
 

--- a/frontend/src/components/ResourcePreview.tsx
+++ b/frontend/src/components/ResourcePreview.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Box, Typography, Chip, Divider, Paper, Tooltip } from '@mui/material';
+import { useTranslation } from 'react-i18next';
 import useTheme from '../stores/themeStore';
 import { darkTheme, lightTheme } from '../lib/theme-utils';
 import InfoIcon from '@mui/icons-material/Info';
@@ -30,6 +31,7 @@ function isRenderable(val: unknown): val is string | number {
 }
 
 const ResourcePreview: React.FC<ResourcePreviewProps> = ({ resource, children }) => {
+  const { t } = useTranslation();
   const theme = useTheme(state => state.theme);
   const isDark = theme === 'dark';
 
@@ -98,7 +100,7 @@ const ResourcePreview: React.FC<ResourcePreviewProps> = ({ resource, children })
             color: isDark ? darkTheme.text.primary : lightTheme.text.primary,
           }}
         >
-          Object Details
+          {t('resources.preview.objectDetails')}
         </Typography>
       </Box>
 
@@ -163,7 +165,7 @@ const ResourcePreview: React.FC<ResourcePreviewProps> = ({ resource, children })
                 color: isDark ? darkTheme.text.secondary : lightTheme.text.secondary,
               }}
             >
-              <strong>Namespace:</strong> {resource.metadata.namespace}
+              <strong>{t('resources.preview.namespace')}:</strong> {resource.metadata.namespace}
             </Typography>
           </Box>
         )}
@@ -182,7 +184,7 @@ const ResourcePreview: React.FC<ResourcePreviewProps> = ({ resource, children })
                 color: isDark ? darkTheme.text.secondary : lightTheme.text.secondary,
               }}
             >
-              <strong>Created:</strong>{' '}
+              <strong>{t('resources.preview.created')}:</strong>{' '}
               {new Date(resource.metadata.creationTimestamp).toLocaleDateString()}
             </Typography>
           </Box>
@@ -198,7 +200,7 @@ const ResourcePreview: React.FC<ResourcePreviewProps> = ({ resource, children })
               wordBreak: 'break-all',
             }}
           >
-            <strong>UID:</strong> {resource.metadata.uid}
+            <strong>{t('resources.preview.uid')}:</strong> {resource.metadata.uid}
           </Typography>
         )}
       </Box>
@@ -224,7 +226,7 @@ const ResourcePreview: React.FC<ResourcePreviewProps> = ({ resource, children })
                 mb: 1,
               }}
             >
-              Labels ({Object.keys(resource.labels).length})
+              {t('resources.preview.labels')} ({Object.keys(resource.labels).length})
             </Typography>
             <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
               {Object.entries(resource.labels)

--- a/frontend/src/locales/strings.en.json
+++ b/frontend/src/locales/strings.en.json
@@ -2765,6 +2765,44 @@
       "topResourceKinds": "Top Object Kinds",
       "topNamespaces": "Top Namespaces"
     },
+    "table": {
+      "name": "Name",
+      "kind": "Kind",
+      "namespace": "Namespace",
+      "status": "Status",
+      "age": "Age",
+      "createdAt": "Created",
+      "labels": "Labels",
+      "actions": "Actions"
+    },
+    "preview": {
+      "objectDetails": "Object Details",
+      "namespace": "Namespace",
+      "createdAt": "Created",
+      "uid": "UID",
+      "noLabels": "No labels",
+      "labels": "Labels"
+    },
+    "time": {
+      "justNow": "Just now",
+      "hoursAgo": "{{count}}h ago",
+      "daysAgo": "{{count}}d ago"
+    },
+    "loading": {
+      "resources": "Loading resources...",
+      "applying": "Applying filters...",
+      "refreshing": "Refreshing..."
+    },
+    "errors": {
+      "loadFailed": "Failed to load resources",
+      "filterFailed": "Failed to apply filters",
+      "actionFailed": "Action failed"
+    },
+    "notifications": {
+      "filtersApplied": "Filters applied successfully",
+      "resourcesRefreshed": "Resources refreshed successfully"
+    },
+    "subtitle": "Explore and manage Kubernetes resources",
     "status": {
       "healthy": "Healthy",
       "warning": "Warning",


### PR DESCRIPTION
###  Updated Components
ResourcePreview.tsx:

Added [useTranslation](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) import
Internationalized:
"Object Details" → [t('resources.preview.objectDetails')](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
"Namespace:" → [t('resources.preview.namespace')](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
"Created:" → [t('resources.preview.created')](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
"UID:" → [t('resources.preview.uid')](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
"Labels" → [t('resources.preview.labels')](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
ResourceCard.tsx:

### Internationalized time formatting:
"Just now" → [t('resources.time.justNow')](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
"Xh ago" → [t('resources.time.hoursAgo', { count: X })](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
"Xd ago" → [t('reso](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)