### PR TITLE
chore: truncate Bearer Token in backend logged http request

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -225,9 +225,9 @@ func sanitizeHeader(headers http.Header) map[string][]string {
 				} else {
 					safeHeaders[k] = []string{"[masked]"}
 				}
-			} else {
-				safeHeaders[k] = v
 			}
+		} else if len(v) > 0 {
+			safeHeaders[k] = v
 		}
 	}
 	return safeHeaders

--- a/backend/main.go
+++ b/backend/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"strings"
@@ -211,6 +212,27 @@ func isWebSocketUpgrade(c *gin.Context) bool {
 		strings.ToLower(c.GetHeader("Upgrade")) == "websocket"
 }
 
+// Helper function to sanitize the headers for logging
+func sanitizeHeader(headers http.Header) map[string][]string {
+	safeHeaders := make(map[string][]string)
+	for k, v := range headers {
+		if strings.ToLower(k) == "authorization" {
+			if len(v) > 0 {
+				// Mask the token, keep only first 10 chars for debugging
+				token := v[0]
+				if len(token) > 10 {
+					safeHeaders[k] = []string{token[:10] + "...[truncated]"}
+				} else {
+					safeHeaders[k] = []string{"[masked]"}
+				}
+			} else {
+				safeHeaders[k] = v
+			}
+		}
+	}
+	return safeHeaders
+}
+
 // Fixed Middleware to handle WebSocket connections properly
 func ZapMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -248,6 +270,9 @@ func ZapMiddleware() gin.HandlerFunc {
 		responseSize := c.Writer.Size()
 		headers := c.Request.Header
 
+		// Sanitize headers for logging
+		safeHeaders := sanitizeHeader(headers)
+
 		// Truncate the request body length
 		maxBodyLen := 500
 		if len(requestBody) > maxBodyLen {
@@ -264,7 +289,7 @@ func ZapMiddleware() gin.HandlerFunc {
 			zap.String("user-agent", c.Request.UserAgent()),
 			zap.Any("query-params", c.Request.URL.Query()),
 			zap.String("request-body", requestBody),
-			zap.Any("headers", headers),
+			zap.Any("headers", safeHeaders),
 			zap.Int("response-size", responseSize),
 		)
 


### PR DESCRIPTION
### Description

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->
In this PR, I truncated the Bearer Token being printed out in the backend log.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #2044

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Added `sanitizeHeader()` helper function to truncate the printed out token.

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->
<img width="1217" height="894" alt="Screenshot 2025-10-03 at 17 27 09" src="https://github.com/user-attachments/assets/81ecd37c-cba2-46f9-a3da-6986b51663a4" />



