### PR TITLE
🐛fix: prevent duplicate toast notifications

### DIFF
--- a/frontend/src/lib/react-query/queryClient.ts
+++ b/frontend/src/lib/react-query/queryClient.ts
@@ -19,20 +19,20 @@ const queryCache = new QueryCache({
       if (status === 401) {
         // Only show authentication toast if user is not already on login page
         if (!isOnLoginPage()) {
-          toast.error('Authentication required. Please log in again.');
+          toast.error('Authentication required. Please log in again.', { id: 'query-error-401' });
         }
       } else if (status === 403) {
-        toast.error("Access denied. You don't have permission for this action.");
+        toast.error("Access denied. You don't have permission for this action.", { id: 'query-error-403' });
       } else if (status && status >= 500) {
-        toast.error('Server error. Please try again later.');
+        toast.error('Server error. Please try again later.', { id: 'query-error-500' });
       } else {
-        toast.error('An error occurred while fetching data');
+        toast.error('An error occurred while fetching data', { id: `query-error-${status || 'unknown'}` });
       }
     } else if (error instanceof Error) {
       // Don't show raw error messages, use generic message instead
-      toast.error('An error occurred while fetching data');
+      toast.error('An error occurred while fetching data', { id: 'query-error-generic' });
     } else {
-      toast.error('An error occurred while fetching data');
+      toast.error('An error occurred while fetching data', { id: 'query-error-unknown' });
     }
   },
 });
@@ -53,20 +53,20 @@ const mutationCache = new MutationCache({
       if (status === 401) {
         // Only show authentication toast if user is not already on login page
         if (!isOnLoginPage()) {
-          toast.error('Authentication required. Please log in again.');
+          toast.error('Authentication required. Please log in again.', { id: 'mutation-error-401' });
         }
       } else if (status === 403) {
-        toast.error("Access denied. You don't have permission for this action.");
+        toast.error("Access denied. You don't have permission for this action.", { id: 'mutation-error-403' });
       } else if (status && status >= 500) {
-        toast.error('Server error. Please try again later.');
+        toast.error('Server error. Please try again later.', { id: 'mutation-error-500' });
       } else {
-        toast.error('An error occurred while updating data');
+        toast.error('An error occurred while updating data', { id: `mutation-error-${status || 'unknown'}` });
       }
     } else if (error instanceof Error) {
       // Don't show raw error messages, use generic message instead
-      toast.error('An error occurred while updating data');
+      toast.error('An error occurred while updating data', { id: 'mutation-error-generic' });
     } else {
-      toast.error('An error occurred while updating data');
+      toast.error('An error occurred while updating data', { id: 'mutation-error-unknown' });
     }
   },
 });


### PR DESCRIPTION
### Description

Duplicate toast notifications were appearing when users encountered errors, particularly "Access denied" messages. The same error would trigger 2-3 identical toasts simultaneously, degrading the user experience.

Fixes #2185 

### Changes Made

Root Cause
Multiple layers of error handling were independently triggering toast notifications:

- QueryCache Handler (queryClient.ts) - Did NOT use unique IDs 
- MutationCache Handler (queryClient.ts) - Did NOT use unique IDs 
When an error occurred (e.g., 403 Forbidden), all three handlers would fire, creating duplicate toasts for the same error.

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

Before
<img width="777" height="637" alt="image" src="https://github.com/user-attachments/assets/fa0689d3-2554-4eb2-8559-b8e87b6ba1f0" />

After
<img width="1759" height="328" alt="image" src="https://github.com/user-attachments/assets/4a2e8b0b-1a88-436b-91e3-f9595fbeed73" />
