### PR TITLE
Fixed The Return to home Button navigate back to the home page without reloading the entire website.

### DIFF
--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { Home, RefreshCw, Rocket } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 
 const NotFoundPage: React.FC = () => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const [currentQuote, setCurrentQuote] = useState(0);
 
   // Get quotes from translation with fallback
@@ -24,6 +26,10 @@ const NotFoundPage: React.FC = () => {
     }, 5000);
     return () => clearInterval(timer);
   }, [quotes.length]);
+
+  const handleGoHome = () => {
+    navigate('/');
+  };
 
   return (
     <div className="relative flex min-h-screen w-full items-center justify-center overflow-hidden bg-base-200">
@@ -295,7 +301,7 @@ const NotFoundPage: React.FC = () => {
 
         {/* Action Buttons */}
         <div className="flex flex-col justify-center gap-4 sm:flex-row">
-          <button onClick={() => (window.location.href = '/')} className="btn btn-primary">
+          <button onClick={handleGoHome} className="btn btn-primary">
             <Home size={20} />
             {t('notFoundPage.returnHomeButton')}
           </button>


### PR DESCRIPTION
### Description

Fixed The Return to home Button navigate back to the home page without reloading the entire website.

### Related Issue


Fixes #2103 

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

[Screencast From 2025-10-11 20-09-47.webm](https://github.com/user-attachments/assets/69064ac2-c5bc-4ed2-97f9-b130985e3321)

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
