### PR TITLE
fIX dashboard issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -179,8 +179,6 @@ services:
       - '--web.enable-lifecycle'
       - '--web.listen-address=0.0.0.0:19090'
     restart: unless-stopped
-    profiles:
-      - monitoring
 
   # Grafana - for visualization
   grafana:
@@ -192,6 +190,7 @@ services:
       - ./monitoring/grafana/dashboards:/etc/grafana/provisioning/dashboards:ro
       - ./monitoring/grafana/datasources:/etc/grafana/provisioning/datasources:ro
     environment:
+      - GF_DATASOURCES_DEFAULT_URL=http://localhost:19090
       - GF_SECURITY_ALLOW_EMBEDDING=true
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-admin}
       - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:-admin}
@@ -200,8 +199,6 @@ services:
     depends_on:
       - prometheus
     restart: unless-stopped
-    profiles:
-      - monitoring
 
   # Node Exporter for system metrics (optional)
   node-exporter:
@@ -217,36 +214,30 @@ services:
       - '--path.sysfs=/host/sys'
       - '--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($$|/)'
     restart: unless-stopped
-    profiles:
-      - monitoring
 
   # PostgreSQL Exporter for database metrics (optional)
   postgres-exporter:
     image: prometheuscommunity/postgres-exporter:latest
     container_name: postgres-exporter
+    network_mode: host
     environment:
       DATA_SOURCE_NAME: "postgresql://authuser:authpass123@localhost:5400/authdbui?sslmode=disable"
-    network_mode: host
     depends_on:
       postgres:
         condition: service_healthy
     restart: unless-stopped
-    profiles:
-      - monitoring
 
   # Redis Exporter for Redis metrics (optional)
   redis-exporter:
     image: oliver006/redis_exporter:latest
     container_name: redis-exporter
+    network_mode: host
     environment:
       REDIS_ADDR: "redis://localhost:6379"
-    network_mode: host
     depends_on:
       redis:
         condition: service_healthy
     restart: unless-stopped
-    profiles:
-      - monitoring
 
 volumes:
   postgres_data: {}

--- a/monitoring/grafana/datasources/prometheus.yml
+++ b/monitoring/grafana/datasources/prometheus.yml
@@ -5,7 +5,7 @@ datasources:
     name: Prometheus
     type: prometheus
     access: proxy
-    url: http://172.27.1.2:19090
+    url: http://localhost:19090
     isDefault: true
     editable: true
     jsonData:


### PR DESCRIPTION
This pull request updates the monitoring configuration in `docker-compose.yml` and the Grafana Prometheus datasource settings to simplify deployment and improve connectivity. The main changes remove the use of Docker Compose profiles for monitoring services and standardize the Prometheus endpoint configuration for Grafana.

**Monitoring service configuration changes:**

* Removed the `profiles: monitoring` section from all monitoring-related services (`prometheus`, `grafana`, `node-exporter`, `postgres-exporter`, `redis-exporter`) in `docker-compose.yml`, making these services always active when the stack is deployed. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L182-L183) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L203-L204) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L220-L249)

**Grafana and Prometheus connectivity improvements:**

* Updated the Prometheus datasource URL in `monitoring/grafana/datasources/prometheus.yml` from `http://172.27.1.2:19090` to `http://localhost:19090` for local connectivity.
* Added the `GF_DATASOURCES_DEFAULT_URL` environment variable to the `grafana` service in `docker-compose.yml` to set the default Prometheus endpoint to `http://localhost:19090`.

**Docker networking adjustments:**

* Moved the `network_mode: host` property higher in the configuration for `postgres-exporter` and `redis-exporter` in `docker-compose.yml` for clarity and consistency.