### PR TITLE
chore: Update GitHub Actions workflow to grant write permissions for issues

### DIFF
--- a/.github/workflows/feedback.yaml
+++ b/.github/workflows/feedback.yaml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
       contents: read
 
     steps:

--- a/.github/workflows/feedback.yaml
+++ b/.github/workflows/feedback.yaml
@@ -25,4 +25,4 @@ jobs:
             We’d love to hear your thoughts to help improve KubeStellar.
             Please take a moment to fill out our short feedback survey:
 
-            https://forms.gle/WJ7N6ZVtp44D9NK79
+            http://kubestellar.io/survey

--- a/.github/workflows/feedback.yaml
+++ b/.github/workflows/feedback.yaml
@@ -25,4 +25,4 @@ jobs:
             We’d love to hear your thoughts to help improve KubeStellar.
             Please take a moment to fill out our short feedback survey:
 
-            http://kubestellar.io/survey
+            https://kubestellar.io/survey


### PR DESCRIPTION

### Description

This pull request makes a minor update to the GitHub Actions workflow configuration. The change grants the workflow additional permission to write to issues, which may be needed for automation or feedback features.

- Updated the `.github/workflows/feedback.yaml` file to add `issues: write` permission under the workflow's job permissions.


### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #<issue_number>

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
