### PR TITLE
Internationalized empty state messages & Header

### DIFF
--- a/frontend/src/locales/strings.hi.json
+++ b/frontend/src/locales/strings.hi.json
@@ -2760,6 +2760,44 @@
       "topResourceKinds": "शीर्ष संसाधन प्रकार",
       "topNamespaces": "शीर्ष नेमस्पेस"
     },
+    "table": {
+      "name": "नाम",
+      "kind": "प्रकार",
+      "namespace": "नेमस्पेस",
+      "status": "स्थिति",
+      "age": "आयु",
+      "createdAt": "निर्मित",
+      "labels": "लेबल्स",
+      "actions": "कार्रवाइयां"
+    },
+    "preview": {
+      "objectDetails": "ऑब्जेक्ट विवरण",
+      "namespace": "नेमस्पेस",
+      "createdAt": "निर्मित",
+      "uid": "UID",
+      "noLabels": "कोई लेबल नहीं",
+      "labels": "लेबल्स"
+    },
+    "time": {
+      "justNow": "अभी",
+      "hoursAgo": "{{count}} घंटे पहले",
+      "daysAgo": "{{count}} दिन पहले"
+    },
+    "loading": {
+      "resources": "संसाधन लोड हो रहे हैं...",
+      "applying": "फ़िल्टर्स लागू कर रहे हैं...",
+      "refreshing": "रीफ्रेश कर रहे हैं..."
+    },
+    "errors": {
+      "loadFailed": "संसाधन लोड करने में विफल",
+      "filterFailed": "फ़िल्टर्स लागू करने में विफल",
+      "actionFailed": "कार्रवाई विफल"
+    },
+    "notifications": {
+      "filtersApplied": "फ़िल्टर्स सफलतापूर्वक लागू किए गए",
+      "resourcesRefreshed": "संसाधन सफलतापूर्वक रीफ्रेश किए गए"
+    },
+    "subtitle": "Kubernetes संसाधनों का अन्वेषण और प्रबंधन करें",
     "status": {
       "healthy": "स्वस्थ",
       "warning": "चेतावनी",

--- a/frontend/src/pages/ObjectFilterPage.tsx
+++ b/frontend/src/pages/ObjectFilterPage.tsx
@@ -1420,7 +1420,7 @@ const ObjectFilterPage: React.FC = () => {
                             fontWeight: 600,
                           }}
                         >
-                          Name
+                          {t('resources.table.name')}
                         </TableCell>
                         <TableCell
                           sx={{
@@ -1428,7 +1428,7 @@ const ObjectFilterPage: React.FC = () => {
                             fontWeight: 600,
                           }}
                         >
-                          Kind
+                          {t('resources.table.kind')}
                         </TableCell>
                         <TableCell
                           sx={{
@@ -1436,7 +1436,7 @@ const ObjectFilterPage: React.FC = () => {
                             fontWeight: 600,
                           }}
                         >
-                          Namespace
+                          {t('resources.table.namespace')}
                         </TableCell>
                         <TableCell
                           sx={{
@@ -1444,7 +1444,7 @@ const ObjectFilterPage: React.FC = () => {
                             fontWeight: 600,
                           }}
                         >
-                          Status
+                          {t('resources.table.status')}
                         </TableCell>
                         <TableCell
                           sx={{
@@ -1452,7 +1452,7 @@ const ObjectFilterPage: React.FC = () => {
                             fontWeight: 600,
                           }}
                         >
-                          Created
+                          {t('resources.table.created')}
                         </TableCell>
                         <TableCell
                           sx={{
@@ -1460,7 +1460,7 @@ const ObjectFilterPage: React.FC = () => {
                             fontWeight: 600,
                           }}
                         >
-                          Actions
+                          {t('resources.table.actions')}
                         </TableCell>
                       </TableRow>
                     </TableHead>
@@ -1657,8 +1657,8 @@ const ObjectFilterPage: React.FC = () => {
                 }}
               >
                 {selectedKinds.length > 0 && selectedNamespaces.length > 0
-                  ? 'No resources found'
-                  : 'Ready to explore'}
+                  ? t('resources.emptyState.noResourcesFound')
+                  : t('resources.emptyState.readyToExplore')}
               </Typography>
               <Typography
                 variant="body1"
@@ -1670,8 +1670,8 @@ const ObjectFilterPage: React.FC = () => {
                 }}
               >
                 {selectedKinds.length > 0 && selectedNamespaces.length > 0
-                  ? 'No resources match your current filters. Try adjusting your search criteria or clearing filters.'
-                  : 'Select a resource kind and namespace to begin exploring your Kubernetes objects.'}
+                  ? t('resources.emptyState.noResourcesDescription')
+                  : t('resources.emptyState.getStartedDescription')}
               </Typography>
               {selectedKinds.length > 0 && selectedNamespaces.length > 0 ? (
                 <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center' }}>


### PR DESCRIPTION
### Internationalized empty state messages:
"No resources found" → [t('resources.emptyState.noResourcesFound')](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
"Ready to explore" → [t('resources.emptyState.readyToExplore')](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Description texts → [t('resources.emptyState.noResourcesDescription')](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [t('resources.emptyState.getStartedDescription')](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

### Internationalized table headers:
"Name" → [t('resources.table.name')](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
"Kind" → [t('resources.table.kind')](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
"Namespace" → [t('resources.table.namespace')](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
"Status" → [t('resources.table.status')](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
"Created" → [t('resources.table.created')](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
"Actions" → [t('resources.table.actions')](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

### Hindi ([strings.hi.json](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)):

Added corresponding Hindi translations for all the above sections