### PR TITLE
refactor: enhance GitHub icon rendering in CreateOptions component

### DIFF
--- a/frontend/src/components/CreateOptions.tsx
+++ b/frontend/src/components/CreateOptions.tsx
@@ -933,9 +933,19 @@ spec:
               label={t('workloads.tabs.github')}
               value="option3"
               icon={
-                <Suspense fallback={<span />}>
-                  <GitHubIcon />
-                </Suspense>
+                <span
+                  style={{
+                    display: 'inline-flex',
+                    width: '24px',
+                    height: '24px',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <Suspense fallback={<span />}>
+                    <GitHubIcon />
+                  </Suspense>
+                </span>
               }
               iconPosition="start"
             />

--- a/frontend/src/components/CreateOptions.tsx
+++ b/frontend/src/components/CreateOptions.tsx
@@ -933,8 +933,8 @@ spec:
               label={t('workloads.tabs.github')}
               value="option3"
               icon={
-                <span
-                  style={{
+                <Box
+                  sx={{
                     display: 'inline-flex',
                     width: '24px',
                     height: '24px',
@@ -945,7 +945,7 @@ spec:
                   <Suspense fallback={<span />}>
                     <GitHubIcon />
                   </Suspense>
-                </span>
+                </Box>
               }
               iconPosition="start"
             />


### PR DESCRIPTION
### Description

Improve the Create Workloads modal by ensuring the GitHub tab icon has the same spacing as the other tabs without changing their layout.

### Related Issue

Fixes #2240

### Changes Made

- [x] Updated `CreateOptions.tsx` to wrap the GitHub icon in a fixed-size flex container so it aligns with the label like the other tabs.
- [x] Fixed the inconsistent spacing between the GitHub icon and text in the tab strip.

### Checklist

- [X] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<img width="1385" height="708" alt="Screenshot 2025-11-17 at 6 57 49 PM" src="https://github.com/user-attachments/assets/812a5aa7-ad09-4439-b6d1-8e2d293c5ec8" />



