### PR TITLE
[FEATURE] Make the Staged and Deployed Workloads UI Component Occupy the Entire Right Side of the UI

### DIFF
--- a/frontend/src/components/treeView/TreeViewHeader.tsx
+++ b/frontend/src/components/treeView/TreeViewHeader.tsx
@@ -1,6 +1,6 @@
-import { memo } from 'react';
-import { Box, Typography, IconButton, Button } from '@mui/material';
-import { Plus } from 'lucide-react';
+import { memo, useRef, useEffect, useState } from 'react';
+import { Box, IconButton, Button } from '@mui/material';
+import { Plus, Menu, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import useTheme from '../../stores/themeStore';
 
@@ -12,97 +12,153 @@ interface TreeViewHeaderProps {
 }
 
 const TreeViewHeader = memo<TreeViewHeaderProps>(
-  ({ viewMode, onViewModeChange, onCreateWorkload, children }) => {
+  ({ viewMode, onViewModeChange, onCreateWorkload }) => {
     const { t } = useTranslation();
     const theme = useTheme(state => state.theme);
+    const [isOpen, setIsOpen] = useState(false);
+    const menuRef = useRef<HTMLDivElement>(null);
+    const buttonRef = useRef<HTMLButtonElement>(null);
+
+    useEffect(() => {
+      if (!isOpen) return;
+
+      const handleClickOutside = (event: MouseEvent) => {
+        if (
+          menuRef.current &&
+          buttonRef.current &&
+          !menuRef.current.contains(event.target as Node) &&
+          !buttonRef.current.contains(event.target as Node)
+        ) {
+          setIsOpen(false);
+        }
+      };
+
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, [isOpen]);
 
     return (
       <Box
         sx={{
-          mb: 4,
-          display: 'flex',
-          alignItems: 'center',
-          gap: 2,
-          flex: 1,
-          justifyContent: 'space-between',
-          padding: 2,
-          borderRadius: 1,
-          boxShadow: '0 6px 6px rgba(0,0,0,0.1)',
-          background: theme === 'dark' ? 'rgb(15, 23, 42)' : '#fff',
+          position: 'fixed',
+          display: 'inline-block',
+          marginLeft: 'auto',
+          right: 44,
+          zIndex: 1000,
         }}
       >
-        <Typography
-          variant="h4"
+        <IconButton
+          ref={buttonRef}
+          onClick={() => setIsOpen(!isOpen)}
           sx={{
-            color: '#4498FF',
-            fontWeight: 700,
-            fontSize: '30px',
-            letterSpacing: '0.5px',
+            padding: 2,
+            borderRadius: '50%',
+            right: 0,
+            width: 56,
+            height: 56,
+            bgcolor: theme === 'dark' ? 'rgb(15, 23, 42)' : '#fff',
+            boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+            border:
+              theme === 'dark'
+                ? '1px solid rgba(144, 202, 249, 0.2)'
+                : '1px solid rgba(0, 0, 0, 0.1)',
+            '&:hover': {
+              bgcolor: theme === 'dark' ? 'rgba(144, 202, 249, 0.1)' : 'rgba(47, 134, 255, 0.05)',
+              borderColor:
+                theme === 'dark' ? 'rgba(144, 202, 249, 0.4)' : 'rgba(47, 134, 255, 0.3)',
+            },
           }}
         >
-          {t('treeView.title')}
-        </Typography>
+          {isOpen ? (
+            <X size={24} color={theme === 'dark' ? '#90CAF9' : '#2F86FF'} />
+          ) : (
+            <Menu size={24} color={theme === 'dark' ? '#90CAF9' : '#2F86FF'} />
+          )}
+        </IconButton>
 
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-          {children}
+        <Box
+          ref={menuRef}
+          sx={{
+            position: 'absolute',
+            top: '100%',
+            right: 0,
+            marginTop: 1,
+            zIndex: 10000,
+            width: 320,
+            maxWidth: 'calc(100vw - 32px)',
+            opacity: isOpen ? 1 : 0,
+            visibility: isOpen ? 'visible' : 'hidden',
+            transform: isOpen ? 'translateY(0) scale(1)' : 'translateY(-10px) scale(0.95)',
+            transition: 'all 0.2s ease-in-out',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'stretch',
+            gap: 2,
+            padding: 2,
+            borderRadius: 2,
+            boxShadow: '0 8px 24px rgba(0,0,0,0.2)',
+            background: theme === 'dark' ? 'rgb(15, 23, 42)' : '#fff',
+          }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, justifyContent: 'center' }}>
+            <IconButton
+              color={viewMode === 'tiles' ? 'primary' : 'default'}
+              onClick={() => onViewModeChange('tiles')}
+              sx={{
+                padding: 1,
+                borderRadius: '50%',
+                width: 40,
+                height: 40,
+                bgcolor:
+                  theme === 'dark' && viewMode === 'tiles'
+                    ? 'rgba(144, 202, 249, 0.15)'
+                    : 'transparent',
+                '&:hover': {
+                  bgcolor: theme === 'dark' ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)',
+                },
+              }}
+            >
+              <span>
+                <i
+                  className="fa fa-th menu_icon"
+                  title={t('treeView.viewModes.tiles')}
+                  style={{
+                    color:
+                      theme === 'dark' ? (viewMode === 'tiles' ? '#90CAF9' : '#FFFFFF') : undefined,
+                  }}
+                />
+              </span>
+            </IconButton>
 
-          <IconButton
-            color={viewMode === 'tiles' ? 'primary' : 'default'}
-            onClick={() => onViewModeChange('tiles')}
-            sx={{
-              padding: 1,
-              borderRadius: '50%',
-              width: 40,
-              height: 40,
-              bgcolor:
-                theme === 'dark' && viewMode === 'tiles'
-                  ? 'rgba(144, 202, 249, 0.15)'
-                  : 'transparent',
-              '&:hover': {
-                bgcolor: theme === 'dark' ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)',
-              },
-            }}
-          >
-            <span>
-              <i
-                className="fa fa-th menu_icon"
-                title={t('treeView.viewModes.tiles')}
-                style={{
-                  color:
-                    theme === 'dark' ? (viewMode === 'tiles' ? '#90CAF9' : '#FFFFFF') : undefined,
-                }}
-              />
-            </span>
-          </IconButton>
-
-          <IconButton
-            color={viewMode === 'list' ? 'primary' : 'default'}
-            onClick={() => onViewModeChange('list')}
-            sx={{
-              padding: 1,
-              borderRadius: '50%',
-              width: 40,
-              height: 40,
-              bgcolor:
-                theme === 'dark' && viewMode === 'list'
-                  ? 'rgba(144, 202, 249, 0.15)'
-                  : 'transparent',
-              '&:hover': {
-                bgcolor: theme === 'dark' ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)',
-              },
-            }}
-          >
-            <span>
-              <i
-                className="fa fa-th-list selected menu_icon"
-                title={t('treeView.viewModes.list')}
-                style={{
-                  color:
-                    theme === 'dark' ? (viewMode === 'list' ? '#90CAF9' : '#FFFFFF') : undefined,
-                }}
-              />
-            </span>
-          </IconButton>
+            <IconButton
+              color={viewMode === 'list' ? 'primary' : 'default'}
+              onClick={() => onViewModeChange('list')}
+              sx={{
+                padding: 1,
+                borderRadius: '50%',
+                width: 40,
+                height: 40,
+                bgcolor:
+                  theme === 'dark' && viewMode === 'list'
+                    ? 'rgba(144, 202, 249, 0.15)'
+                    : 'transparent',
+                '&:hover': {
+                  bgcolor: theme === 'dark' ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)',
+                },
+              }}
+            >
+              <span>
+                <i
+                  className="fa fa-th-list selected menu_icon"
+                  title={t('treeView.viewModes.list')}
+                  style={{
+                    color:
+                      theme === 'dark' ? (viewMode === 'list' ? '#90CAF9' : '#FFFFFF') : undefined,
+                  }}
+                />
+              </span>
+            </IconButton>
+          </Box>
 
           <Button
             variant="outlined"
@@ -115,6 +171,7 @@ const TreeViewHeader = memo<TreeViewHeaderProps>(
               fontWeight: '600',
               borderRadius: '8px',
               textTransform: 'none',
+              width: '100%',
             }}
           >
             {t('treeView.createWorkload')}

--- a/frontend/src/components/wds_topology/ZoomControls.tsx
+++ b/frontend/src/components/wds_topology/ZoomControls.tsx
@@ -19,8 +19,8 @@ import {
   ViewQuilt,
   Fullscreen,
   FullscreenExit,
-  ChevronLeft,
-  ChevronRight,
+  ExpandMore,
+  ExpandLess,
 } from '@mui/icons-material';
 import { useReactFlow } from 'reactflow';
 import { useTranslation } from 'react-i18next';
@@ -33,11 +33,15 @@ const pulseGlow = keyframes`
   50% { transform: scale3d(1, 1, 1); box-shadow: 0 0 0 4px rgba(59, 130, 246, 0); }
 `;
 
-const bounceIn = keyframes`
-  0% { transform: scale3d(0.3, 0.3, 1); opacity: 0; }
-  50% { transform: scale3d(1.05, 1.05, 1); }
-  70% { transform: scale3d(0.9, 0.9, 1); }
-  100% { transform: scale3d(1, 1, 1); opacity: 1; }
+const slideDown = keyframes`
+  from { 
+    transform: translateY(-100%);
+    opacity: 0;
+  }
+  to { 
+    transform: translateY(0);
+    opacity: 1;
+  }
 `;
 
 const wiggle = keyframes`
@@ -191,7 +195,7 @@ export const ZoomControls = memo<ZoomControlsProps>(
           minWidth: '40px',
           height: '40px',
           borderRadius: '12px',
-          margin: '0 2px',
+          margin: '2px 0',
           background: isActive
             ? theme === 'dark'
               ? 'linear-gradient(135deg, #3b82f6, #6366f1)'
@@ -219,7 +223,7 @@ export const ZoomControls = memo<ZoomControlsProps>(
             hoveredButton === buttonId ? 'translateY(-2px) scale(1.05)' : 'translateY(0) scale(1)',
           animation: isActive ? `${pulseGlow} 2s infinite` : 'none',
           backdropFilter: 'blur(10px)',
-          willChange: hoveredButton === buttonId || isActive ? 'transform' : 'auto', // Optimize for animations
+          willChange: hoveredButton === buttonId || isActive ? 'transform' : 'auto',
           '&:hover': {
             background: isActive
               ? 'linear-gradient(135deg, #2563eb, #4f46e5)'
@@ -252,8 +256,9 @@ export const ZoomControls = memo<ZoomControlsProps>(
         sx={{
           position: 'absolute',
           top: 20,
-          left: 20,
+          right: 20,
           display: 'flex',
+          flexDirection: 'column',
           gap: 1,
           background:
             theme === 'dark'
@@ -271,15 +276,36 @@ export const ZoomControls = memo<ZoomControlsProps>(
             theme === 'dark'
               ? '1px solid rgba(148, 163, 184, 0.1)'
               : '1px solid rgba(148, 163, 184, 0.2)',
-          animation: `${bounceIn} 0.6s ease-out`,
+          animation: `${slideDown} 0.6s ease-out`,
         }}
       >
+        {/* Button to show or hide the control panel */}
+        <Tooltip
+          title={
+            showControls
+              ? t(`${translationPrefix}.hideControls.hide`)
+              : t(`${translationPrefix}.hideControls.show`)
+          }
+          placement="left"
+          arrow
+        >
+          <Button
+            variant="text"
+            onClick={toggleControls}
+            sx={getButtonStyles('toggleControls', !showControls)}
+            onMouseEnter={handleMouseEnter('toggleControls')}
+            onMouseLeave={handleMouseLeave}
+          >
+            {showControls ? <ExpandLess fontSize="medium" /> : <ExpandMore fontSize="medium" />}
+          </Button>
+        </Tooltip>
+
         {/* Group/Collapse Controls */}
         {showControls && (
           <>
             <Tooltip
               title={t(`${translationPrefix}.zoomControls.groupByResource`)}
-              placement="bottom"
+              placement="left"
               arrow
             >
               <Button
@@ -295,7 +321,7 @@ export const ZoomControls = memo<ZoomControlsProps>(
 
             <Tooltip
               title={t(`${translationPrefix}.zoomControls.expandAll`)}
-              placement="bottom"
+              placement="left"
               arrow
             >
               <Button
@@ -311,7 +337,7 @@ export const ZoomControls = memo<ZoomControlsProps>(
 
             <Tooltip
               title={t(`${translationPrefix}.zoomControls.collapseAll`)}
-              placement="bottom"
+              placement="left"
               arrow
             >
               <Button
@@ -328,17 +354,17 @@ export const ZoomControls = memo<ZoomControlsProps>(
             {/* Separator */}
             <Box
               sx={{
-                width: '1px',
-                height: '32px',
+                width: '32px',
+                height: '1px',
                 background:
                   theme === 'dark'
-                    ? 'linear-gradient(to bottom, transparent, rgba(148, 163, 184, 0.3), transparent)'
-                    : 'linear-gradient(to bottom, transparent, rgba(148, 163, 184, 0.4), transparent)',
-                margin: '0 8px',
+                    ? 'linear-gradient(to right, transparent, rgba(148, 163, 184, 0.3), transparent)'
+                    : 'linear-gradient(to right, transparent, rgba(148, 163, 184, 0.4), transparent)',
+                margin: '8px 0',
               }}
             />
             {/* Zoom Controls */}
-            <Tooltip title={t(`${translationPrefix}.zoomControls.zoomIn`)} placement="bottom" arrow>
+            <Tooltip title={t(`${translationPrefix}.zoomControls.zoomIn`)} placement="left" arrow>
               <Button
                 variant="text"
                 onClick={handleZoomIn}
@@ -349,11 +375,7 @@ export const ZoomControls = memo<ZoomControlsProps>(
                 <ZoomIn />
               </Button>
             </Tooltip>
-            <Tooltip
-              title={t(`${translationPrefix}.zoomControls.zoomOut`)}
-              placement="bottom"
-              arrow
-            >
+            <Tooltip title={t(`${translationPrefix}.zoomControls.zoomOut`)} placement="left" arrow>
               <Button
                 variant="text"
                 onClick={handleZoomOut}
@@ -366,7 +388,7 @@ export const ZoomControls = memo<ZoomControlsProps>(
             </Tooltip>
             <Tooltip
               title={t(`${translationPrefix}.zoomControls.resetZoom`)}
-              placement="bottom"
+              placement="left"
               arrow
             >
               <Button
@@ -466,19 +488,19 @@ export const ZoomControls = memo<ZoomControlsProps>(
             {/* Separator */}
             <Box
               sx={{
-                width: '1px',
-                height: '32px',
+                width: '32px',
+                height: '1px',
                 background:
                   theme === 'dark'
-                    ? 'linear-gradient(to bottom, transparent, rgba(148, 163, 184, 0.3), transparent)'
-                    : 'linear-gradient(to bottom, transparent, rgba(148, 163, 184, 0.4), transparent)',
-                margin: '0 8px',
+                    ? 'linear-gradient(to right, transparent, rgba(148, 163, 184, 0.3), transparent)'
+                    : 'linear-gradient(to right, transparent, rgba(148, 163, 184, 0.4), transparent)',
+                margin: '8px 0',
               }}
             />
             {/* Edge Type Controls */}
             <Tooltip
               title={t(`${translationPrefix}.zoomControls.edgeStyle`)}
-              placement="bottom"
+              placement="left"
               arrow
             >
               <ToggleButtonGroup
@@ -486,6 +508,7 @@ export const ZoomControls = memo<ZoomControlsProps>(
                 exclusive
                 onChange={handleEdgeTypeChange}
                 size="small"
+                orientation="vertical"
                 aria-label="Edge Type"
                 sx={{
                   borderRadius: '10px',
@@ -511,10 +534,10 @@ export const ZoomControls = memo<ZoomControlsProps>(
                       transform: 'scale(1.02)',
                     },
                     '&:first-of-type': {
-                      borderRadius: '10px 0 0 10px',
+                      borderRadius: '10px 10px 0 0',
                     },
                     '&:last-of-type': {
-                      borderRadius: '0 10px 10px 0',
+                      borderRadius: '0 0 10px 10px',
                     },
                   },
                 }}
@@ -551,13 +574,13 @@ export const ZoomControls = memo<ZoomControlsProps>(
                 {/* Separator */}
                 <Box
                   sx={{
-                    width: '1px',
-                    height: '32px',
+                    width: '32px',
+                    height: '1px',
                     background:
                       theme === 'dark'
-                        ? 'linear-gradient(to bottom, transparent, rgba(148, 163, 184, 0.3), transparent)'
-                        : 'linear-gradient(to bottom, transparent, rgba(148, 163, 184, 0.4), transparent)',
-                    margin: '0 8px',
+                        ? 'linear-gradient(to right, transparent, rgba(148, 163, 184, 0.3), transparent)'
+                        : 'linear-gradient(to right, transparent, rgba(148, 163, 184, 0.4), transparent)',
+                    margin: '8px 0',
                   }}
                 />
                 <Tooltip
@@ -566,7 +589,7 @@ export const ZoomControls = memo<ZoomControlsProps>(
                       ? t(`${translationPrefix}.zoomControls.exitFullscreen`)
                       : t(`${translationPrefix}.zoomControls.fullscreen`)
                   }
-                  placement="bottom"
+                  placement="left"
                   arrow
                 >
                   <Button
@@ -583,27 +606,6 @@ export const ZoomControls = memo<ZoomControlsProps>(
             )}
           </>
         )}
-        {/* Button to show or hide the control panel */}
-
-        <Tooltip
-          title={
-            showControls
-              ? t(`${translationPrefix}.hideControls.hide`)
-              : t(`${translationPrefix}.hideControls.show`)
-          }
-          placement="bottom"
-          arrow
-        >
-          <Button
-            variant="text"
-            onClick={toggleControls}
-            sx={getButtonStyles('toggleControls', !showControls)}
-            onMouseEnter={handleMouseEnter('toggleControls')}
-            onMouseLeave={handleMouseLeave}
-          >
-            {showControls ? <ChevronLeft fontSize="medium" /> : <ChevronRight fontSize="medium" />}
-          </Button>
-        </Tooltip>
       </Box>
     );
   }


### PR DESCRIPTION
### Description

This feature update modifies the Staged and Deployed Workloads UI component so that it expands to occupy the full right-hand side of the user interface. The goal is to improve visibility, enhance layout usability, and provide a cleaner presentation of workload details.

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #2231 

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated ...
- [x] Refactored ...
- [x] Fixed ...
- [x] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

[Screencast From 2025-11-19 16-08-00.webm](https://github.com/user-attachments/assets/abe0e952-f205-4a04-bedc-82d72a454f7d)


<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
