### PR TITLE
Implement cluster-scoped resource API and update frontend fetching logic

### DIFF
--- a/backend/k8s/client.go
+++ b/backend/k8s/client.go
@@ -119,7 +119,6 @@ func GetClientSetWithContext(contextName string) (*kubernetes.Clientset, dynamic
 		telemetry.K8sClientErrorCounter.WithLabelValues("GetClientSetWithContext", "create_restconfig", "500").Inc()
 		return nil, nil, fmt.Errorf("failed to create restconfig: %v", err)
 	}
-
 	clientset, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		log.LogError("Failed to create Kubernetes client", zap.Error(err))

--- a/backend/k8s/resources.go
+++ b/backend/k8s/resources.go
@@ -299,6 +299,15 @@ func GetResource(c *gin.Context) {
 
 // ListResources lists all resources of a given type in a namespace
 func ListResources(c *gin.Context) {
+	listResourcesCommon(c, c.Param("namespace"), true)
+}
+
+// ListClusterResources lists all cluster-scoped resources of a given type
+func ListClusterResources(c *gin.Context) {
+	listResourcesCommon(c, "", false)
+}
+
+func listResourcesCommon(c *gin.Context, namespace string, namespaceProvided bool) {
 	cookieContext, err := c.Cookie("ui-wds-context")
 	if err != nil {
 		cookieContext = "wds1"
@@ -310,7 +319,6 @@ func ListResources(c *gin.Context) {
 	}
 
 	resourceKind := c.Param("resourceKind")
-	namespace := c.Param("namespace")
 
 	// Get filter parameters
 	kindFilter := c.Query("kind")
@@ -326,9 +334,15 @@ func ListResources(c *gin.Context) {
 
 	var resource dynamic.ResourceInterface
 	if isNamespaced {
+		if !namespaceProvided || namespace == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Namespace is required for this resource"})
+			return
+		}
 		resource = dynamicClient.Resource(gvr).Namespace(namespace)
 	} else {
 		resource = dynamicClient.Resource(gvr)
+		namespace = ""
+		namespaceFilter = ""
 	}
 
 	// Create list options with label selector if provided
@@ -345,16 +359,21 @@ func ListResources(c *gin.Context) {
 	}
 
 	// Apply additional filtering on the server side
-	if kindFilter != "" || namespaceFilter != "" {
+	if kindFilter != "" || namespaceFilter != "" || namespace != "" {
 		filteredItems := make([]unstructured.Unstructured, 0)
 		for _, item := range result.Items {
 			// Apply kind filter if specified
-			if kindFilter != "" && item.GetKind() != kindFilter {
+			if kindFilter != "" && !strings.EqualFold(item.GetKind(), kindFilter) {
 				continue
 			}
 
 			// Apply namespace filter if specified
 			if namespaceFilter != "" && item.GetNamespace() != namespaceFilter {
+				continue
+			}
+
+			// Ensure items respect the requested namespace when provided
+			if namespace != "" && item.GetNamespace() != namespace {
 				continue
 			}
 

--- a/backend/k8s/resources.go
+++ b/backend/k8s/resources.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/kubestellar/ui/backend/telemetry"
 	"io"
 	"log"
 	"net/http"
@@ -14,6 +13,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/kubestellar/ui/backend/telemetry"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
@@ -350,8 +351,7 @@ func listResourcesCommon(c *gin.Context, namespace string, namespaceProvided boo
 	if labelFilter != "" {
 		listOptions.LabelSelector = labelFilter
 	}
-
-	// Retrieve list of resources
+	// call list
 	result, err := resource.List(c, listOptions)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/backend/routes/resources.go
+++ b/backend/routes/resources.go
@@ -16,6 +16,7 @@ func setupResourceRoutes(router *gin.Engine) {
 		api.GET("/wds/context", func(ctx *gin.Context) {
 			wds.CreateWDSContextUsingCommand(ctx.Writer, ctx.Request, ctx)
 		})
+		api.GET("/wds/list-sse", wds.ListAllResourcesDetailsSSE)
 		api.GET("/wds/list/:namespace", wds.ListAllResourcesByNamespace)
 		api.GET("/:resourceKind/:namespace/log", k8s.LogWorkloads)
 		api.POST("/resources", k8s.CreateResource)                        // Create a new resource

--- a/backend/routes/resources.go
+++ b/backend/routes/resources.go
@@ -16,11 +16,11 @@ func setupResourceRoutes(router *gin.Engine) {
 		api.GET("/wds/context", func(ctx *gin.Context) {
 			wds.CreateWDSContextUsingCommand(ctx.Writer, ctx.Request, ctx)
 		})
-		api.GET("/wds/list-sse", wds.ListAllResourcesDetailsSSE)
 		api.GET("/wds/list/:namespace", wds.ListAllResourcesByNamespace)
 		api.GET("/:resourceKind/:namespace/log", k8s.LogWorkloads)
 		api.POST("/resources", k8s.CreateResource)                        // Create a new resource
 		api.POST("/resource/upload", k8s.UploadYAMLFile)                  // Upload any k8s resource file with "wds" key
+		api.GET("/cluster/:resourceKind", k8s.ListClusterResources)       // List cluster-scoped resources
 		api.GET("/:resourceKind/:namespace", k8s.ListResources)           // List all resources
 		api.GET("/:resourceKind/:namespace/:name", k8s.GetResource)       // Get a resource
 		api.PUT("/:resourceKind/:namespace/:name", k8s.UpdateResource)    // Update a resource
@@ -30,4 +30,5 @@ func setupResourceRoutes(router *gin.Engine) {
 		api.GET("/resources/kinds", k8s.GetResourceKinds)   // Get all available resource kinds
 		api.GET("/resources/namespaces", k8s.GetNamespaces) // Get all available namespaces
 	}
+
 }

--- a/frontend/src/hooks/useObjectFilters.ts
+++ b/frontend/src/hooks/useObjectFilters.ts
@@ -107,7 +107,7 @@ export const useObjectFilters = (): UseObjectFiltersResult => {
         setIsLoading(false);
       }
     },
-    []
+    [resourceKinds]
   );
 
   return {

--- a/frontend/src/hooks/useObjectFilters.ts
+++ b/frontend/src/hooks/useObjectFilters.ts
@@ -84,8 +84,16 @@ export const useObjectFilters = (): UseObjectFiltersResult => {
       try {
         const fetchPromises: Promise<FetchResourcesResponse>[] = [];
         for (const kind of kinds) {
-          for (const ns of nsList) {
-            fetchPromises.push(fetchResources(kind, ns, filters));
+          const kindInfo = resourceKinds.find(resourceKind => resourceKind.name === kind);
+          console.log(resourceKinds)
+          console.log(kindInfo)
+          const isNamespaced = kindInfo?.namespaced ?? true;
+          if (isNamespaced) {
+            for (const ns of nsList) {
+              fetchPromises.push(fetchResources(kind, ns, filters, { isNamespaced: true }));
+            }
+          } else {
+            fetchPromises.push(fetchResources(kind, undefined, filters, { isNamespaced: false }));
           }
         }
         const results = await Promise.all(fetchPromises);

--- a/frontend/src/hooks/useObjectFilters.ts
+++ b/frontend/src/hooks/useObjectFilters.ts
@@ -85,8 +85,8 @@ export const useObjectFilters = (): UseObjectFiltersResult => {
         const fetchPromises: Promise<FetchResourcesResponse>[] = [];
         for (const kind of kinds) {
           const kindInfo = resourceKinds.find(resourceKind => resourceKind.name === kind);
-          console.log(resourceKinds)
-          console.log(kindInfo)
+          console.log(resourceKinds);
+          console.log(kindInfo);
           const isNamespaced = kindInfo?.namespaced ?? true;
           if (isNamespaced) {
             for (const ns of nsList) {

--- a/frontend/src/pages/ObjectFilterPage.tsx
+++ b/frontend/src/pages/ObjectFilterPage.tsx
@@ -89,6 +89,7 @@ interface ResourceKind {
   kind: string;
   group: string;
   version: string;
+  namespaced?: boolean;
 }
 
 // Enhanced view modes for better UX
@@ -145,59 +146,18 @@ const ObjectFilterPage: React.FC = () => {
   const filteredNamespaces = useMemo(
     () =>
       namespaces.filter(
-        (ns: { name: string }) => !ns.name.startsWith('kube-') && ns.name !== 'kubestellar-report'
+        (ns: { name: string }) =>
+          !ns.name.toLowerCase().startsWith('kube-') && ns.name.toLowerCase() !== 'kubestellar-report'
       ),
     [namespaces]
   );
 
-  const hasNamespaceKind = useMemo(
-    () => selectedKinds.some(kind => kind.kind.toLowerCase() === 'namespace'),
-    [selectedKinds]
-  );
-
-  const nonNamespaceKinds = useMemo(
-    () => selectedKinds.filter(kind => kind.kind.toLowerCase() !== 'namespace'),
-    [selectedKinds]
-  );
-
-  const namespaceResources = useMemo<Resource[]>(() => {
-    if (!hasNamespaceKind) return [];
-
-    const hasSelection = selectedNamespaces.length > 0;
-    const selectedSet = new Set(selectedNamespaces);
-
-    return filteredNamespaces
-      .filter(ns => !hasSelection || selectedSet.has(ns.name))
-      .map(ns => ({
-        kind: 'Namespace',
-        metadata: {
-          name: ns.name,
-          namespace: '',
-          uid: `namespace-${ns.name}`,
-          creationTimestamp: ns.createdAt,
-        },
-        status: ns.status,
-        labels: ns.labels || {},
-      }));
-  }, [filteredNamespaces, hasNamespaceKind, selectedNamespaces]);
-
   const displayResources = useMemo<Resource[]>(() => {
-    const combined: Resource[] = [];
-
-    if (hasNamespaceKind) {
-      combined.push(...namespaceResources);
-    }
-
     if (filteredResources && Array.isArray(filteredResources)) {
-      combined.push(...((filteredResources as unknown as Resource[]) || []));
+      return [...((filteredResources as unknown as Resource[]) || [])];
     }
-
-    if (!hasNamespaceKind) {
-      return combined;
-    }
-
-    return combined;
-  }, [filteredResources, hasNamespaceKind, namespaceResources]);
+    return [];
+  }, [filteredResources]);
 
   const derivedResources = useMemo<DerivedResource[]>(() => {
     if (!displayResources || displayResources.length === 0) return [];
@@ -430,25 +390,22 @@ const ObjectFilterPage: React.FC = () => {
   }, []);
 
   const handleApplyFilters = useCallback(async () => {
-    const kindsToFetch = nonNamespaceKinds.map(k => k.name);
+    const kindsToFetch = selectedKinds.map(k => k.name);
 
     if (kindsToFetch.length > 0) {
       await applyFilters(kindsToFetch, selectedNamespaces, resourceFilters);
     }
-  }, [nonNamespaceKinds, selectedNamespaces, resourceFilters, applyFilters]);
+  }, [selectedKinds, selectedNamespaces, resourceFilters, applyFilters]);
 
   const handleRefresh = useCallback(async () => {
-    const kindsToFetch = nonNamespaceKinds.map(k => k.name);
+    const kindsToFetch = selectedKinds.map(k => k.name);
 
     if (kindsToFetch.length > 0) {
       setIsRefreshing(true);
       await applyFilters(kindsToFetch, selectedNamespaces, resourceFilters);
       setIsRefreshing(false);
-    } else if (hasNamespaceKind) {
-      setIsRefreshing(true);
-      setIsRefreshing(false);
     }
-  }, [nonNamespaceKinds, selectedNamespaces, resourceFilters, applyFilters, hasNamespaceKind]);
+  }, [selectedKinds, selectedNamespaces, resourceFilters, applyFilters]);
 
   // New handlers for enhanced functionality
   const handleViewModeChange = (_event: React.MouseEvent<HTMLElement>, newViewMode: ViewMode) => {
@@ -517,11 +474,10 @@ const ObjectFilterPage: React.FC = () => {
   };
 
   useEffect(() => {
-    // Auto-apply filters when both kinds and namespaces are selected
-    if (nonNamespaceKinds.length > 0) {
+    if (selectedKinds.length > 0) {
       handleApplyFilters();
     }
-  }, [nonNamespaceKinds, selectedNamespaces, handleApplyFilters]);
+  }, [selectedKinds, selectedNamespaces, handleApplyFilters]);
 
   // Helper function to determine status color
   const getStatusColor = (status: string | undefined) => {
@@ -672,11 +628,7 @@ const ObjectFilterPage: React.FC = () => {
             <Tooltip title={t('resources.refresh')}>
               <IconButton
                 onClick={handleRefresh}
-                disabled={
-                  isRefreshing ||
-                  selectedKinds.length === 0 ||
-                  (!hasNamespaceKind && selectedNamespaces.length === 0)
-                }
+                disabled={isRefreshing || selectedKinds.length === 0}
                 sx={{
                   color: isDark ? darkTheme.text.secondary : lightTheme.text.secondary,
                   '&:hover': {
@@ -994,7 +946,7 @@ const ObjectFilterPage: React.FC = () => {
             </Grid>
           </Box>
 
-          {selectedKinds.length > 0 && (hasNamespaceKind || selectedNamespaces.length > 0) && (
+          {selectedKinds.length > 0 && (
             <Box
               sx={{
                 mt: 3,
@@ -1709,7 +1661,7 @@ const ObjectFilterPage: React.FC = () => {
                   mb: 1,
                 }}
               >
-                {selectedKinds.length > 0 && (hasNamespaceKind || selectedNamespaces.length > 0)
+                {selectedKinds.length > 0
                   ? t('resources.emptyState.noResourcesFound')
                   : t('resources.emptyState.readyToExplore')}
               </Typography>
@@ -1722,11 +1674,11 @@ const ObjectFilterPage: React.FC = () => {
                   margin: '0 auto 24px',
                 }}
               >
-                {selectedKinds.length > 0 && (hasNamespaceKind || selectedNamespaces.length > 0)
+                {selectedKinds.length > 0
                   ? t('resources.emptyState.noResourcesDescription')
                   : t('resources.emptyState.getStartedDescription')}
               </Typography>
-              {selectedKinds.length > 0 && (hasNamespaceKind || selectedNamespaces.length > 0) ? (
+              {selectedKinds.length > 0 ? (
                 <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center' }}>
                   <Button
                     variant="outlined"

--- a/frontend/src/pages/ObjectFilterPage.tsx
+++ b/frontend/src/pages/ObjectFilterPage.tsx
@@ -147,7 +147,8 @@ const ObjectFilterPage: React.FC = () => {
     () =>
       namespaces.filter(
         (ns: { name: string }) =>
-          !ns.name.toLowerCase().startsWith('kube-') && ns.name.toLowerCase() !== 'kubestellar-report'
+          !ns.name.toLowerCase().startsWith('kube-') &&
+          ns.name.toLowerCase() !== 'kubestellar-report'
       ),
     [namespaces]
   );

--- a/frontend/src/pages/ObjectFilterPage.tsx
+++ b/frontend/src/pages/ObjectFilterPage.tsx
@@ -432,7 +432,7 @@ const ObjectFilterPage: React.FC = () => {
   const handleApplyFilters = useCallback(async () => {
     const kindsToFetch = nonNamespaceKinds.map(k => k.name);
 
-    if (kindsToFetch.length > 0 && selectedNamespaces.length > 0) {
+    if (kindsToFetch.length > 0) {
       await applyFilters(kindsToFetch, selectedNamespaces, resourceFilters);
     }
   }, [nonNamespaceKinds, selectedNamespaces, resourceFilters, applyFilters]);
@@ -440,7 +440,7 @@ const ObjectFilterPage: React.FC = () => {
   const handleRefresh = useCallback(async () => {
     const kindsToFetch = nonNamespaceKinds.map(k => k.name);
 
-    if (kindsToFetch.length > 0 && selectedNamespaces.length > 0) {
+    if (kindsToFetch.length > 0) {
       setIsRefreshing(true);
       await applyFilters(kindsToFetch, selectedNamespaces, resourceFilters);
       setIsRefreshing(false);
@@ -518,7 +518,7 @@ const ObjectFilterPage: React.FC = () => {
 
   useEffect(() => {
     // Auto-apply filters when both kinds and namespaces are selected
-    if (nonNamespaceKinds.length > 0 && selectedNamespaces.length > 0) {
+    if (nonNamespaceKinds.length > 0) {
       handleApplyFilters();
     }
   }, [nonNamespaceKinds, selectedNamespaces, handleApplyFilters]);

--- a/frontend/src/services/resourceService.ts
+++ b/frontend/src/services/resourceService.ts
@@ -15,10 +15,15 @@ export interface ResourceQueryParams {
  * @param filters Optional filters to apply
  * @returns Promise with the filtered resources
  */
+interface FetchResourcesOptions {
+  isNamespaced?: boolean;
+}
+
 export const fetchResources = async (
   resourceKind: string,
-  namespace: string,
-  filters?: ObjectFilter
+  namespace?: string,
+  filters?: ObjectFilter,
+  options?: FetchResourcesOptions
 ) => {
   // Convert ObjectFilter to query parameters
   const queryParams: ResourceQueryParams = {};
@@ -35,7 +40,19 @@ export const fetchResources = async (
     .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
     .join('&');
 
-  const url = `/api/${resourceKind}/${namespace}${queryString ? `?${queryString}` : ''}`;
+  const trimmedNamespace = namespace?.trim();
+
+  let basePath: string;
+
+  if (options?.isNamespaced === false) {
+    basePath = `/api/cluster/${resourceKind}`;
+  } else if (trimmedNamespace) {
+    basePath = `/api/${resourceKind}/${trimmedNamespace}`;
+  } else {
+    basePath = `/api/cluster/${resourceKind}`;
+  }
+
+  const url = `${basePath}${queryString ? `?${queryString}` : ''}`;
 
   try {
     const response = await api.get(url);


### PR DESCRIPTION
### Description

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->
Add cluster resource endpoint: Introduced 
ListClusterResources() and route /api/cluster/:resourceKind so cluster-scoped objects can be fetched without a namespace (backend/k8s/resources.go, backend/routes/resources.go).
Scope-aware fetch service: Updated fetchResources() to switch between /api/{kind}/{namespace} and /api/cluster/{kind} based on the kind’s namespaced flag frontend/src/services/resourceService.ts
Frontend integration: useObjectFilters() now passes the scope flag into fetchResources, and ObjectFilterPage.tsx treats all kinds uniformly, eliminating namespace-specific hacks.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #2049

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated ...
- [x] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

https://github.com/user-attachments/assets/bf8d3070-dabd-48ee-a2cd-7e874ba37da3



### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
