### PR TITLE
🐛 fix: Missing link between namespace and child resources in Remote-Cluster

### DIFF
--- a/frontend/src/components/WecsTopology.tsx
+++ b/frontend/src/components/WecsTopology.tsx
@@ -831,7 +831,7 @@ const WecsTreeview = () => {
       if (!cachedNode) nodeCache.current.set(id, node);
       newNodes.push(node);
 
-      if (parent && stateRef.current.isExpanded) {
+      if (parent) {
         const uniqueSuffix = resourceData?.metadata?.uid || edgeIdCounter.current++;
         const edgeId = `edge-${parent}-${id}-${uniqueSuffix}`;
         const edge = {


### PR DESCRIPTION
## Description

This PR fixes the missing visual connections (edges) between namespace nodes and their child resource nodes in the Remote-Cluster Treeview. The issue caused a broken visual hierarchy where resources appeared under namespaces but without connecting lines, making the parent-child relationships unclear.

Fixes #2301

## Screenshot
<img width="3072" height="1840" alt="Screenshot From 2026-01-21 11-24-37" src="https://github.com/user-attachments/assets/840adf59-a5c6-4d87-bfb7-391865e156db" />

The tree now shows all parent-child connections correctly.

**Before (Bug):**
- Namespace nodes showed child resources without connecting lines
- Visual hierarchy was broken
- Edges rendered inconsistently during component lifecycle

## Root Cause

The edge creation logic in [WecsTopology.tsx](cci:7://file:///home/linux/LFX/ui/frontend/src/components/WecsTopology.tsx:0:0-0:0) included a conditional check that prevented edges from being created in certain states:

// BEFORE (Line 834 - Buggy)
if (parent && stateRef.current.isExpanded) {
  // edges only created when isExpanded === true
}

## Solution
Removed the isExpanded conditional check from edge creation logic. Edges are now always created when a parent-child relationship exists, allowing ReactFlow to properly manage their visibility:
// AFTER (Line 834 - Fixed)
if (parent) {
  // edges always created when parent exists
}