### PR TITLE
Fix: Prometheus can now successfully scrape metrics from /api/v1/metrics

### DIFF
--- a/backend/api/metrics.go
+++ b/backend/api/metrics.go
@@ -86,13 +86,12 @@ func SetupMetricsRoutes(router *gin.Engine, logger *zap.Logger) {
 
 	// Raw Prometheus metrics endpoint (for Prometheus scraping)
 	router.GET("/metrics", GetRawMetrics)
-	
+
 	// API v1 metrics endpoint for Prometheus compatibility
 	v1 := router.Group("/api/v1")
 	{
 		v1.GET("/metrics", GetRawMetrics)
 	}
-
 }
 
 // GetPodHealthMetrics returns the percentage of healthy pods across all clusters/contexts

--- a/backend/api/metrics.go
+++ b/backend/api/metrics.go
@@ -86,6 +86,12 @@ func SetupMetricsRoutes(router *gin.Engine, logger *zap.Logger) {
 
 	// Raw Prometheus metrics endpoint (for Prometheus scraping)
 	router.GET("/metrics", GetRawMetrics)
+	
+	// API v1 metrics endpoint for Prometheus compatibility
+	v1 := router.Group("/api/v1")
+	{
+		v1.GET("/metrics", GetRawMetrics)
+	}
 
 }
 

--- a/backend/monitoring/prometheus/prometheus.yml/config.yml
+++ b/backend/monitoring/prometheus/prometheus.yml/config.yml
@@ -5,3 +5,4 @@ scrape_configs:
   - job_name: prometheus
     static_configs:
       - targets: ["host.docker.internal:4000"]
+    metrics_path: /api/v1/metrics

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -17,8 +17,6 @@ scrape_configs:
       # Both services use host networking, so localhost works
       - targets: ['localhost:4000']
     metrics_path: /api/v1/metrics
-    params:
-      format: ['raw']
 
 
   # Node Exporter for system metrics


### PR DESCRIPTION
### Added the missing /api/v1/metrics route in [metrics.go](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to handle Prometheus scraping requests

- Updated Prometheus configurations in both:
- [prometheus.yml](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- [config.yml](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

### The fix ensures that:

1. Prometheus can successfully scrape metrics from /api/v1/metrics
2. The endpoint returns proper Prometheus-formatted metrics via [api.GetRawMetrics](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
3. No more 400 errors will occur during metrics collection