### PR TITLE
fix(wecs): update edge styles when theme toggles

### DIFF
--- a/frontend/src/components/WecsTopology.tsx
+++ b/frontend/src/components/WecsTopology.tsx
@@ -595,6 +595,34 @@ const WecsTreeview = () => {
     updateNodeStyles();
   }, [updateNodeStyles]);
 
+  // Update edge styles when theme changes
+  const updateEdgeStyles = useCallback(() => {
+    setEdges(currentEdges => {
+      if (currentEdges.length === 0) return currentEdges;
+
+      return currentEdges.map(edge => ({
+        ...edge,
+        style: {
+          ...edge.style,
+          stroke: theme === 'dark' ? 'url(#edge-gradient-dark)' : 'url(#edge-gradient-light)',
+          filter:
+            theme === 'dark'
+              ? 'drop-shadow(0 2px 4px rgba(0,0,0,0.3))'
+              : 'drop-shadow(0 1px 2px rgba(0,0,0,0.1))',
+        },
+        markerEnd: {
+          ...edge.markerEnd,
+          type: MarkerType.ArrowClosed,
+          color: theme === 'dark' ? '#64748b' : '#94a3b8',
+        },
+      }));
+    });
+  }, [theme]);
+
+  useEffect(() => {
+    updateEdgeStyles();
+  }, [updateEdgeStyles]);
+
   // Update edge types when edgeType changes
   useEffect(() => {
     if (edges.length > 0) {

--- a/frontend/src/components/WecsTopology.tsx
+++ b/frontend/src/components/WecsTopology.tsx
@@ -612,7 +612,6 @@ const WecsTreeview = () => {
         },
         markerEnd: {
           ...edge.markerEnd,
-          type: MarkerType.ArrowClosed,
           color: theme === 'dark' ? '#64748b' : '#94a3b8',
         },
       }));


### PR DESCRIPTION
## Description

Added an `updateEdgeStyles` effect in `WecsTopology.tsx` that updates edge styling properties when the theme changes. Previously, node styles were updated via `updateNodeStyles` effect keyed on theme, but edges retained their previous theme's styles until a full data transform occurred. This caused visual inconsistency when toggling between light and dark themes.

## Related Issue

Fixes #2323 update edge styles when theme toggles 
## Changes Made

- [x] Added `updateEdgeStyles` callback function that updates edge stroke gradients, filter shadows, and marker colors based on the current theme
- [x] Added `useEffect` hook that triggers `updateEdgeStyles` when theme changes
- [x] Edge stroke now correctly switches between `url(#edge-gradient-dark)` and `url(#edge-gradient-light)`
- [x] Edge filter shadow adjusts opacity based on theme
- [x] Marker end arrow color updates to match theme (`#64748b` for dark, `#94a3b8` for light)

## Checklist

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

## Screenshots or Logs (if applicable)

N/A - Visual fix for edge styling on theme toggle

## Additional Notes

The implementation follows the same pattern as the existing `updateNodeStyles` function, maintaining code consistency.