### PR TITLE
🐛 Increase timeout for context dialog E2E test to 30s

### DIFF
--- a/frontend/e2e/WDSContextFiltering.spec.ts
+++ b/frontend/e2e/WDSContextFiltering.spec.ts
@@ -72,12 +72,9 @@ test.describe('WDS Context Filtering - Context Management Tests', () => {
   test('create new context dialog', async ({ page }) => {
     await page.waitForTimeout(1000);
 
-    const contextSelect = page
-      .locator('select, [role="combobox"]')
-      .filter({ hasText: /all|wds/i })
-      .first();
+    const contextSelect = page.locator('#context-filter-button');
 
-    await contextSelect.waitFor({ state: 'visible', timeout: 10000 });
+    await contextSelect.waitFor({ state: 'visible', timeout: 30000 });
 
     await page.keyboard.press('Escape');
     await page.waitForTimeout(200);


### PR DESCRIPTION
## Description

This PR fixes the flaky E2E test:

> **WDS Context Filtering - Context Management Tests › create new context dialog**

which was consistently timing out in CI environments.

The test was failing because:

- It used a brittle selector (`select, [role="combobox"]`) that didn't accurately target the custom button component used for the context dropdown.
- The timeout of **10,000 ms (10s)** was insufficient for slower CI runners, as local testing showed the test can take up to **20s** to complete during full rendering.

---

## Related Issue

Fixes #2398

---

## Changes Made

- [x] Updated `frontend/e2e/WDSContextFiltering.spec.ts` to use the stable ID selector `#context-filter-button` instead of generic role-based selectors.
- [x] Increased the visibility timeout for the context dialog from **10,000 ms** to **30,000 ms** to accommodate network/rendering latency in CI.

---

## Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (N/A – fixing existing E2E test).
- [ ] I have updated the documentation (N/A).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

---

## Screenshots or Logs (if applicable)

Local execution confirms the test passes but requires ~20s, justifying the timeout increase:

```text
Running 3 tests using 3 workers

  ✓  1 …c.ts:138:3 › WDS Context Filtering - Context Management Tests › filter updates tree view (17.4s)
  ✓  2 …c.ts:72:3 › WDS Context Filtering - Context Management Tests › create new context dialog (20.0s)
  ✓  3 … › WDS Context Filtering - Context Management Tests › context dropdown displays contexts (18.5s)

  3 passed (25.8s)
