### PR TITLE
Update monitoring configurations and frontend components

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/kubestellar/kubestellar v0.26.0
 	github.com/lib/pq v1.10.9
 	github.com/prometheus/client_golang v1.22.0
-	github.com/prometheus/client_model v0.6.1
 	github.com/redis/go-redis/v9 v9.7.3
 	github.com/stretchr/testify v1.10.0
 	github.com/tetratelabs/wazero v1.9.0
@@ -126,6 +125,7 @@ require (
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rubenv/sql-migrate v1.8.0 // indirect

--- a/backend/monitoring/prometheus/prometheus.yml/config.yml
+++ b/backend/monitoring/prometheus/prometheus.yml/config.yml
@@ -4,5 +4,5 @@ global:
 scrape_configs:
   - job_name: prometheus
     static_configs:
-      - targets: ["host.docker.internal:4000"]
+      - targets: ["172.27.1.1:4000"]
     metrics_path: /api/v1/metrics

--- a/frontend/public/mockServiceWorker.js
+++ b/frontend/public/mockServiceWorker.js
@@ -7,7 +7,7 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.11.3'
+const PACKAGE_VERSION = '2.11.2'
 const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/frontend/src/pages/GrafanaDashboardPage.tsx
+++ b/frontend/src/pages/GrafanaDashboardPage.tsx
@@ -5,7 +5,7 @@ const GrafanaDashboardPage: React.FC = () => {
     <div className="p-4">
       <h1 className="mb-4 text-2xl font-bold">Grafana Dashboard</h1>
       <iframe
-        src="http://localhost:3000/d/kubestellar-overview/kubestellar-ui-overview?orgId=1&from=now-1h&to=now&timezone=browser&refresh=30s"
+        src="http://localhost:13000/d/kubestellar-overview/kubestellar-ui-overview?orgId=1&from=now-1h&to=now&timezone=browser&refresh=30s"
         width="100%"
         height="800"
         className="border-0"

--- a/monitoring/grafana/datasources/prometheus.yml
+++ b/monitoring/grafana/datasources/prometheus.yml
@@ -5,7 +5,7 @@ datasources:
     name: Prometheus
     type: prometheus
     access: proxy
-    url: http://localhost:19090
+    url: http://172.27.1.2:19090
     isDefault: true
     editable: true
     jsonData:


### PR DESCRIPTION
This pull request updates several configuration files to support new network addresses and ports for monitoring services, and makes minor dependency and version adjustments. The most important changes are grouped below.

**Monitoring configuration updates:**

* Updated the Prometheus scrape target in `backend/monitoring/prometheus/prometheus.yml/config.yml` from `host.docker.internal:4000` to `172.27.1.1:4000` to reflect the new network setup.
* Changed the Prometheus data source URL in `monitoring/grafana/datasources/prometheus.yml` from `http://localhost:19090` to `http://172.27.1.2:19090` for Grafana integration.
* Updated the Grafana dashboard iframe source in `frontend/src/pages/GrafanaDashboardPage.tsx` to use port `13000` instead of `3000`.

**Dependency and version management:**

* Adjusted the `github.com/prometheus/client_model` dependency in `backend/go.mod` from direct to indirect, moving its declaration accordingly. [[1]](diffhunk://#diff-10e03f00c5bf8508d67e327c7a19879247498e8392ec699e9a05afcd36a8ed1fL22) [[2]](diffhunk://#diff-10e03f00c5bf8508d67e327c7a19879247498e8392ec699e9a05afcd36a8ed1fR128)
* Downgraded the `PACKAGE_VERSION` in `frontend/public/mockServiceWorker.js` from `2.11.3` to `2.11.2`.


Fixes #2172