### PR TITLE
Enhance Plugin Manager Cards to Clearly Display Active, Inactive, and Total Plugins

### DIFF
--- a/frontend/src/pages/PluginManager.tsx
+++ b/frontend/src/pages/PluginManager.tsx
@@ -311,30 +311,62 @@ export const PluginManager: React.FC = () => {
           ).map((stat, index) => (
             <motion.div
               key={stat.label}
-              className="flex flex-col gap-1 rounded-xl p-4"
+              className="group relative flex cursor-pointer flex-col gap-3 overflow-hidden rounded-2xl p-5"
               style={{
                 background: themeStyles.effects.glassMorphism.background,
                 border: `1px solid ${themeStyles.card.borderColor}`,
+                boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
               }}
               initial={{ opacity: 0, y: 8 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.25, delay: index * 0.05 }}
-              whileHover={{ y: -2 }}
+              whileHover={{
+                y: -4,
+                boxShadow:
+                  '0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)',
+              }}
             >
+              {/* Gradient overlay on hover */}
               <div
-                className="flex h-10 w-10 items-center justify-center rounded-lg"
-                style={{ background: stat.iconBg }}
+                className="absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+                style={{
+                  background: `linear-gradient(135deg, ${stat.iconColor}05 0%, ${stat.iconColor}10 100%)`,
+                }}
+              />
+
+              <div
+                className="relative z-10 flex h-12 w-12 items-center justify-center rounded-xl transition-all duration-300 group-hover:scale-105"
+                style={{
+                  background: stat.iconBg,
+                  boxShadow: '0 0 0 0 transparent',
+                }}
               >
-                <stat.Icon className="h-5 w-5" style={{ color: stat.iconColor }} />
+                <stat.Icon
+                  className="h-6 w-6 transition-transform duration-300 group-hover:scale-110"
+                  style={{ color: stat.iconColor }}
+                />
               </div>
-              <div className="flex flex-col">
-                <span className="text-2xl font-bold" style={{ color: stat.color }}>
+
+              <div className="relative z-10 flex flex-col gap-1">
+                <span
+                  className="origin-left text-3xl font-bold tracking-tight transition-transform duration-300 group-hover:scale-105"
+                  style={{ color: stat.color }}
+                >
                   {stat.value}
                 </span>
-                <span className="text-sm" style={{ color: themeStyles.colors.text.secondary }}>
+                <span
+                  className="text-sm font-medium"
+                  style={{ color: themeStyles.colors.text.secondary }}
+                >
                   {stat.label}
                 </span>
               </div>
+
+              {/* Bottom accent line */}
+              <div
+                className="absolute bottom-0 left-0 h-0.5 w-0 transition-all duration-300 group-hover:w-full"
+                style={{ background: stat.iconColor }}
+              />
             </motion.div>
           ))}
         </div>

--- a/frontend/src/pages/PluginManager.tsx
+++ b/frontend/src/pages/PluginManager.tsx
@@ -271,22 +271,31 @@ export const PluginManager: React.FC = () => {
         </div>
 
         {/* Stats */}
-        <div className="flex gap-4">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
           {[
             {
               label: t('plugins.list.total'),
               value: availablePlugins.length,
               color: themeStyles.colors.text.primary,
+              iconBg: themeStyles.colors.text.secondary + '15',
+              iconColor: themeStyles.colors.text.primary,
+              Icon: HiOutlinePuzzlePiece,
             },
             {
               label: t('plugins.list.active'),
               value: availablePlugins.filter(p => p.enabled).length,
               color: themeStyles.colors.status.success,
+              iconBg: themeStyles.colors.status.success + '20',
+              iconColor: themeStyles.colors.status.success,
+              Icon: HiOutlineCheckCircle,
             },
             {
               label: t('plugins.list.inactive'),
               value: availablePlugins.filter(p => !p.enabled).length,
               color: themeStyles.colors.text.secondary,
+              iconBg: themeStyles.colors.text.secondary + '20',
+              iconColor: themeStyles.colors.text.secondary,
+              Icon: HiOutlinePause,
             },
           ].map((stat, index) => (
             <motion.div
@@ -296,16 +305,25 @@ export const PluginManager: React.FC = () => {
                 background: themeStyles.effects.glassMorphism.background,
                 border: `1px solid ${themeStyles.card.borderColor}`,
               }}
-              initial={{ opacity: 0, scale: 0.9 }}
-              animate={{ opacity: 1, scale: 1 }}
-              transition={{ duration: 0.3, delay: index * 0.1 }}
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.25, delay: index * 0.05 }}
+              whileHover={{ y: -2 }}
             >
-              <span className="text-2xl font-bold" style={{ color: stat.color }}>
-                {stat.value}
-              </span>
-              <span className="text-sm" style={{ color: themeStyles.colors.text.secondary }}>
-                {stat.label}
-              </span>
+              <div
+                className="flex h-10 w-10 items-center justify-center rounded-lg"
+                style={{ background: (stat as any).iconBg }}
+              >
+                <stat.Icon className="h-5 w-5" style={{ color: (stat as any).iconColor }} />
+              </div>
+              <div className="flex flex-col">
+                <span className="text-2xl font-bold" style={{ color: stat.color }}>
+                  {stat.value}
+                </span>
+                <span className="text-sm" style={{ color: themeStyles.colors.text.secondary }}>
+                  {stat.label}
+                </span>
+              </div>
             </motion.div>
           ))}
         </div>

--- a/frontend/src/pages/PluginManager.tsx
+++ b/frontend/src/pages/PluginManager.tsx
@@ -39,6 +39,15 @@ interface Plugin {
   id: number;
 }
 
+interface Stat {
+  label: string;
+  value: number;
+  color: string;
+  iconBg: string;
+  iconColor: string;
+  Icon: React.ComponentType<{ className?: string; style?: React.CSSProperties }>;
+}
+
 export const PluginManager: React.FC = () => {
   const { t } = useTranslation();
   const { theme } = useTheme();
@@ -272,32 +281,34 @@ export const PluginManager: React.FC = () => {
 
         {/* Stats */}
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-          {[
-            {
-              label: t('plugins.list.total'),
-              value: availablePlugins.length,
-              color: themeStyles.colors.text.primary,
-              iconBg: themeStyles.colors.text.secondary + '15',
-              iconColor: themeStyles.colors.text.primary,
-              Icon: HiOutlinePuzzlePiece,
-            },
-            {
-              label: t('plugins.list.active'),
-              value: availablePlugins.filter(p => p.enabled).length,
-              color: themeStyles.colors.status.success,
-              iconBg: themeStyles.colors.status.success + '20',
-              iconColor: themeStyles.colors.status.success,
-              Icon: HiOutlineCheckCircle,
-            },
-            {
-              label: t('plugins.list.inactive'),
-              value: availablePlugins.filter(p => !p.enabled).length,
-              color: themeStyles.colors.text.secondary,
-              iconBg: themeStyles.colors.text.secondary + '20',
-              iconColor: themeStyles.colors.text.secondary,
-              Icon: HiOutlinePause,
-            },
-          ].map((stat, index) => (
+          {(
+            [
+              {
+                label: t('plugins.list.total'),
+                value: availablePlugins.length,
+                color: themeStyles.colors.text.primary,
+                iconBg: themeStyles.colors.text.secondary + '15',
+                iconColor: themeStyles.colors.text.primary,
+                Icon: HiOutlinePuzzlePiece,
+              },
+              {
+                label: t('plugins.list.active'),
+                value: availablePlugins.filter(p => p.enabled).length,
+                color: themeStyles.colors.status.success,
+                iconBg: themeStyles.colors.status.success + '20',
+                iconColor: themeStyles.colors.status.success,
+                Icon: HiOutlineCheckCircle,
+              },
+              {
+                label: t('plugins.list.inactive'),
+                value: availablePlugins.filter(p => !p.enabled).length,
+                color: themeStyles.colors.text.secondary,
+                iconBg: themeStyles.colors.text.secondary + '20',
+                iconColor: themeStyles.colors.text.secondary,
+                Icon: HiOutlinePause,
+              },
+            ] as Stat[]
+          ).map((stat, index) => (
             <motion.div
               key={stat.label}
               className="flex flex-col gap-1 rounded-xl p-4"
@@ -312,9 +323,9 @@ export const PluginManager: React.FC = () => {
             >
               <div
                 className="flex h-10 w-10 items-center justify-center rounded-lg"
-                style={{ background: (stat as any).iconBg }}
+                style={{ background: stat.iconBg }}
               >
-                <stat.Icon className="h-5 w-5" style={{ color: (stat as any).iconColor }} />
+                <stat.Icon className="h-5 w-5" style={{ color: stat.iconColor }} />
               </div>
               <div className="flex flex-col">
                 <span className="text-2xl font-bold" style={{ color: stat.color }}>


### PR DESCRIPTION

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

This update enhances the Plugin Manager Cards by improving their alignment and overall structure. The layout now clearly displays the counts for Active, Inactive, and Total Plugins, ensuring a more organized and visually consistent presentation across all screen sizes.


**Befoure**
<img width="1503" height="817" alt="512102397-1a1ed6e5-c7ff-451e-abd8-6025cef10b3d" src="https://github.com/user-attachments/assets/f0a57655-44e8-45ec-8e44-93db02b90c99" />


**After**

<img width="1605" height="552" alt="Screenshot From 2025-11-09 14-58-42" src="https://github.com/user-attachments/assets/9abcb99e-717c-4e74-a300-649b8e35c861" />


Fixes #2193 

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
