### PR TITLE
[refactor] :  ObjectFilterPage to use derivedResources

### DIFF
--- a/frontend/src/pages/ObjectFilterPage.tsx
+++ b/frontend/src/pages/ObjectFilterPage.tsx
@@ -1518,7 +1518,7 @@ const ObjectFilterPage: React.FC = () => {
                       </TableRow>
                     </TableHead>
                     <TableBody>
-                      {(filteredResources as unknown as Resource[]).map(resource => {
+                      {derivedResources.map(resource => {
                         const resourceStatus =
                           typeof resource.status === 'string'
                             ? resource.status === 'Running' || resource.status === 'Active'


### PR DESCRIPTION
### Description

Fixed an inconsistency in the Object Explorer where namespaces were visible in grid and list views but not in the table view (third view with calculator-like icon). When users selected `Namespace` in the `"Select Kind/Object"` dropdown, the table view was not displaying namespace resources, creating an inconsistent user experience across different view modes.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #2083

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [X] Fixed table view to use derivedResources instead of filteredResources for consistent data display
- [X] Updated `ObjectFilterPage.tsx` to ensure namespaces appear in all view modes



### Checklist

Please ensure the following before submitting your PR:

- [X] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [X] I have tested the changes locally and ensured they work as expected.
- [X] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)


https://github.com/user-attachments/assets/7897b676-5a61-4040-8d0f-bb5c82be4843



### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
