### PR TITLE
🌱 Sync workflows from kubestellar/infra

### DIFF
--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -1,0 +1,9 @@
+name: Copilot DCO
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  copilot-dco:
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main


### PR DESCRIPTION
This PR syncs the caller workflows from `kubestellar/infra`.

These workflows call reusable workflows from `kubestellar/infra`:
- `add-help-wanted.yml`
- `assignment-helper.yml`
- `copilot-dco.yml`
- `feedback.yml`
- `greetings.yml`
- `label-helper.yml`
- `pr-verifier.yml`
- `pr-verify-title.yml`
- `scorecard.yml`
- `stale.yml`

Auto-generated by workflow sync