### PR TITLE
Make locale sync check informational instead of failing

### DIFF
--- a/.github/workflows/locale-sync-check.yml
+++ b/.github/workflows/locale-sync-check.yml
@@ -27,7 +27,9 @@ jobs:
 
       - name: Run locale sync check
         working-directory: frontend
-        run: npm run local-sync-check
+        # Don't fail the workflow on sync issues - just report them
+        # The script creates GitHub issues for tracking
+        run: npm run local-sync-check || echo "Locale sync issues found - see created issues"
 
       - name: Add native speaker warning to locale-sync issues
         run: bash scripts/add-locale-warning.sh


### PR DESCRIPTION
## Summary
- Changes the scheduled locale sync check workflow to not fail when translation mismatches are found
- The script still creates GitHub issues for tracking out-of-sync locales
- This prevents daily workflow failures while maintaining visibility into translation needs

## Background
The locale sync check runs daily and compares all locale files against the English master. Currently several locales have missing keys (es, fr, hi, it, ja, pt, zh-Hans, zh-Hant), causing the workflow to fail every day.

## Changes
- Added `|| echo "Locale sync issues found - see created issues"` to prevent workflow failure
- The script still runs and creates/updates GitHub issues for tracking

🤖 Generated with [Claude Code](https://claude.ai/code)