### PR TITLE
chore: add success status to JSON response

### DIFF
--- a/backend/api/plugins.go
+++ b/backend/api/plugins.go
@@ -538,6 +538,7 @@ func InstallPluginHandler(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
+		"success": true,
 		"message": "Plugin installed and loaded successfully",
 		"name":    manifest.Metadata.Name,
 		"version": manifest.Metadata.Version,


### PR DESCRIPTION
### Description

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->
I added the success status to the JSON response when the plugin is successfully installed. This resolved the warning problem when we try to upload a plugin from local files.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #2038
### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Added `success: true` to the JSON response when successfully installed the plugin.

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->


https://github.com/user-attachments/assets/0d6938d1-f63d-4935-8b4a-92ef6ea1c13c

