### PR TITLE
fix: added pagination in explore page

### DIFF
--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -1,0 +1,179 @@
+import { Box, Button, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { darkTheme, lightTheme } from '../lib/theme-utils';
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  itemsPerPage: number;
+  totalItems: number;
+  onPageChange: (page: number) => void;
+  isDark: boolean;
+}
+
+const Pagination = ({
+  currentPage,
+  totalPages,
+  itemsPerPage,
+  totalItems,
+  onPageChange,
+  isDark,
+}: PaginationProps) => {
+  const { t } = useTranslation();
+
+  // Don't render if no items or only one page
+  if (totalItems === 0 || totalPages <= 1) return null;
+
+  const startItem = (currentPage - 1) * itemsPerPage + 1;
+  const endItem = Math.min(currentPage * itemsPerPage, totalItems);
+
+  return (
+    <Box
+      sx={{
+        mt: 4,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        gap: 2,
+        flexWrap: 'wrap',
+      }}
+    >
+      <Button
+        disabled={currentPage === 1}
+        onClick={() => onPageChange(currentPage - 1)}
+        variant="outlined"
+        sx={{
+          color:
+            currentPage === 1
+              ? isDark
+                ? 'rgba(255, 255, 255, 0.3)'
+                : 'rgba(0, 0, 0, 0.26)'
+              : isDark
+                ? darkTheme.brand.primary
+                : lightTheme.brand.primary,
+          borderColor:
+            currentPage === 1
+              ? isDark
+                ? 'rgba(255, 255, 255, 0.3)'
+                : 'rgba(0, 0, 0, 0.26)'
+              : isDark
+                ? darkTheme.brand.primary
+                : lightTheme.brand.primary,
+          backgroundColor:
+            isDark && currentPage !== 1 ? 'rgba(59, 130, 246, 0.1)' : 'transparent',
+          '&:hover': {
+            borderColor:
+              currentPage !== 1
+                ? isDark
+                  ? darkTheme.brand.primaryLight
+                  : lightTheme.brand.primaryLight
+                : undefined,
+            backgroundColor: isDark ? 'rgba(59, 130, 246, 0.2)' : 'rgba(59, 130, 246, 0.1)',
+          },
+          textTransform: 'none',
+          fontWeight: 600,
+          px: 3,
+          py: 1,
+          borderRadius: '10px',
+        }}
+      >
+        {t('common.previous')}
+      </Button>
+
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            px: 2,
+            py: 1,
+            backgroundColor: isDark ? 'rgba(59, 130, 246, 0.1)' : 'rgba(59, 130, 246, 0.05)',
+            borderRadius: '10px',
+            border: `1px solid ${isDark ? 'rgba(59, 130, 246, 0.2)' : 'rgba(59, 130, 246, 0.1)'}`,
+          }}
+        >
+          <Typography
+            sx={{
+              color: isDark ? darkTheme.text.secondary : lightTheme.text.secondary,
+              fontSize: '0.9rem',
+              mr: 0.5,
+            }}
+          >
+            {t('common.page')}
+          </Typography>
+          <Typography
+            sx={{
+              color: isDark ? darkTheme.brand.primary : lightTheme.brand.primary,
+              fontWeight: 600,
+              fontSize: '1.1rem',
+              mx: 0.5,
+            }}
+          >
+            {currentPage}
+          </Typography>
+          <Typography
+            sx={{
+              color: isDark ? darkTheme.text.secondary : lightTheme.text.secondary,
+              fontSize: '0.9rem',
+            }}
+          >
+            {t('common.of')} {totalPages}
+          </Typography>
+        </Box>
+        <Typography
+          sx={{
+            color: isDark ? darkTheme.text.secondary : lightTheme.text.secondary,
+            fontSize: '0.9rem',
+          }}
+        >
+          {`Showing ${startItem}-${endItem} of ${totalItems} ${totalItems === 1 ? 'item' : 'items'}`}
+        </Typography>
+      </Box>
+
+      <Button
+        disabled={currentPage === totalPages}
+        onClick={() => onPageChange(currentPage + 1)}
+        variant="outlined"
+        sx={{
+          color:
+            currentPage === totalPages
+              ? isDark
+                ? 'rgba(255, 255, 255, 0.3)'
+                : 'rgba(0, 0, 0, 0.26)'
+              : isDark
+                ? darkTheme.brand.primary
+                : lightTheme.brand.primary,
+          borderColor:
+            currentPage === totalPages
+              ? isDark
+                ? 'rgba(255, 255, 255, 0.3)'
+                : 'rgba(0, 0, 0, 0.26)'
+              : isDark
+                ? darkTheme.brand.primary
+                : lightTheme.brand.primary,
+          backgroundColor:
+            isDark && currentPage !== totalPages ? 'rgba(59, 130, 246, 0.1)' : 'transparent',
+          '&:hover': {
+            borderColor:
+              currentPage !== totalPages
+                ? isDark
+                  ? darkTheme.brand.primaryLight
+                  : lightTheme.brand.primaryLight
+                : undefined,
+            backgroundColor: isDark ? 'rgba(59, 130, 246, 0.2)' : 'rgba(59, 130, 246, 0.1)',
+          },
+          textTransform: 'none',
+          fontWeight: 600,
+          px: 3,
+          py: 1,
+          borderRadius: '10px',
+        }}
+      >
+        {t('common.next')}
+      </Button>
+    </Box>
+  );
+};
+
+export default Pagination;

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -59,8 +59,7 @@ const Pagination = ({
               : isDark
                 ? darkTheme.brand.primary
                 : lightTheme.brand.primary,
-          backgroundColor:
-            isDark && currentPage !== 1 ? 'rgba(59, 130, 246, 0.1)' : 'transparent',
+          backgroundColor: isDark && currentPage !== 1 ? 'rgba(59, 130, 246, 0.1)' : 'transparent',
           '&:hover': {
             borderColor:
               currentPage !== 1

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -126,7 +126,7 @@ const Pagination = ({
             fontSize: '0.9rem',
           }}
         >
-          {t('resources.pagination.showing', {
+          {t('workloads.pagination.showing', {
             from: startItem,
             to: endItem,
             total: totalItems,

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -126,7 +126,12 @@ const Pagination = ({
             fontSize: '0.9rem',
           }}
         >
-          {`Showing ${startItem}-${endItem} of ${totalItems} ${totalItems === 1 ? 'item' : 'items'}`}
+          {t('resources.pagination.showing', {
+            from: startItem,
+            to: endItem,
+            total: totalItems,
+          })}{' '}
+          {totalItems === 1 ? 'item' : 'items'}
         </Typography>
       </Box>
 

--- a/frontend/src/pages/ObjectFilterPage.tsx
+++ b/frontend/src/pages/ObjectFilterPage.tsx
@@ -142,7 +142,7 @@ const ObjectFilterPage: React.FC = () => {
   const [actionMenuAnchor, setActionMenuAnchor] = useState<null | HTMLElement>(null);
   const [selectedResourceForAction, setSelectedResourceForAction] = useState<Resource | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
-  const [itemsPerPage, setItemsPerPage] = useState(10);
+  const itemsPerPage = 9;
 
   const availableResourceKinds = useMemo(
     () => resourceKinds.filter(kind => kind.kind.toLowerCase() !== 'binding'),

--- a/frontend/src/pages/ObjectFilterPage.tsx
+++ b/frontend/src/pages/ObjectFilterPage.tsx
@@ -141,6 +141,8 @@ const ObjectFilterPage: React.FC = () => {
   const [autoRefresh, setAutoRefresh] = useState(false);
   const [actionMenuAnchor, setActionMenuAnchor] = useState<null | HTMLElement>(null);
   const [selectedResourceForAction, setSelectedResourceForAction] = useState<Resource | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [itemsPerPage, setItemsPerPage] = useState(10);
 
   const availableResourceKinds = useMemo(
     () => resourceKinds.filter(kind => kind.kind.toLowerCase() !== 'binding'),
@@ -378,6 +380,19 @@ const ObjectFilterPage: React.FC = () => {
     }));
   }, [derivedResources]);
 
+  // Pagination calculations
+  const totalPages = Math.ceil(derivedResources.length / itemsPerPage);
+  const paginatedResources = useMemo(() => {
+    const startIndex = (currentPage - 1) * itemsPerPage;
+    const endIndex = startIndex + itemsPerPage;
+    return derivedResources.slice(startIndex, endIndex);
+  }, [derivedResources, currentPage, itemsPerPage]);
+
+  // Reset to page 1 when filters change
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [selectedKinds, selectedNamespaces, resourceFilters, quickSearchQuery]);
+
   const filterChipStyles = useMemo(
     () => ({
       fontWeight: 600,
@@ -522,6 +537,161 @@ const ObjectFilterPage: React.FC = () => {
 
   const toggleFilters = () => {
     setShowFilters(!showFilters);
+  };
+
+  // Reusable pagination component
+  const renderPagination = () => {
+    if (derivedResources.length === 0) return null;
+
+    return (
+      <Box
+        sx={{
+          mt: 4,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          gap: 2,
+          flexWrap: 'wrap',
+        }}
+      >
+        <Button
+          disabled={currentPage === 1}
+          onClick={() => setCurrentPage(currentPage - 1)}
+          variant="outlined"
+          sx={{
+            color:
+              currentPage === 1
+                ? isDark
+                  ? 'rgba(255, 255, 255, 0.3)'
+                  : 'rgba(0, 0, 0, 0.26)'
+                : isDark
+                  ? darkTheme.brand.primary
+                  : lightTheme.brand.primary,
+            borderColor:
+              currentPage === 1
+                ? isDark
+                  ? 'rgba(255, 255, 255, 0.3)'
+                  : 'rgba(0, 0, 0, 0.26)'
+                : isDark
+                  ? darkTheme.brand.primary
+                  : lightTheme.brand.primary,
+            backgroundColor:
+              isDark && currentPage !== 1 ? 'rgba(59, 130, 246, 0.1)' : 'transparent',
+            '&:hover': {
+              borderColor:
+                currentPage !== 1
+                  ? isDark
+                    ? darkTheme.brand.primaryLight
+                    : lightTheme.brand.primaryLight
+                  : undefined,
+              backgroundColor: isDark ? 'rgba(59, 130, 246, 0.2)' : 'rgba(59, 130, 246, 0.1)',
+            },
+            textTransform: 'none',
+            fontWeight: 600,
+            px: 3,
+            py: 1,
+            borderRadius: '10px',
+          }}
+        >
+          {t('common.previous')}
+        </Button>
+
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              px: 2,
+              py: 1,
+              backgroundColor: isDark ? 'rgba(59, 130, 246, 0.1)' : 'rgba(59, 130, 246, 0.05)',
+              borderRadius: '10px',
+              border: `1px solid ${isDark ? 'rgba(59, 130, 246, 0.2)' : 'rgba(59, 130, 246, 0.1)'}`,
+            }}
+          >
+            <Typography
+              sx={{
+                color: isDark ? darkTheme.text.secondary : lightTheme.text.secondary,
+                fontSize: '0.9rem',
+                mr: 0.5,
+              }}
+            >
+              {t('common.page')}
+            </Typography>
+            <Typography
+              sx={{
+                color: isDark ? darkTheme.brand.primary : lightTheme.brand.primary,
+                fontWeight: 600,
+                fontSize: '1.1rem',
+                mx: 0.5,
+              }}
+            >
+              {currentPage}
+            </Typography>
+            <Typography
+              sx={{
+                color: isDark ? darkTheme.text.secondary : lightTheme.text.secondary,
+                fontSize: '0.9rem',
+              }}
+            >
+              {t('common.of')} {totalPages}
+            </Typography>
+          </Box>
+          <Typography
+            sx={{
+              color: isDark ? darkTheme.text.secondary : lightTheme.text.secondary,
+              fontSize: '0.9rem',
+            }}
+          >
+            {t(derivedResources.length === 1 ? 'common.items' : 'common.items_plural', {
+              count: derivedResources.length,
+            })}
+          </Typography>
+        </Box>
+
+        <Button
+          disabled={currentPage === totalPages}
+          onClick={() => setCurrentPage(currentPage + 1)}
+          variant="outlined"
+          sx={{
+            color:
+              currentPage === totalPages
+                ? isDark
+                  ? 'rgba(255, 255, 255, 0.3)'
+                  : 'rgba(0, 0, 0, 0.26)'
+                : isDark
+                  ? darkTheme.brand.primary
+                  : lightTheme.brand.primary,
+            borderColor:
+              currentPage === totalPages
+                ? isDark
+                  ? 'rgba(255, 255, 255, 0.3)'
+                  : 'rgba(0, 0, 0, 0.26)'
+                : isDark
+                  ? darkTheme.brand.primary
+                  : lightTheme.brand.primary,
+            backgroundColor:
+              isDark && currentPage !== totalPages ? 'rgba(59, 130, 246, 0.1)' : 'transparent',
+            '&:hover': {
+              borderColor:
+                currentPage !== totalPages
+                  ? isDark
+                    ? darkTheme.brand.primaryLight
+                    : lightTheme.brand.primaryLight
+                  : undefined,
+              backgroundColor: isDark ? 'rgba(59, 130, 246, 0.2)' : 'rgba(59, 130, 246, 0.1)',
+            },
+            textTransform: 'none',
+            fontWeight: 600,
+            px: 3,
+            py: 1,
+            borderRadius: '10px',
+          }}
+        >
+          {t('common.next')}
+        </Button>
+      </Box>
+    );
   };
 
   useEffect(() => {
@@ -1239,189 +1409,203 @@ const ObjectFilterPage: React.FC = () => {
 
               {/* Grid View */}
               {viewMode === 'grid' && (
-                <Grid container spacing={3}>
-                  {derivedResources.map(resource => {
-                    const uid =
-                      resource.metadata?.uid || `${resource.kind}-${resource.metadata?.name}`;
-                    const isSelected = selectedResources.some(r => r.uid === uid);
+                <>
+                  <Grid container spacing={3}>
+                    {paginatedResources.map(resource => {
+                      const uid =
+                        resource.metadata?.uid || `${resource.kind}-${resource.metadata?.name}`;
+                      const isSelected = selectedResources.some(r => r.uid === uid);
 
-                    return (
-                      <Grid item xs={12} sm={6} lg={4} key={uid}>
-                        <ResourceCard
-                          resource={resource}
-                          isSelected={isSelected}
-                          isDark={isDark}
-                          onSelect={handleResourceSelect}
-                          onViewDetails={resource => handleResourceAction(resource, 'view')}
-                          onActionClick={(e, resource) => {
-                            setSelectedResourceForAction(resource);
-                            setActionMenuAnchor(e.currentTarget);
-                          }}
-                        />
-                      </Grid>
-                    );
-                  })}
-                </Grid>
+                      return (
+                        <Grid item xs={12} sm={6} lg={4} key={uid}>
+                          <ResourceCard
+                            resource={resource}
+                            isSelected={isSelected}
+                            isDark={isDark}
+                            onSelect={handleResourceSelect}
+                            onViewDetails={resource => handleResourceAction(resource, 'view')}
+                            onActionClick={(e, resource) => {
+                              setSelectedResourceForAction(resource);
+                              setActionMenuAnchor(e.currentTarget);
+                            }}
+                          />
+                        </Grid>
+                      );
+                    })}
+                  </Grid>
+
+                  {/* Pagination */}
+                  {renderPagination()}
+                </>
               )}
 
               {/* List View */}
               {viewMode === 'list' && (
-                <Box sx={{ mt: 2 }}>
-                  {derivedResources.map(resource => {
-                    const statusColors = getStatusColor(resource.displayStatus);
-                    const uid =
-                      resource.metadata?.uid || `${resource.kind}-${resource.metadata?.name}`;
-                    const isSelected = selectedResources.some(r => r.uid === uid);
+                <>
+                  <Box sx={{ mt: 2 }}>
+                    {paginatedResources.map(resource => {
+                      const statusColors = getStatusColor(resource.displayStatus);
+                      const uid =
+                        resource.metadata?.uid || `${resource.kind}-${resource.metadata?.name}`;
+                      const isSelected = selectedResources.some(r => r.uid === uid);
 
-                    return (
-                      <Paper
-                        key={uid}
-                        elevation={0}
-                        sx={{
-                          mb: 1,
-                          p: 2,
-                          backgroundColor: isDark
-                            ? darkTheme.bg.secondary
-                            : lightTheme.bg.secondary,
-                          border: `1px solid ${isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.1)'}`,
-                          borderRadius: '12px',
-                          cursor: 'pointer',
-                          transition: 'all 0.2s ease',
-                          position: 'relative',
-                          '&:hover': {
-                            backgroundColor: isDark
-                              ? 'rgba(59, 130, 246, 0.05)'
-                              : 'rgba(59, 130, 246, 0.02)',
-                            border: `1px solid ${isDark ? darkTheme.brand.primaryLight : lightTheme.brand.primary}`,
-                          },
-                        }}
-                        onClick={() => handleResourceSelect(resource)}
-                      >
-                        <Box
+                      return (
+                        <Paper
+                          key={uid}
+                          elevation={0}
                           sx={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'space-between',
+                            mb: 1,
+                            p: 2,
+                            backgroundColor: isDark
+                              ? darkTheme.bg.secondary
+                              : lightTheme.bg.secondary,
+                            border: `1px solid ${isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.1)'}`,
+                            borderRadius: '12px',
+                            cursor: 'pointer',
+                            transition: 'all 0.2s ease',
+                            position: 'relative',
+                            '&:hover': {
+                              backgroundColor: isDark
+                                ? 'rgba(59, 130, 246, 0.05)'
+                                : 'rgba(59, 130, 246, 0.02)',
+                              border: `1px solid ${isDark ? darkTheme.brand.primaryLight : lightTheme.brand.primary}`,
+                            },
                           }}
+                          onClick={() => handleResourceSelect(resource)}
                         >
-                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flex: 1 }}>
-                            <Box>
-                              <Typography
-                                variant="h6"
-                                sx={{
-                                  color: isDark ? darkTheme.text.primary : lightTheme.text.primary,
-                                  fontWeight: 600,
-                                  fontSize: '1rem',
-                                }}
-                              >
-                                {resource.displayName}
-                              </Typography>
-                              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 0.5 }}>
-                                <Chip
-                                  label={resource.kind}
-                                  size="small"
+                          <Box
+                            sx={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'space-between',
+                            }}
+                          >
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flex: 1 }}>
+                              <Box>
+                                <Typography
+                                  variant="h6"
                                   sx={{
-                                    backgroundColor: isDark
-                                      ? 'rgba(59, 130, 246, 0.2)'
-                                      : 'rgba(59, 130, 246, 0.1)',
                                     color: isDark
-                                      ? darkTheme.brand.primaryLight
-                                      : darkTheme.brand.primary,
+                                      ? darkTheme.text.primary
+                                      : lightTheme.text.primary,
                                     fontWeight: 600,
+                                    fontSize: '1rem',
                                   }}
-                                />
-                                {resource.displayNamespace && (
+                                >
+                                  {resource.displayName}
+                                </Typography>
+                                <Box
+                                  sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 0.5 }}
+                                >
                                   <Chip
-                                    label={resource.displayNamespace}
+                                    label={resource.kind}
                                     size="small"
-                                    variant="outlined"
                                     sx={{
-                                      borderColor: isDark
-                                        ? 'rgba(255, 255, 255, 0.23)'
-                                        : 'rgba(0, 0, 0, 0.23)',
+                                      backgroundColor: isDark
+                                        ? 'rgba(59, 130, 246, 0.2)'
+                                        : 'rgba(59, 130, 246, 0.1)',
                                       color: isDark
-                                        ? darkTheme.text.secondary
-                                        : lightTheme.text.secondary,
-                                    }}
-                                  />
-                                )}
-                                {resource.displayStatus && (
-                                  <Chip
-                                    label={resource.displayStatus}
-                                    size="small"
-                                    sx={{
-                                      backgroundColor: statusColors.bg,
-                                      color: statusColors.color,
+                                        ? darkTheme.brand.primaryLight
+                                        : darkTheme.brand.primary,
                                       fontWeight: 600,
                                     }}
                                   />
-                                )}
+                                  {resource.displayNamespace && (
+                                    <Chip
+                                      label={resource.displayNamespace}
+                                      size="small"
+                                      variant="outlined"
+                                      sx={{
+                                        borderColor: isDark
+                                          ? 'rgba(255, 255, 255, 0.23)'
+                                          : 'rgba(0, 0, 0, 0.23)',
+                                        color: isDark
+                                          ? darkTheme.text.secondary
+                                          : lightTheme.text.secondary,
+                                      }}
+                                    />
+                                  )}
+                                  {resource.displayStatus && (
+                                    <Chip
+                                      label={resource.displayStatus}
+                                      size="small"
+                                      sx={{
+                                        backgroundColor: statusColors.bg,
+                                        color: statusColors.color,
+                                        fontWeight: 600,
+                                      }}
+                                    />
+                                  )}
+                                </Box>
                               </Box>
                             </Box>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                              <Button
+                                size="small"
+                                startIcon={<VisibilityIcon />}
+                                onClick={e => {
+                                  e.stopPropagation();
+                                  handleResourceAction(resource, 'view');
+                                }}
+                                sx={{
+                                  color: isDark
+                                    ? darkTheme.brand.primaryLight
+                                    : lightTheme.brand.primary,
+                                }}
+                              >
+                                {t('resources.actions.view')}
+                              </Button>
+                              <IconButton
+                                size="small"
+                                onClick={e => {
+                                  e.stopPropagation();
+                                  setSelectedResourceForAction(resource);
+                                  setActionMenuAnchor(e.currentTarget);
+                                }}
+                                sx={{
+                                  color: isDark
+                                    ? darkTheme.text.secondary
+                                    : lightTheme.text.secondary,
+                                }}
+                              >
+                                <MoreVertIcon fontSize="small" />
+                              </IconButton>
+                            </Box>
                           </Box>
-                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                            <Button
-                              size="small"
-                              startIcon={<VisibilityIcon />}
-                              onClick={e => {
-                                e.stopPropagation();
-                                handleResourceAction(resource, 'view');
-                              }}
+                          {/* Selection indicator */}
+                          {isSelected && (
+                            <Box
                               sx={{
-                                color: isDark
-                                  ? darkTheme.brand.primaryLight
+                                position: 'absolute',
+                                top: 8,
+                                left: 8,
+                                width: 20,
+                                height: 20,
+                                borderRadius: '50%',
+                                backgroundColor: isDark
+                                  ? darkTheme.brand.primary
                                   : lightTheme.brand.primary,
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
                               }}
                             >
-                              {t('resources.actions.view')}
-                            </Button>
-                            <IconButton
-                              size="small"
-                              onClick={e => {
-                                e.stopPropagation();
-                                setSelectedResourceForAction(resource);
-                                setActionMenuAnchor(e.currentTarget);
-                              }}
-                              sx={{
-                                color: isDark
-                                  ? darkTheme.text.secondary
-                                  : lightTheme.text.secondary,
-                              }}
-                            >
-                              <MoreVertIcon fontSize="small" />
-                            </IconButton>
-                          </Box>
-                        </Box>
-                        {/* Selection indicator */}
-                        {isSelected && (
-                          <Box
-                            sx={{
-                              position: 'absolute',
-                              top: 8,
-                              left: 8,
-                              width: 20,
-                              height: 20,
-                              borderRadius: '50%',
-                              backgroundColor: isDark
-                                ? darkTheme.brand.primary
-                                : lightTheme.brand.primary,
-                              display: 'flex',
-                              alignItems: 'center',
-                              justifyContent: 'center',
-                            }}
-                          >
-                            <Typography
-                              variant="caption"
-                              sx={{ color: '#ffffff', fontSize: '0.7rem', fontWeight: 'bold' }}
-                            >
-                              ✓
-                            </Typography>
-                          </Box>
-                        )}
-                      </Paper>
-                    );
-                  })}
-                </Box>
+                              <Typography
+                                variant="caption"
+                                sx={{ color: '#ffffff', fontSize: '0.7rem', fontWeight: 'bold' }}
+                              >
+                                ✓
+                              </Typography>
+                            </Box>
+                          )}
+                        </Paper>
+                      );
+                    })}
+                  </Box>
+
+                  {/* Pagination */}
+                  {renderPagination()}
+                </>
               )}
 
               {/* Table View */}
@@ -1496,7 +1680,7 @@ const ObjectFilterPage: React.FC = () => {
                       </TableRow>
                     </TableHead>
                     <TableBody>
-                      {derivedResources.map(resource => {
+                      {paginatedResources.map(resource => {
                         const resourceStatus =
                           typeof resource.status === 'string'
                             ? resource.status === 'Running' || resource.status === 'Active'
@@ -1646,6 +1830,9 @@ const ObjectFilterPage: React.FC = () => {
                   </Table>
                 </TableContainer>
               )}
+
+              {/* Pagination */}
+              {viewMode === 'table' && renderPagination()}
             </Box>
           ) : (
             /* Enhanced Empty State */

--- a/frontend/src/pages/ObjectFilterPage.tsx
+++ b/frontend/src/pages/ObjectFilterPage.tsx
@@ -162,31 +162,10 @@ const ObjectFilterPage: React.FC = () => {
   );
 
   const displayResources = useMemo<Resource[]>(() => {
-    // TEMPORARY: Add 20 demo resources for testing pagination
-    const demoResources: Resource[] = Array.from({ length: 20 }, (_, i) => ({
-      kind: ['Pod', 'Deployment', 'Service', 'ConfigMap'][i % 4],
-      apiVersion: 'v1',
-      metadata: {
-        name: `demo-resource-${String(i + 1).padStart(2, '0')}`,
-        namespace: ['default', 'kube-system', 'production'][i % 3],
-        uid: `demo-uid-${i + 1}`,
-        creationTimestamp: new Date(Date.now() - i * 86400000).toISOString(),
-        labels: {
-          app: `demo-app-${(i % 5) + 1}`,
-          env: ['dev', 'staging', 'prod'][i % 3],
-        },
-      },
-      status: ['running', 'pending', 'succeeded', 'active'][i % 4],
-      labels: {
-        app: `demo-app-${(i % 5) + 1}`,
-        env: ['dev', 'staging', 'prod'][i % 3],
-      },
-    }));
-
     if (filteredResources && Array.isArray(filteredResources)) {
-      return [...demoResources, ...((filteredResources as unknown as Resource[]) || [])];
+      return [...((filteredResources as unknown as Resource[]) || [])];
     }
-    return demoResources;
+    return [];
   }, [filteredResources]);
 
   const derivedResources = useMemo<DerivedResource[]>(() => {
@@ -1030,7 +1009,21 @@ const ObjectFilterPage: React.FC = () => {
         </Paper>
       </Collapse>
 
-      {/* Error Display - TEMPORARY: Hidden for testing */}
+      {/* Error Display */}
+      {error && (
+        <Alert
+          severity="error"
+          variant="filled"
+          sx={{
+            mb: 3,
+            backgroundColor: isDark ? 'rgba(211, 47, 47, 0.9)' : undefined,
+            borderRadius: '12px',
+            boxShadow: isDark ? darkTheme.shadow.md : lightTheme.shadow.md,
+          }}
+        >
+          {error as string}
+        </Alert>
+      )}
 
       {/* Bulk Actions Bar */}
       {selectedResources.length > 0 && (


### PR DESCRIPTION
### Description

Added pagination functionality to the Object Explorer page (`/resources`) to improve performance and user experience when viewing large numbers of Kubernetes resources. Previously, all resources were displayed on a single page, which could lead to performance issues and poor UX with hundreds of objects. Now, resources are paginated with 10 items per page, making it easier to browse and navigate through resources.

The pagination implementation follows the existing design patterns used in the codebase (specifically `BPPagination.tsx`) and includes smooth navigation controls with proper styling for both light and dark themes.

### Related Issue

Fixes #2124 

### Video after fix:


https://github.com/user-attachments/assets/45de60fb-41a5-485e-9dd1-6b1c049328f9



### Changes Made

- [x] Added pagination state management (`currentPage`, `itemsPerPage`) to ObjectFilterPage
- [x] Implemented pagination calculation logic using `useMemo` for performance optimization
- [x] Created reusable `renderPagination()` function to avoid code duplication across view modes
- [x] Added auto-reset functionality that resets to page 1 when filters change
- [x] Integrated pagination UI in all three view modes (Grid, List, and Table views)
- [x] Applied consistent styling matching the existing `BPPagination` component design
- [x] Used existing i18n translation keys (`common.previous`, `common.next`, `common.page`, etc.)

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

