### PR TITLE
🐛:fix(wecs): Edge styles don't update when theme toggles in wecs 

### DIFF
--- a/frontend/src/components/WecsTopology.tsx
+++ b/frontend/src/components/WecsTopology.tsx
@@ -316,12 +316,12 @@ const getLayoutedElements = (
     const dagreNode = dagreGraph.node(node.id);
     return dagreNode
       ? {
-          ...node,
-          position: {
-            x: dagreNode.x - NODE_WIDTH / 2 + 50,
-            y: dagreNode.y - NODE_HEIGHT / 2 + 50,
-          },
-        }
+        ...node,
+        position: {
+          x: dagreNode.x - NODE_WIDTH / 2 + 50,
+          y: dagreNode.y - NODE_HEIGHT / 2 + 50,
+        },
+      }
       : node;
   });
 
@@ -594,6 +594,34 @@ const WecsTreeview = () => {
   useEffect(() => {
     updateNodeStyles();
   }, [updateNodeStyles]);
+
+  const updateEdgeStyles = useCallback(() => {
+    setEdges(currentEdges => {
+      if (currentEdges.length === 0) return currentEdges;
+
+      return currentEdges.map(edge => ({
+        ...edge,
+        style: {
+          ...edge.style,
+          stroke: theme === 'dark' ? 'url(#edge-gradient-dark)' : 'url(#edge-gradient-light)',
+          filter:
+            theme === 'dark'
+              ? 'drop-shadow(0 2px 4px rgba(0,0,0,0.3))'
+              : 'drop-shadow(0 1px 2px rgba(0,0,0,0.1))',
+        },
+        markerEnd: edge.markerEnd
+          ? {
+            ...edge.markerEnd,
+            color: theme === 'dark' ? '#64748b' : '#94a3b8',
+          }
+          : undefined,
+      }));
+    });
+  }, [theme]);
+
+  useEffect(() => {
+    updateEdgeStyles();
+  }, [updateEdgeStyles]);
 
   // Update edge types when edgeType changes
   useEffect(() => {

--- a/frontend/src/components/WecsTopology.tsx
+++ b/frontend/src/components/WecsTopology.tsx
@@ -316,12 +316,12 @@ const getLayoutedElements = (
     const dagreNode = dagreGraph.node(node.id);
     return dagreNode
       ? {
-        ...node,
-        position: {
-          x: dagreNode.x - NODE_WIDTH / 2 + 50,
-          y: dagreNode.y - NODE_HEIGHT / 2 + 50,
-        },
-      }
+          ...node,
+          position: {
+            x: dagreNode.x - NODE_WIDTH / 2 + 50,
+            y: dagreNode.y - NODE_HEIGHT / 2 + 50,
+          },
+        }
       : node;
   });
 
@@ -611,9 +611,9 @@ const WecsTreeview = () => {
         },
         markerEnd: edge.markerEnd
           ? {
-            ...edge.markerEnd,
-            color: theme === 'dark' ? '#64748b' : '#94a3b8',
-          }
+              ...edge.markerEnd,
+              color: theme === 'dark' ? '#64748b' : '#94a3b8',
+            }
           : undefined,
       }));
     });


### PR DESCRIPTION
### Description

This PR fixes an issue where edge styles in the WECS topology view would not update when the application theme was toggled (e.g., switching between dark and light mode). Previously, edge styles were only set on initial render or when the edge type changed. This change ensures that edge colors and styles dynamically respond to theme changes.

### Related Issue

Fixes #2270

### Changes Made

- [x] Updated [WecsTopology.tsx](cci:7://file:///Users/aadishah/Desktop/kubeui/frontend/src/components/WecsTopology.tsx:0:0-0:0) to include a `updateEdgeStyles` callback function.
- [x] Added a `useEffect` hook to trigger `updateEdgeStyles` whenever the `theme` changes.
- [x] Refactored edge style logic to be reactive to theme updates, ensuring proper stroke color, gradient, and marker colors are applied.

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Video Demonstration

[

https://github.com/user-attachments/assets/e7391900-360c-441b-accc-81acb33820ec

]

### Additional Notes

This fix ensures visual consistency across the application when switching themes without requiring a page reload or graph re-render.