### PR TITLE
Implement React Query workloads integration in useKubestellarData

### DIFF
--- a/frontend/src/hooks/useKubestellarData.ts
+++ b/frontend/src/hooks/useKubestellarData.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { api } from '../lib/api';
 import { BindingPolicyInfo, ManagedCluster, Workload } from '../types/bindingPolicy';
 import { useTranslation } from 'react-i18next';
+import { useWDSQueries } from './queries/useWDSQueries';
 
 interface UseKubestellarDataProps {
   // Optional callback to run after data refresh
@@ -50,6 +51,7 @@ export function useKubestellarData({
   skipFetch = false,
 }: UseKubestellarDataProps = {}) {
   const { t } = useTranslation();
+  const { useWorkloads } = useWDSQueries();
   const [clusters, setClusters] = useState<ManagedCluster[]>([]);
   const [workloads, setWorkloads] = useState<Workload[]>([]);
   const [policies, setPolicies] = useState<BindingPolicyInfo[]>([]);
@@ -117,38 +119,63 @@ export function useKubestellarData({
     }
   }, [skipFetch, t]);
 
-  // Fetch workloads from Workload Description Space
-  const fetchWorkloads = useCallback(async () => {
-    if (skipFetch) return;
-    try {
-      setLoading(prev => ({ ...prev, workloads: true }));
-      const response = await api.get('/api/wds/workloads');
+  const {
+    data: workloadsQueryData,
+    isLoading: isLoadingWorkloads,
+    isFetching: isFetchingWorkloads,
+    error: workloadsQueryError,
+    refetch: refetchWorkloads,
+  } = useWorkloads({
+    enabled: !skipFetch,
+  });
 
-      // Map the response data to our Workload type
-      const workloadData = response.data.map((workload: WorkloadApiData) => ({
+  useEffect(() => {
+    if (skipFetch) {
+      setLoading(prev => ({ ...prev, workloads: false }));
+      return;
+    }
+
+    setLoading(prev => ({
+      ...prev,
+      workloads: isLoadingWorkloads || isFetchingWorkloads,
+    }));
+  }, [skipFetch, isLoadingWorkloads, isFetchingWorkloads]);
+
+  useEffect(() => {
+    if (skipFetch) {
+      setWorkloads([]);
+      setError(prev => ({ ...prev, workloads: undefined }));
+      return;
+    }
+
+    if (workloadsQueryError) {
+      console.error(t('kubestellarData.logging.errorFetchingWorkloads'), workloadsQueryError);
+      setError(prev => ({ ...prev, workloads: t('kubestellarData.errors.failedFetchWorkloads') }));
+      setWorkloads([]);
+      return;
+    }
+
+    if (workloadsQueryData) {
+      const workloadData: Workload[] = workloadsQueryData.map(workload => ({
         name: workload.name,
-        type: workload.kind || t('kubestellarData.defaults.deployment'), // Default to Deployment if kind is not specified
+        kind: workload.kind || t('kubestellarData.defaults.deployment'),
         namespace: workload.namespace || t('kubestellarData.defaults.defaultNamespace'),
         creationTime: workload.creationTime,
-        labels: workload.labels || {}, // Using empty object as default
-        // Additional details that might be useful
+        labels: workload.labels || {},
         status: workload.status || t('kubestellarData.defaults.active'),
-        replicas: workload.replicas || 1,
-        selector: workload.selector || {},
-        apiVersion: workload.apiVersion || 'apps/v1',
+        replicas: workload.replicas,
       }));
 
       console.log(t('kubestellarData.logging.processedWorkloads'), workloadData);
       setWorkloads(workloadData);
       setError(prev => ({ ...prev, workloads: undefined }));
-    } catch (err) {
-      console.error(t('kubestellarData.logging.errorFetchingWorkloads'), err);
-      setError(prev => ({ ...prev, workloads: t('kubestellarData.errors.failedFetchWorkloads') }));
-      setWorkloads([]);
-    } finally {
-      setLoading(prev => ({ ...prev, workloads: false }));
     }
-  }, [skipFetch, t]);
+  }, [
+    skipFetch,
+    workloadsQueryData,
+    workloadsQueryError,
+    t,
+  ]);
 
   // Fetch binding policies
   const fetchPolicies = useCallback(async () => {
@@ -193,13 +220,15 @@ export function useKubestellarData({
   // Function to refresh all data
   const refreshAllData = useCallback(() => {
     fetchClusters();
-    fetchWorkloads();
+    if (!skipFetch) {
+      void refetchWorkloads();
+    }
     fetchPolicies();
 
     if (onDataLoaded) {
       onDataLoaded();
     }
-  }, [fetchClusters, fetchWorkloads, fetchPolicies, onDataLoaded]);
+  }, [fetchClusters, fetchPolicies, onDataLoaded, refetchWorkloads, skipFetch]);
 
   // Fetch all data on initial load
   useEffect(() => {


### PR DESCRIPTION


### Description

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->
Reuse existing query hook: Switched the workloads branch of 
useKubestellarData() to consume useWDSQueries().useWorkloads() for /api/wds/workloads data in frontend/src/hooks/useKubestellarData.ts
Preserve state shape: Transformed the query result back into the local Workload shape with translation-backed defaults for kind, namespace, and status.
Align loading/error flags: Derived workloads loading and error indicators directly from the React Query state, removing the manual Axios call.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Under #729 

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated ...
- [x] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
