### PR TITLE
fix: update KubeStellar Slack community URL

### DIFF
--- a/frontend/src/components/login/KubeStellarLayout.tsx
+++ b/frontend/src/components/login/KubeStellarLayout.tsx
@@ -265,7 +265,7 @@ const KubeStellarLayout = ({ isLoaded, showLogin, leftSide }: KubeStellarLayoutP
             <p>
               {t('login.layout.needHelp')}{' '}
               <a
-                href="https://kubernetes.slack.com/archives/C058SUSL5AA"
+                href="https://cloud-native.slack.com/archives/C097094RZ3M"
                 target="_blank"
                 rel="noreferrer"
                 className="text-blue-400 transition-colors hover:text-blue-300"


### PR DESCRIPTION
### Description

Updated the **Slack help link** in the login layout to point to the correct **Cloud Native Slack KubeStellar channel** so users are redirected to the active community.

### Related Issue
https://github.com/kubestellar/ui/issues/2303

### Changes Made

* Updated the Slack community URL in `KubeStellarLayout.tsx`

