### PR TITLE
fix: css fix

### DIFF
--- a/frontend/src/locales/strings.en.json
+++ b/frontend/src/locales/strings.en.json
@@ -2719,7 +2719,7 @@
     "searchPlaceholder": "Search object kinds...",
     "quickSearchPlaceholder": "Quick search objects...",
     "bulkActions": {
-      "resourcesSelected": "{{count}} object{{count > 1 ? 's' : ''}} selected",
+      "resourcesSelected": "{{count}} {{objectText}} selected",
       "clearSelection": "Clear Selection",
       "viewDetails": "View Details",
       "export": "Export"

--- a/frontend/src/locales/strings.hi.json
+++ b/frontend/src/locales/strings.hi.json
@@ -2714,7 +2714,7 @@
     "searchPlaceholder": "संसाधन प्रकार खोजें...",
     "quickSearchPlaceholder": "संसाधनों को त्वरित खोजें...",
     "bulkActions": {
-      "resourcesSelected": "{{count}} संसाधन चयनित",
+      "resourcesSelected": "{{count}} {{objectText}} चयनित",
       "clearSelection": "चयन साफ़ करें",
       "viewDetails": "विवरण देखें",
       "export": "निर्यात करें"

--- a/frontend/src/pages/ObjectFilterPage.tsx
+++ b/frontend/src/pages/ObjectFilterPage.tsx
@@ -21,7 +21,6 @@ import {
   Tooltip,
   Autocomplete,
   TextField,
-  Badge,
   ToggleButtonGroup,
   ToggleButton,
   Switch,

--- a/frontend/src/pages/ObjectFilterPage.tsx
+++ b/frontend/src/pages/ObjectFilterPage.tsx
@@ -1024,7 +1024,10 @@ const ObjectFilterPage: React.FC = () => {
         >
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
             <Typography variant="body1" sx={{ fontWeight: 600 }}>
-              {t('resources.bulkActions.resourcesSelected', { count: selectedResources.length })}
+              {t('resources.bulkActions.resourcesSelected', {
+                count: selectedResources.length,
+                objectText: selectedResources.length === 1 ? 'object' : 'objects',
+              })}
             </Typography>
             <Button
               variant="outlined"

--- a/frontend/src/pages/ObjectFilterPage.tsx
+++ b/frontend/src/pages/ObjectFilterPage.tsx
@@ -1110,27 +1110,15 @@ const ObjectFilterPage: React.FC = () => {
             >
               {t('resources.results')}
             </Typography>
-            <Badge
-              badgeContent={resources.length}
-              color="primary"
+            <Chip
+              label={`${resources.length} object${resources.length !== 1 ? 's' : ''}`}
+              size="small"
               sx={{
-                '& .MuiBadge-badge': {
-                  backgroundColor: isDark ? darkTheme.brand.primary : lightTheme.brand.primary,
-                  color: '#ffffff',
-                  fontWeight: 600,
-                },
+                backgroundColor: isDark ? 'rgba(59, 130, 246, 0.2)' : 'rgba(59, 130, 246, 0.1)',
+                color: isDark ? darkTheme.brand.primaryLight : darkTheme.brand.primary,
+                fontWeight: 600,
               }}
-            >
-              <Chip
-                label={`${resources.length} object${resources.length !== 1 ? 's' : ''}`}
-                size="small"
-                sx={{
-                  backgroundColor: isDark ? 'rgba(59, 130, 246, 0.2)' : 'rgba(59, 130, 246, 0.1)',
-                  color: isDark ? darkTheme.brand.primaryLight : darkTheme.brand.primary,
-                  fontWeight: 600,
-                }}
-              />
-            </Badge>
+            />
           </Box>
 
           {resources.length > 0 && (


### PR DESCRIPTION
### Description

Fixed a text rendering issue in the resource selection banner where JavaScript template literal syntax was being displayed as plain text instead of being evaluated. The selection banner was showing `"1 object{{count > 1 ? 's' : ''}} selected"` instead of properly rendering as `"1 object selected"` or `"2 objects selected"`.

Fixes #2097 

- After Fix: 

https://github.com/user-attachments/assets/d585012e-f460-45d2-971a-94a817c3f194




### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated `frontend/src/locales/strings.en.json` to use interpolation variable `{{objectText}}` instead of inline ternary expression
- [x] Updated `frontend/src/locales/strings.hi.json` to match the new translation pattern
- [x] Refactored `frontend/src/pages/ObjectFilterPage.tsx` to pass the correct singular/plural form through the `objectText` parameter
- [x] Fixed the selection banner to properly display "object" (singular) or "objects" (plural) based on selection count

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.
