### PR TITLE
fix: resolve CI failures in scorecard and image-scanning workflows

### DIFF
--- a/.github/workflows/image-scanning.yml
+++ b/.github/workflows/image-scanning.yml
@@ -7,17 +7,19 @@ on:
     branches:
       - main
     paths:
-      - 'Dockerfile*'
+      - '**/Dockerfile*'
       - 'go.mod'
       - 'go.sum'
+      - 'package.json'
       - '.github/workflows/image-scanning.yml'
   pull_request:
     branches:
       - main
     paths:
-      - 'Dockerfile*'
+      - '**/Dockerfile*'
       - 'go.mod'
       - 'go.sum'
+      - 'package.json'
   schedule:
     # Weekly scan
     - cron: '0 8 * * 0'
@@ -35,20 +37,26 @@ jobs:
   build-and-scan:
     name: Build and scan image
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        component:
+          - frontend
+          - backend
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Build image
         run: |
-          docker build -t local/image:${{ github.sha }} .
+          docker build -f ${{ matrix.component }}/Dockerfile -t local/${{ matrix.component }}:${{ github.sha }} ${{ matrix.component }}
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.28.0
         with:
-          image-ref: 'local/image:${{ github.sha }}'
+          image-ref: 'local/${{ matrix.component }}:${{ github.sha }}'
           format: 'sarif'
-          output: 'trivy-results.sarif'
+          output: 'trivy-results-${{ matrix.component }}.sarif'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
 
@@ -56,4 +64,5 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         if: always()
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: 'trivy-results-${{ matrix.component }}.sarif'
+          category: '${{ matrix.component }}'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,17 +13,21 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
-# Required permissions for scorecard
-permissions:
-  security-events: write  # Upload SARIF results
-  id-token: write         # For badge generation
-  contents: read
-  actions: read
+# Minimal default permissions - job-level permissions are set below
+permissions: read-all
 
 jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    permissions:
+      # Needed for Code Scanning upload
+      security-events: write
+      # Needed for GitHub OIDC token if publish_results is true
+      id-token: write
+      # Required for repo access
+      contents: read
+      actions: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -48,3 +52,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif
+


### PR DESCRIPTION
## Summary
- Fix scorecard.yml: use job-level permissions instead of workflow-level to satisfy OSSF scorecard webapp restrictions
- Fix image-scanning.yml: use matrix build for frontend and backend components

## Details
The OpenSSF Scorecard action rejects workflows with global write permissions. This PR moves the permissions to job-level.

## Test plan
- [ ] Verify OpenSSF Scorecard workflow passes
- [ ] Verify Container Image Scanning workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)