### PR TITLE
fix: [Bug]: It allows other extension files to upload

### DIFF
--- a/frontend/src/components/CreateOptions.tsx
+++ b/frontend/src/components/CreateOptions.tsx
@@ -838,10 +838,7 @@ spec:
     e.preventDefault();
     e.currentTarget.style.borderColor = '#bdbdbd';
     const file = e.dataTransfer.files?.[0] || null;
-    if (
-      file &&
-      (file.name.endsWith('.yaml') || file.name.endsWith('.yml'))
-    ) {
+    if (file && (file.name.endsWith('.yaml') || file.name.endsWith('.yml'))) {
       setSelectedFile(file);
     } else {
       toast.error(t('workloads.createOptions.file.invalidFile'));

--- a/frontend/src/components/CreateOptions.tsx
+++ b/frontend/src/components/CreateOptions.tsx
@@ -840,7 +840,7 @@ spec:
     const file = e.dataTransfer.files?.[0] || null;
     if (
       file &&
-      (file.name.endsWith('.yaml') || file.name.endsWith('.yml') || file.name.endsWith('.json'))
+      (file.name.endsWith('.yaml') || file.name.endsWith('.yml'))
     ) {
       setSelectedFile(file);
     } else {

--- a/frontend/src/components/workloads/UploadFileTab.tsx
+++ b/frontend/src/components/workloads/UploadFileTab.tsx
@@ -304,7 +304,7 @@ export const UploadFileTab = ({
               <input
                 type="file"
                 hidden
-                accept=".yaml,.yml,.json"
+                accept=".yaml,.yml"
                 onClick={e => (e.currentTarget.value = '')}
                 onChange={handleFileChange}
               />


### PR DESCRIPTION
### Description

This PR fixes a bug where the file upload component was accepting any file extension, including unsupported formats like `.json`. The backend's `UploadYAMLFile` handler only supports YAML files through the `parseYAMLFile()` function, which uses `yaml.NewDecoder`. Users were able to select and upload `.json` files, which would always fail with an "invalid YAML file format" error, causing confusion and frustration.

This fix restricts file uploads to only `.yaml` and `.yml` extensions, aligning the frontend validation with the backend's actual capabilities.


Fixes #2140 

### Changes Made

- [x] Updated file input `accept` attribute in `UploadFileTab.tsx` to only allow `.yaml` and `.yml` files
- [x] Fixed drag-and-drop validation in `CreateOptions.tsx` to reject `.json` files
- [x] Removed `.json` from file extension validation to prevent upload failures

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.
