### PR TITLE
Integrate React Query v5 for manifest fetch/update with cache invalidation

### DIFF
--- a/frontend/src/components/wecs_details/WecsDetailsPanel.tsx
+++ b/frontend/src/components/wecs_details/WecsDetailsPanel.tsx
@@ -80,6 +80,14 @@ interface WecsDetailsProps {
   isDeploymentOrJobPod?: boolean;
 }
 
+// Improve readability for mutation args
+interface UpdateManifestArgs {
+  endpoint: string;
+  method: 'PUT' | 'PATCH';
+  manifestData: unknown;
+  params: Record<string, string>;
+}
+
 const WecsDetailsPanel = ({
   namespace,
   name,
@@ -166,7 +174,7 @@ const WecsDetailsPanel = ({
     staleTime: 30000,
     gcTime: 300000,
     queryFn: async () => {
-      if (type.toLowerCase() === 'cluster') {
+      if (type?.toLowerCase() === 'cluster') {
         const response = await api.get(`/api/cluster/details/${encodeURIComponent(name)}`);
         const clusterData = response.data;
         const formattedCluster = {
@@ -189,7 +197,7 @@ const WecsDetailsPanel = ({
       }
 
       const response = await api.get(
-        `/api/${type.toLowerCase()}/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`,
+        `/api/${type?.toLowerCase() || ''}/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`,
         { params: cluster ? { cluster } : {} }
       );
 
@@ -568,7 +576,17 @@ const WecsDetailsPanel = ({
           );
       setEditedManifest(fallback);
     }
-  }, [tabValue, isOpen, name, namespace, type, manifestQueryData, manifestQueryLoading, editedManifest, resourceData]);
+  }, [
+    tabValue,
+    isOpen,
+    name,
+    namespace,
+    type,
+    manifestQueryData,
+    manifestQueryLoading,
+    editedManifest,
+    resourceData,
+  ]);
 
   // JSON to YAML conversion function
   const jsonToYaml = useCallback((jsonString: string): string => {
@@ -602,8 +620,14 @@ const WecsDetailsPanel = ({
 
   // React Query mutation for manifest update
   const updateManifestMutation = useMutation({
-    mutationFn: async ({ endpoint, method, manifestData, params }: { endpoint: string; method: 'PUT' | 'PATCH'; manifestData: unknown; params: Record<string, string> }) => {
-      return api.request({ method, url: endpoint, data: manifestData, params, headers: { 'Content-Type': 'application/json' } });
+    mutationFn: async ({ endpoint, method, manifestData, params }: UpdateManifestArgs) => {
+      return api.request({
+        method,
+        url: endpoint,
+        data: manifestData,
+        params,
+        headers: { 'Content-Type': 'application/json' },
+      });
     },
     onSuccess: () => {
       setSnackbarMessage(t('wecsDetailsPanel.success.manifestUpdated'));
@@ -654,7 +678,7 @@ const WecsDetailsPanel = ({
       }
 
       // Special handling for cluster resources
-      if (type.toLowerCase() === 'cluster') {
+      if (type?.toLowerCase() === 'cluster') {
         let labels = {};
         try {
           // Extract all labels from the manifest
@@ -697,7 +721,7 @@ const WecsDetailsPanel = ({
       let endpoint: string;
       const method: 'PUT' | 'PATCH' = 'PUT';
 
-      if (type.toLowerCase() === 'cluster') {
+      if (type?.toLowerCase() === 'cluster') {
         endpoint = `/api/cluster/${encodeURIComponent(name)}`;
       } else {
         if (!namespace) {
@@ -706,7 +730,7 @@ const WecsDetailsPanel = ({
           setSnackbarOpen(true);
           return;
         }
-        endpoint = `/api/${type.toLowerCase()}/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`;
+        endpoint = `/api/${type?.toLowerCase() || ''}/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`;
       }
 
       // Add cluster context if available


### PR DESCRIPTION
### Description
Integrate React Query v5 into high-priority UI areas to improve caching, background refresh, and error handling, while preserving existing behavior and avoiding breaking changes.

- Added query and mutation for manifests in `WecsDetailsPanel.tsx`
- Audited and aligned options with React Query v5 (gcTime instead of deprecated cacheTime)
- [x] Added React Query manifest fetch in frontend/src/components/wecs_details/WecsDetailsPanel.tsx
- [x] Added React Query mutation for manifest updates with cache invalidation and refetch
- [x] Synced loading state with query loading for Edit tab
- [x] Preserved legacy manifest-updated event and fallback manifest creation
- [x] Replaced deprecated cacheTime usage with gcTime where applicable
- [x] Ensured no changes to component props, endpoints, or SSE/WS flows


### Related Issue



Under #2053 

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated ...
- [ ] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->

