### PR TITLE
Fix: Docker Setup - Redis and Postgres Connectivity

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -3,32 +3,45 @@ services:
     image: postgres:15-alpine
     container_name: auth_postgres
     environment:
-      POSTGRES_DB: authdb
+      POSTGRES_DB: authdbui
       POSTGRES_USER: authuser
       POSTGRES_PASSWORD: authpass123
+      POSTGRES_SHARED_PRELOAD_LIBRARIES: pg_stat_statements
+      POSTGRES_MAX_CONNECTIONS: 100
+      POSTGRES_SHARED_BUFFERS: 256MB
+      POSTGRES_EFFECTIVE_CACHE_SIZE: 1GB
     ports:
       - "5400:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U authuser -d authdb"]
+      test: ["CMD-SHELL", "pg_isready -U authuser -d authdbui"]
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 30s
+    restart: unless-stopped
     networks:
       - kubestellar-network
 
   redis:
-    image: '${REDIS_IMAGE:-ghcr.io/kubestellar/ui/redis:latest}'
+    image: '${REDIS_IMAGE:-redis:7-alpine}'
     container_name: '${REDIS_CONTAINER_NAME:-kubestellar-redis}'
     ports:
       - '${REDIS_PORT:-6379}:6379'
+    environment:
+      - REDIS_APPENDONLY=yes
+      - REDIS_MAXMEMORY=256mb
+      - REDIS_MAXMEMORY_POLICY=allkeys-lru
+    volumes:
+      - redis_data:/data
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
       timeout: 5s
-      retries: 3
-      start_period: 30s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
     networks:
       - kubestellar-network
   
@@ -69,6 +82,7 @@ services:
 
 volumes:
   postgres_data:
+  redis_data:
   prometheus_data:
   grafana_data:
 


### PR DESCRIPTION
### Problem
Backend service was unable to connect to Redis and Postgres containers.

Fixed Docker Compose configuration issues for Redis, Postgres, and monitoring stack (Prometheus & Grafana) across both root and backend directories.