### PR TITLE
fix: Not proper error message when different user comes

### DIFF
--- a/backend/middleware/auth.go
+++ b/backend/middleware/auth.go
@@ -46,7 +46,7 @@ func RequireAdmin() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		isAdmin, exists := c.Get("is_admin")
 		if !exists || !isAdmin.(bool) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "Admin access required"})
+			c.JSON(http.StatusForbidden, gin.H{"error": "Insufficient permission"})
 			c.Abort()
 			return
 		}
@@ -59,7 +59,7 @@ func RequirePermission(component, requiredPermission string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		permissions, exists := c.Get("permissions")
 		if !exists {
-			c.JSON(http.StatusForbidden, gin.H{"error": "No permissions found"})
+			c.JSON(http.StatusForbidden, gin.H{"error": "Insufficient permission"})
 			c.Abort()
 			return
 		}
@@ -68,13 +68,13 @@ func RequirePermission(component, requiredPermission string) gin.HandlerFunc {
 		userPerm, hasComponent := userPermissions[component]
 
 		if !hasComponent {
-			c.JSON(http.StatusForbidden, gin.H{"error": "No permission for this component"})
+			c.JSON(http.StatusForbidden, gin.H{"error": "Insufficient permission"})
 			c.Abort()
 			return
 		}
 
 		if !hasRequiredPermission(userPerm, requiredPermission) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "Insufficient permissions"})
+			c.JSON(http.StatusForbidden, gin.H{"error": "Insufficient permission"})
 			c.Abort()
 			return
 		}

--- a/backend/test/middleware/auth_test.go
+++ b/backend/test/middleware/auth_test.go
@@ -132,7 +132,7 @@ func TestRequireAdmin_NonAdminUser(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusForbidden, w.Code)
-	assert.Contains(t, w.Body.String(), "Admin access required")
+	assert.Contains(t, w.Body.String(), "Insufficient permission")
 }
 
 func TestRequireAdmin_NoAdminFlag(t *testing.T) {
@@ -147,7 +147,7 @@ func TestRequireAdmin_NoAdminFlag(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusForbidden, w.Code)
-	assert.Contains(t, w.Body.String(), "Admin access required")
+	assert.Contains(t, w.Body.String(), "Insufficient permission")
 }
 
 func TestRequirePermission_ValidPermission(t *testing.T) {
@@ -205,7 +205,7 @@ func TestRequirePermission_InsufficientPermission(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusForbidden, w.Code)
-	assert.Contains(t, w.Body.String(), "Insufficient permissions")
+	assert.Contains(t, w.Body.String(), "Insufficient permission")
 }
 
 func TestRequirePermission_NoComponentPermission(t *testing.T) {
@@ -225,7 +225,7 @@ func TestRequirePermission_NoComponentPermission(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusForbidden, w.Code)
-	assert.Contains(t, w.Body.String(), "No permission for this component")
+	assert.Contains(t, w.Body.String(), "Insufficient permission")
 }
 
 func TestRequirePermission_NoPermissions(t *testing.T) {
@@ -240,7 +240,7 @@ func TestRequirePermission_NoPermissions(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusForbidden, w.Code)
-	assert.Contains(t, w.Body.String(), "No permissions found")
+	assert.Contains(t, w.Body.String(), "Insufficient permission")
 }
 
 func TestRequirePermission_InvalidRequiredPermission(t *testing.T) {
@@ -260,7 +260,7 @@ func TestRequirePermission_InvalidRequiredPermission(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusForbidden, w.Code)
-	assert.Contains(t, w.Body.String(), "Insufficient permissions")
+	assert.Contains(t, w.Body.String(), "Insufficient permission")
 }
 
 // Test the permission logic by creating a test function that mimics the middleware behavior


### PR DESCRIPTION
### Description

This PR improves the error messaging for permission checks in the authentication middleware. When a user without sufficient permissions accesses protected routes, the API now consistently returns "Insufficient permission" as the error message.

Fixes #2080 

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated all permission-related error messages in `backend/middleware/auth.go` to "Insufficient permission"
- [x] Refactored error handling for admin and permission checks to use a consistent message
- [x] Fixed unit tests in `backend/test/middleware/auth_test.go` to expect the new error message
- [x] Added/updated tests to verify correct error messaging for insufficient permissions

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

