### PR TITLE
fix: remove refreshToken during logout process

### DIFF
--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -34,6 +34,7 @@ export const useAuthActions = () => {
   return {
     logout: () => {
       localStorage.removeItem('jwtToken');
+      localStorage.removeItem('refreshToken');
       localStorage.setItem('tokenRemovalTime', Date.now().toString());
       queryClient.invalidateQueries({ queryKey: AUTH_QUERY_KEY });
     },
@@ -45,6 +46,7 @@ export const useAuthActions = () => {
 
 export const logout = () => {
   localStorage.removeItem('jwtToken');
+  localStorage.removeItem('refreshToken');
   localStorage.setItem('tokenRemovalTime', Date.now().toString());
   window.dispatchEvent(new Event('storage'));
 };

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -3,6 +3,7 @@ import { VerifyToken } from '../api/auth';
 import { AUTH_QUERY_KEY } from '../api/auth/constant';
 import { api } from '../lib/api';
 import { useState, useEffect } from 'react';
+import { clearTokens } from '../components/login/tokenUtils';
 
 export const useAuth = () => {
   return useQuery({
@@ -33,8 +34,7 @@ export const useAuthActions = () => {
 
   return {
     logout: () => {
-      localStorage.removeItem('jwtToken');
-      localStorage.removeItem('refreshToken');
+      clearTokens();
       localStorage.setItem('tokenRemovalTime', Date.now().toString());
       queryClient.invalidateQueries({ queryKey: AUTH_QUERY_KEY });
     },
@@ -45,8 +45,7 @@ export const useAuthActions = () => {
 };
 
 export const logout = () => {
-  localStorage.removeItem('jwtToken');
-  localStorage.removeItem('refreshToken');
+  clearTokens();
   localStorage.setItem('tokenRemovalTime', Date.now().toString());
   window.dispatchEvent(new Event('storage'));
 };


### PR DESCRIPTION
### Description

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->
This PR fixes a critical bug where the application would freeze or enter an infinite redirect loop when a user clicked "Sign Out".
### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #2305 

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated `useAuth.ts` to explicitly remove the `refreshToken` along with jwtToken

### Checklist

Please ensure the following before submitting your PR:

- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->
https://github.com/user-attachments/assets/90166e84-f720-41a5-bcfe-d42dc868ff33


### Additional Notes




<!-- Add any other context, suggestions, or questions related to this PR. -->
