### PR TITLE
Improve filter chip and auto-refresh toggle visibility across themes

### DIFF
--- a/frontend/src/pages/ObjectFilterPage.tsx
+++ b/frontend/src/pages/ObjectFilterPage.tsx
@@ -377,6 +377,50 @@ const ObjectFilterPage: React.FC = () => {
       metadata: resource.metadata || {},
     }));
   }, [derivedResources]);
+
+  const filterChipStyles = useMemo(
+    () => ({
+      fontWeight: 600,
+      backgroundColor: isDark ? 'rgba(59, 130, 246, 0.25)' : lightTheme.brand.primary,
+      color: isDark ? darkTheme.text.secondary : '#ffffff',
+      '& .MuiChip-deleteIcon': {
+        color: isDark ? darkTheme.text.secondary : '#ffffff',
+      },
+      '&:hover': {
+        backgroundColor: isDark ? 'rgba(59, 130, 246, 0.35)' : lightTheme.brand.primaryDark,
+      },
+    }),
+    [isDark]
+  );
+
+  const autoRefreshSwitchStyles = useMemo(
+    () => ({
+      '& .MuiSwitch-switchBase': {
+        color: isDark ? darkTheme.text.secondary : lightTheme.text.secondary,
+        '&:hover': {
+          backgroundColor: isDark ? 'rgba(59, 130, 246, 0.12)' : 'rgba(37, 99, 235, 0.08)',
+        },
+      },
+      '& .MuiSwitch-switchBase.Mui-checked': {
+        color: isDark ? darkTheme.brand.primaryLight : lightTheme.brand.primary,
+        '&:hover': {
+          backgroundColor: isDark ? 'rgba(59, 130, 246, 0.2)' : 'rgba(37, 99, 235, 0.12)',
+        },
+      },
+      '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
+        backgroundColor: isDark ? 'rgba(59, 130, 246, 0.6)' : 'rgba(37, 99, 235, 0.6)',
+        opacity: 1,
+      },
+      '& .MuiSwitch-track': {
+        backgroundColor: isDark ? 'rgba(148, 163, 184, 0.4)' : 'rgba(148, 163, 184, 0.4)',
+        opacity: 1,
+      },
+      '& .MuiSwitch-thumb': {
+        backgroundColor: '#ffffff',
+      },
+    }),
+    [isDark]
+  );
   const handleKindsChange = (
     _event: React.SyntheticEvent<Element, Event>,
     value: ResourceKind[]
@@ -566,6 +610,7 @@ const ObjectFilterPage: React.FC = () => {
                   checked={autoRefresh}
                   onChange={e => setAutoRefresh(e.target.checked)}
                   size="small"
+                  sx={autoRefreshSwitchStyles}
                 />
               }
               label={t('resources.autoRefresh')}
@@ -703,14 +748,7 @@ const ObjectFilterPage: React.FC = () => {
                       <Chip
                         label={option.kind}
                         {...getTagProps({ index })}
-                        sx={{
-                          color: '#fff',
-                          backgroundColor: 'rgba(255,255,255,0.3)', // White background with 0.3 opacity
-                          fontWeight: 600,
-                          '& .MuiChip-deleteIcon': {
-                            color: '#fff',
-                          },
-                        }}
+                        sx={filterChipStyles}
                         deleteIcon={<CloseIcon />}
                       />
                     ))
@@ -847,14 +885,7 @@ const ObjectFilterPage: React.FC = () => {
                             key={ns}
                             label={ns}
                             size="small"
-                            sx={{
-                              color: '#fff',
-                              backgroundColor: 'rgba(255,255,255,0.3)', // White background with 0.3 opacity
-                              fontWeight: 600,
-                              '& .MuiChip-deleteIcon': {
-                                color: '#fff',
-                              },
-                            }}
+                            sx={filterChipStyles}
                             onDelete={e => {
                               e.stopPropagation();
                               setSelectedNamespaces(selectedNamespaces.filter(n => n !== ns));


### PR DESCRIPTION
### Description

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->
Chip contrast Added filterChipStyles in frontend/src/pages/ObjectFilterPage.tsx  to ensure kind and namespace chips stay legible in light and dark modes.
Auto-refresh toggle Introduced theme-aware autoRefreshSwitchStyles for the header switch so its thumb and track are clearly visible in dark mode.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #2048 

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated ...
- [x] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

https://github.com/user-attachments/assets/1329192b-34d1-47ca-a00b-339ed9dd7b47



### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
