### PR TITLE
fix: Disable/Uninstall action for plugin works as expected

### DIFF
--- a/frontend/src/plugins/PluginLoader.tsx
+++ b/frontend/src/plugins/PluginLoader.tsx
@@ -182,7 +182,8 @@ export const PluginProvider: React.FC<PluginProviderProps> = ({ children }) => {
         // remove plugin routes
         setPluginRoutes(prev => {
           const pluginRoutePaths = plugin.manifest.spec.frontend.navigation.map(
-            item => `${item.path}-${pluginID}`
+            item =>
+              `${item.path}~${plugin.manifest.metadata.author}~${plugin.manifest.metadata.version}`
           );
 
           const newRoutes = prev.filter(item => !pluginRoutePaths.includes(item.path as string));
@@ -192,7 +193,8 @@ export const PluginProvider: React.FC<PluginProviderProps> = ({ children }) => {
         // remove plugin menu items
         setPluginMenuItems(prev => {
           const pluginRoutePaths = plugin.manifest.spec.frontend.navigation.map(
-            item => `${item.path}-${pluginID}`
+            item =>
+              `${item.path}~${plugin.manifest.metadata.author}~${plugin.manifest.metadata.version}`
           );
           const newMenuItems = prev.filter(item => !pluginRoutePaths.includes(item.url));
           return newMenuItems;


### PR DESCRIPTION
### Description
This PR fixes the issue related with menu items for plugin. Menu items for plugin was still there even after uninstalling/disabling plugin. 
Now, plugin menu items/ plugin routes is removed whenever user disable/uninstall plugin. 


<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #2195

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
