### PR TITLE
refactor: update the condition for displaying the invalid token

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -84,7 +84,10 @@ api.interceptors.response.use(
     } else {
       console.error('Axios Interceptor: API error response.', error.response);
       // Don't show error toast for 401 responses from auth checks (/api/me) when on login page
-      const shouldSuppressToast = error.response.status === 401 && isAuthCheck && isOnLoginPage();
+      // Suppress toast if:
+      // - user is already on login page (we don't want "Invalid Token" there)
+      // - OR it's an auth check endpoint
+      const shouldSuppressToast = isOnLoginPage() || (error.response.status === 401 && isAuthCheck);
 
       if (!shouldSuppressToast) {
         // For other errors, show toast but use a consistent ID to prevent duplicates


### PR DESCRIPTION


### Description

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->
I adjusted the condition for displaying the warning relating to JWT Token on the Login page (to not show the warning).

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #2037

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated the warning message condition inside `src/lib/api.ts`

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

https://github.com/user-attachments/assets/ce976b0a-c801-40ff-a013-75e9ba1d51bd



### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
To test this change, you can temporarily set the expiration time for the JWT Token to 10 seconds instead of 24 hours.
File: `backend/utils/jwt.go`
