### PR TITLE
FIX:Docker postgres authdb

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: postgres:15-alpine
     container_name: auth_postgres
     environment:
-      POSTGRES_DB: authdbui
+      POSTGRES_DB: authdb
       POSTGRES_USER: authuser
       POSTGRES_PASSWORD: authpass123
     ports:


### PR DESCRIPTION
the POSTGRES_DB value is correctly set to authdb in the backend's [docker-compose.yml](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) file, which matches the health check configuration and the database connection string in the root docker-compose.yml.