### PR TITLE
fix: Update database URL in config and migration logic

### DIFF
--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -15,7 +15,7 @@ type Config struct {
 
 func LoadConfig() *Config {
 	return &Config{
-		DatabaseURL:     GetEnv("DATABASE_URL", "postgres://authuser:authpass123@localhost:5400/authdb?sslmode=disable"),
+		DatabaseURL:     GetEnv("DATABASE_URL", "postgres://authuser:authpass123@localhost:5400/authdbui?sslmode=disable"),
 		JWTSecret:       GetEnv("JWT_SECRET", "your-secret-key-here"),
 		Port:            GetEnv("PORT", "5400"),
 		GinMode:         GetEnv("GIN_MODE", "debug"),

--- a/backend/postgresql/migrate.go
+++ b/backend/postgresql/migrate.go
@@ -2,9 +2,9 @@ package postgresql
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/kubestellar/ui/backend/log"
+	"github.com/kubestellar/ui/backend/pkg/config"
 	"go.uber.org/zap"
 
 	"github.com/golang-migrate/migrate/v4"
@@ -13,17 +13,16 @@ import (
 )
 
 func RunMigration() error {
-	dbURL := os.Getenv("DATABASE_URL")
-	if dbURL == "" {
-		log.LogError("DATABASE_URL environment variable is not set")
-		return fmt.Errorf("DATABASE_URL is not set")
+	if config.LoadConfig().DatabaseURL == "" {
+		log.LogError("Database URL is not set in config")
+		return fmt.Errorf("Database URL is not set")
 	}
 
 	migratePath := "file://postgresql/migrations"
 
 	m, err := migrate.New(
 		migratePath,
-		dbURL,
+		config.LoadConfig().DatabaseURL,
 	)
 	if err != nil {
 		log.LogError("Failed to initialize migrate", zap.String("error", err.Error()))

--- a/backend/postgresql/migrate.go
+++ b/backend/postgresql/migrate.go
@@ -13,16 +13,11 @@ import (
 )
 
 func RunMigration() error {
-	if config.LoadConfig().DatabaseURL == "" {
-		log.LogError("Database URL is not set in config")
-		return fmt.Errorf("Database URL is not set")
-	}
-
 	migratePath := "file://postgresql/migrations"
-
+	DBURL := config.LoadConfig().DatabaseURL
 	m, err := migrate.New(
 		migratePath,
-		config.LoadConfig().DatabaseURL,
+		DBURL,
 	)
 	if err != nil {
 		log.LogError("Failed to initialize migrate", zap.String("error", err.Error()))

--- a/backend/test/pkg/config/config_test.go
+++ b/backend/test/pkg/config/config_test.go
@@ -17,7 +17,7 @@ func TestLoadConfigDefaults(t *testing.T) {
 
 	cfg := config.LoadConfig()
 
-	assert.Equal(t, "postgres://authuser:authpass123@localhost:5400/authdb?sslmode=disable", cfg.DatabaseURL)
+	assert.Equal(t, "postgres://authuser:authpass123@localhost:5400/authdbui?sslmode=disable", cfg.DatabaseURL)
 	assert.Equal(t, "your-secret-key-here", cfg.JWTSecret)
 	assert.Equal(t, "5400", cfg.Port)
 	assert.Equal(t, "debug", cfg.GinMode)


### PR DESCRIPTION
### Description

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->
- Based on the merged PR #2291 and the conversation details, it appears that the Docker Compose configuration was updated to resolve connectivity issues with the Redis and Postgres containers.
However, the default config values in `config.go` were not changed, which is causing errors during the default backend startup.
- Also in `migrate.go`, the PostgreSQL URL was directly fetched from os.env, which should have been from the  config file to handle the default env configurations in case env vars are not set 
### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #2297 

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated  `config.go` , `migrate.go`

### Checklist

Please ensure the following before submitting your PR:

- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
