### PR TITLE
fix: refine error handling in login process and toast notifications

### DIFF
--- a/frontend/src/components/login/LoginForm.tsx
+++ b/frontend/src/components/login/LoginForm.tsx
@@ -163,7 +163,7 @@ const LoginForm = () => {
     console.log(
       `[LoginForm] Form submission started at ${performance.now() - renderStartTime.current}ms`
     );
-    toast.dismiss('login-error'); // Only dismiss previous login errors
+    toast.dismiss('login-error');
     toast.loading(t('login.form.signingIn'), { id: 'auth-loading' });
 
     login({ username, password, rememberMe });

--- a/frontend/src/components/login/LoginForm.tsx
+++ b/frontend/src/components/login/LoginForm.tsx
@@ -163,7 +163,7 @@ const LoginForm = () => {
     console.log(
       `[LoginForm] Form submission started at ${performance.now() - renderStartTime.current}ms`
     );
-    toast.dismiss();
+    toast.dismiss('login-error'); // Only dismiss previous login errors
     toast.loading(t('login.form.signingIn'), { id: 'auth-loading' });
 
     login({ username, password, rememberMe });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -54,7 +54,6 @@ api.interceptors.response.use(
       error.response?.data?.message || error.response?.data?.error || error.message;
     const isAuthCheck = error.config?.url?.includes('/api/me');
 
-    // Don't try to refresh token for login endpoint - 401 means wrong credentials
     const isLoginEndpoint = error.config?.url?.includes('/login');
 
     if (
@@ -73,8 +72,6 @@ api.interceptors.response.use(
       } else {
         console.error('Axios Interceptor: Token refresh failed. Redirecting to login.');
         clearTokens();
-
-        // Only show toast if user is not already on login page
         if (!isOnLoginPage()) {
           toast.error('Session expired. Please log in again.');
         }
@@ -91,9 +88,6 @@ api.interceptors.response.use(
       setGlobalNetworkError(true);
     } else {
       console.error('Axios Interceptor: API error response.', error.response);
-      // Don't show error toast for:
-      // - 401 responses from auth checks (/api/me) when on login page (we don't want "Invalid Token" there)
-      // - Login endpoint errors (handled by useLogin hook)
       const isLoginEndpoint = error.config?.url?.includes('/login');
       const shouldSuppressToast = (error.response.status === 401 && isAuthCheck) || isLoginEndpoint;
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -56,8 +56,13 @@ api.interceptors.response.use(
 
     // Don't try to refresh token for login endpoint - 401 means wrong credentials
     const isLoginEndpoint = error.config?.url?.includes('/login');
-    
-    if (error.response?.status === 401 && !originalRequest._retry && !isAuthCheck && !isLoginEndpoint) {
+
+    if (
+      error.response?.status === 401 &&
+      !originalRequest._retry &&
+      !isAuthCheck &&
+      !isLoginEndpoint
+    ) {
       console.warn('Axios Interceptor: 401 Unauthorized. Attempting token refresh.');
       originalRequest._retry = true;
       const newToken = await refreshAccessToken(api);


### PR DESCRIPTION
### Description
Fixed login error toast not appearing when users enter incorrect credentials. The issue was caused by the axios interceptor attempting to refresh tokens for login endpoint 401 errors, which resulted in page reloads and prevented error toasts from displaying.
This fix ensures a better user experience by providing clear feedback when authentication fails, while maintaining the existing token refresh functionality for authenticated API endpoints.

### Related Issue


Fixes #2056 

### Changes Made

- [x] Fixed axios interceptor logic to exclude login endpoint from token refresh attempts
- [x] Updated LoginForm component to only dismiss specific login error toasts instead of all toasts
- [x] Improved error handling flow to prevent page reloads during failed login attempts
- [x] Ensured proper error toast display for authentication failures
---
- [ ] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)


https://github.com/user-attachments/assets/814fec0c-1f6c-46d3-885d-a4d05b1c81e0



### Additional Notes

**Key Changes**:
   - Modified `frontend/src/lib/api.ts` to exclude login endpoints from token refresh logic
   - Updated `frontend/src/components/login/LoginForm.tsx` to only dismiss specific error toasts
   - Fixed error handling flow in `frontend/src/hooks/queries/useLogin.ts`

3. **Files Modified**:
   - `frontend/src/lib/api.ts` - Added login endpoint exclusion in axios interceptor
   - `frontend/src/components/login/LoginForm.tsx` - Changed `toast.dismiss()` to `toast.dismiss('login-error')`
