### PR TITLE
✨ Unified CardAIActions for Diagnose/Repair/Ask buttons across all cards

### DIFF
--- a/web/src/config/cards/active-alerts.ts
+++ b/web/src/config/cards/active-alerts.ts
@@ -1,0 +1,80 @@
+/**
+ * Active Alerts Card Configuration
+ *
+ * Displays currently firing alerts from Prometheus/Alertmanager.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const activeAlertsConfig: UnifiedCardConfig = {
+  type: 'active_alerts',
+  title: 'Active Alerts',
+  category: 'alerting',
+  description: 'Currently firing alerts across clusters',
+  icon: 'Bell',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+
+  isDemoData: true, // Uses demo data hook in registerHooks.ts
+
+  dataSource: {
+    type: 'hook',
+    hook: 'useActiveAlerts',
+  },
+
+  stats: [
+    {
+      id: 'critical',
+      icon: 'AlertTriangle',
+      color: 'red',
+      label: 'Critical',
+      bgColor: 'bg-red-500',
+      valueSource: { type: 'count', filter: 'severity=critical' },
+    },
+    {
+      id: 'warning',
+      icon: 'AlertCircle',
+      color: 'yellow',
+      label: 'Warning',
+      bgColor: 'bg-yellow-500',
+      valueSource: { type: 'count', filter: 'severity=warning' },
+    },
+  ],
+
+  content: {
+    type: 'list',
+    columns: [
+      {
+        field: 'severity',
+        header: '',
+        width: 32,
+        render: 'status-badge',
+      },
+      {
+        field: 'alertname',
+        header: 'Alert',
+        primary: true,
+      },
+      {
+        field: 'duration',
+        header: 'Duration',
+        width: 80,
+        render: 'relative-time',
+      },
+    ],
+    pageSize: 6,
+  },
+
+  emptyState: {
+    icon: 'BellOff',
+    title: 'No active alerts',
+    message: 'All systems operating normally',
+    variant: 'success',
+  },
+
+  footer: {
+    showTotal: true,
+    text: 'alerts firing',
+  },
+}

--- a/web/src/config/cards/alert-rules.ts
+++ b/web/src/config/cards/alert-rules.ts
@@ -1,0 +1,34 @@
+/**
+ * Alert Rules Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const alertRulesConfig: UnifiedCardConfig = {
+  type: 'alert_rules',
+  title: 'Alert Rules',
+  category: 'alerts',
+  description: 'Prometheus/Alertmanager alert rules',
+  icon: 'Bell',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useAlertRules' },
+  filters: [
+    { field: 'search', type: 'text', placeholder: 'Search rules...', searchFields: ['name', 'severity'], storageKey: 'alert-rules' },
+  ],
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Rule', primary: true, render: 'truncate' },
+      { field: 'severity', header: 'Severity', render: 'status-badge', width: 80 },
+      { field: 'state', header: 'State', render: 'status-badge', width: 80 },
+      { field: 'alertsCount', header: 'Alerts', render: 'number', width: 60 },
+    ],
+  },
+  emptyState: { icon: 'Bell', title: 'No Alert Rules', message: 'No alert rules configured', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default alertRulesConfig

--- a/web/src/config/cards/app-status.ts
+++ b/web/src/config/cards/app-status.ts
@@ -1,0 +1,29 @@
+/**
+ * App Status Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const appStatusConfig: UnifiedCardConfig = {
+  type: 'app_status',
+  title: 'Application Status',
+  category: 'workloads',
+  description: 'Application deployment status overview',
+  icon: 'Package',
+  iconColor: 'text-blue-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useAppStatus' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'running', label: 'Running', color: 'green' },
+      { field: 'pending', label: 'Pending', color: 'yellow' },
+      { field: 'failed', label: 'Failed', color: 'red' },
+    ],
+  },
+  emptyState: { icon: 'Package', title: 'No Apps', message: 'No applications found', variant: 'info' },
+  loadingState: { type: 'stats', count: 3 },
+  isDemoData: false,
+  isLive: true,
+}
+export default appStatusConfig

--- a/web/src/config/cards/argocd-applications.ts
+++ b/web/src/config/cards/argocd-applications.ts
@@ -1,0 +1,34 @@
+/**
+ * ArgoCD Applications Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const argocdApplicationsConfig: UnifiedCardConfig = {
+  type: 'argocd_applications',
+  title: 'ArgoCD Applications',
+  category: 'gitops',
+  description: 'ArgoCD managed applications',
+  icon: 'GitBranch',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useArgoCDApplications' },
+  filters: [
+    { field: 'search', type: 'text', placeholder: 'Search apps...', searchFields: ['name', 'namespace', 'project'], storageKey: 'argocd-apps' },
+  ],
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Application', primary: true, render: 'truncate' },
+      { field: 'project', header: 'Project', render: 'text', width: 100 },
+      { field: 'syncStatus', header: 'Sync', render: 'status-badge', width: 80 },
+      { field: 'healthStatus', header: 'Health', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'GitBranch', title: 'No Applications', message: 'No ArgoCD applications found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default argocdApplicationsConfig

--- a/web/src/config/cards/argocd-health.ts
+++ b/web/src/config/cards/argocd-health.ts
@@ -1,0 +1,30 @@
+/**
+ * ArgoCD Health Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const argocdHealthConfig: UnifiedCardConfig = {
+  type: 'argocd_health',
+  title: 'ArgoCD Health',
+  category: 'gitops',
+  description: 'Health status of ArgoCD applications',
+  icon: 'HeartPulse',
+  iconColor: 'text-red-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useArgoCDHealth' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'healthy', label: 'Healthy', color: 'green' },
+      { field: 'degraded', label: 'Degraded', color: 'yellow' },
+      { field: 'progressing', label: 'Progressing', color: 'blue' },
+      { field: 'missing', label: 'Missing', color: 'red' },
+    ],
+  },
+  emptyState: { icon: 'HeartPulse', title: 'No Health Data', message: 'No ArgoCD health data available', variant: 'info' },
+  loadingState: { type: 'stats', count: 4 },
+  isDemoData: true,
+  isLive: false,
+}
+export default argocdHealthConfig

--- a/web/src/config/cards/argocd-sync-status.ts
+++ b/web/src/config/cards/argocd-sync-status.ts
@@ -1,0 +1,29 @@
+/**
+ * ArgoCD Sync Status Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const argocdSyncStatusConfig: UnifiedCardConfig = {
+  type: 'argocd_sync_status',
+  title: 'ArgoCD Sync Status',
+  category: 'gitops',
+  description: 'Sync status of ArgoCD applications',
+  icon: 'RefreshCw',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useArgoCDSyncStatus' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'synced', label: 'Synced', color: 'green' },
+      { field: 'outOfSync', label: 'Out of Sync', color: 'yellow' },
+      { field: 'unknown', label: 'Unknown', color: 'gray' },
+    ],
+  },
+  emptyState: { icon: 'RefreshCw', title: 'No Status', message: 'No sync status available', variant: 'info' },
+  loadingState: { type: 'stats', count: 3 },
+  isDemoData: true,
+  isLive: false,
+}
+export default argocdSyncStatusConfig

--- a/web/src/config/cards/cert-manager.ts
+++ b/web/src/config/cards/cert-manager.ts
@@ -1,0 +1,29 @@
+/**
+ * Cert Manager Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const certManagerConfig: UnifiedCardConfig = {
+  type: 'cert_manager',
+  title: 'Certificates',
+  category: 'security',
+  description: 'cert-manager certificate status',
+  icon: 'FileKey',
+  iconColor: 'text-green-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useCertManager' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'total', label: 'Total', color: 'blue' },
+      { field: 'ready', label: 'Ready', color: 'green' },
+      { field: 'expiringSoon', label: 'Expiring', color: 'yellow' },
+    ],
+  },
+  emptyState: { icon: 'FileKey', title: 'No Certs', message: 'No certificates found', variant: 'info' },
+  loadingState: { type: 'stats', count: 3 },
+  isDemoData: false,
+  isLive: true,
+}
+export default certManagerConfig

--- a/web/src/config/cards/chart-versions.ts
+++ b/web/src/config/cards/chart-versions.ts
@@ -1,0 +1,31 @@
+/**
+ * Chart Versions Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const chartVersionsConfig: UnifiedCardConfig = {
+  type: 'chart_versions',
+  title: 'Chart Versions',
+  category: 'gitops',
+  description: 'Available Helm chart versions',
+  icon: 'Package',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useChartVersions' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Chart', primary: true, render: 'truncate' },
+      { field: 'version', header: 'Version', render: 'text', width: 80 },
+      { field: 'appVersion', header: 'App Ver', render: 'text', width: 80 },
+      { field: 'created', header: 'Created', render: 'relative-time', width: 100 },
+    ],
+  },
+  emptyState: { icon: 'Package', title: 'No Charts', message: 'No chart versions found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default chartVersionsConfig

--- a/web/src/config/cards/checkers.ts
+++ b/web/src/config/cards/checkers.ts
@@ -1,0 +1,22 @@
+/**
+ * Checkers Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const checkersConfig: UnifiedCardConfig = {
+  type: 'checkers',
+  title: 'AI Checkers',
+  category: 'games',
+  description: 'Play checkers against AI',
+  icon: 'Circle',
+  iconColor: 'text-red-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'Checkers' },
+  emptyState: { icon: 'Circle', title: 'Checkers', message: 'Start a new game', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default checkersConfig

--- a/web/src/config/cards/cluster-comparison.ts
+++ b/web/src/config/cards/cluster-comparison.ts
@@ -1,0 +1,32 @@
+/**
+ * Cluster Comparison Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const clusterComparisonConfig: UnifiedCardConfig = {
+  type: 'cluster_comparison',
+  title: 'Cluster Comparison',
+  category: 'cluster-health',
+  description: 'Compare metrics across clusters',
+  icon: 'GitCompare',
+  iconColor: 'text-blue-400',
+  defaultWidth: 12,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useClusterComparison' },
+  content: {
+    type: 'table',
+    columns: [
+      { field: 'cluster', header: 'Cluster', primary: true, render: 'cluster-badge' },
+      { field: 'nodes', header: 'Nodes', render: 'number', align: 'right' },
+      { field: 'pods', header: 'Pods', render: 'number', align: 'right' },
+      { field: 'cpu', header: 'CPU %', render: 'percentage', align: 'right' },
+      { field: 'memory', header: 'Memory %', render: 'percentage', align: 'right' },
+      { field: 'status', header: 'Status', render: 'status-badge' },
+    ],
+  },
+  emptyState: { icon: 'GitCompare', title: 'No Clusters', message: 'No clusters to compare', variant: 'info' },
+  loadingState: { type: 'table', rows: 4 },
+  isDemoData: false,
+  isLive: true,
+}
+export default clusterComparisonConfig

--- a/web/src/config/cards/cluster-costs.ts
+++ b/web/src/config/cards/cluster-costs.ts
@@ -1,0 +1,29 @@
+/**
+ * Cluster Costs Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const clusterCostsConfig: UnifiedCardConfig = {
+  type: 'cluster_costs',
+  title: 'Cluster Costs',
+  category: 'cost',
+  description: 'Cost allocation by cluster',
+  icon: 'DollarSign',
+  iconColor: 'text-green-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useClusterCosts' },
+  content: {
+    type: 'chart',
+    chartType: 'bar',
+    dataKey: 'clusters',
+    xAxis: 'cluster',
+    yAxis: ['compute', 'storage', 'network'],
+    colors: ['#3b82f6', '#10b981', '#f59e0b'],
+  },
+  emptyState: { icon: 'DollarSign', title: 'No Cost Data', message: 'Cost data not available', variant: 'info' },
+  loadingState: { type: 'chart' },
+  isDemoData: true,
+  isLive: false,
+}
+export default clusterCostsConfig

--- a/web/src/config/cards/cluster-focus.ts
+++ b/web/src/config/cards/cluster-focus.ts
@@ -1,0 +1,30 @@
+/**
+ * Cluster Focus Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const clusterFocusConfig: UnifiedCardConfig = {
+  type: 'cluster_focus',
+  title: 'Cluster Focus',
+  category: 'cluster-health',
+  description: 'Focused view of selected cluster',
+  icon: 'Target',
+  iconColor: 'text-purple-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useClusterFocus' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'nodes', label: 'Nodes', color: 'blue' },
+      { field: 'pods', label: 'Pods', color: 'green' },
+      { field: 'cpu', label: 'CPU %', color: 'orange', format: 'percentage' },
+      { field: 'memory', label: 'Memory %', color: 'purple', format: 'percentage' },
+    ],
+  },
+  emptyState: { icon: 'Target', title: 'Select Cluster', message: 'Select a cluster to view details', variant: 'info' },
+  loadingState: { type: 'stats', count: 4 },
+  isDemoData: false,
+  isLive: true,
+}
+export default clusterFocusConfig

--- a/web/src/config/cards/cluster-groups.ts
+++ b/web/src/config/cards/cluster-groups.ts
@@ -1,0 +1,30 @@
+/**
+ * Cluster Groups Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const clusterGroupsConfig: UnifiedCardConfig = {
+  type: 'cluster_groups',
+  title: 'Cluster Groups',
+  category: 'cluster-health',
+  description: 'Manage cluster groupings',
+  icon: 'Layers',
+  iconColor: 'text-indigo-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useClusterGroups' },
+  content: {
+    type: 'list',
+    pageSize: 8,
+    columns: [
+      { field: 'name', header: 'Group', primary: true, render: 'truncate' },
+      { field: 'clusterCount', header: 'Clusters', render: 'number', width: 70 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'Layers', title: 'No Groups', message: 'No cluster groups defined', variant: 'info' },
+  loadingState: { type: 'list', rows: 4 },
+  isDemoData: false,
+  isLive: true,
+}
+export default clusterGroupsConfig

--- a/web/src/config/cards/cluster-health-monitor.ts
+++ b/web/src/config/cards/cluster-health-monitor.ts
@@ -1,0 +1,22 @@
+/**
+ * Cluster Health Monitor Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const clusterHealthMonitorConfig: UnifiedCardConfig = {
+  type: 'cluster_health_monitor',
+  title: 'Cluster Monitor',
+  category: 'cluster-health',
+  description: 'Comprehensive cluster health',
+  icon: 'HeartPulse',
+  iconColor: 'text-red-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useClusterHealthMonitor' },
+  content: { type: 'custom', component: 'ClusterHealthView' },
+  emptyState: { icon: 'HeartPulse', title: 'No Clusters', message: 'No clusters to monitor', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default clusterHealthMonitorConfig

--- a/web/src/config/cards/cluster-health.ts
+++ b/web/src/config/cards/cluster-health.ts
@@ -1,0 +1,127 @@
+/**
+ * Cluster Health Card Configuration
+ *
+ * Displays cluster health status across all connected clusters.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const clusterHealthConfig: UnifiedCardConfig = {
+  type: 'cluster_health',
+  title: 'Cluster Health',
+  category: 'cluster-health',
+  description: 'Health status of all connected Kubernetes clusters',
+
+  // Appearance
+  icon: 'Activity',
+  iconColor: 'text-green-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useClusters',
+  },
+
+  // Inline stats at top of card
+  stats: [
+    {
+      id: 'healthy',
+      icon: 'CheckCircle',
+      color: 'text-green-400',
+      bgColor: 'bg-green-500/10',
+      label: 'Healthy',
+      valueSource: { type: 'computed', expression: 'filter:healthy|count' },
+    },
+    {
+      id: 'unhealthy',
+      icon: 'XCircle',
+      color: 'text-orange-400',
+      bgColor: 'bg-orange-500/10',
+      label: 'Unhealthy',
+      valueSource: { type: 'computed', expression: 'filter:!healthy&!unreachable|count' },
+    },
+    {
+      id: 'offline',
+      icon: 'WifiOff',
+      color: 'text-yellow-400',
+      bgColor: 'bg-yellow-500/10',
+      label: 'Offline',
+      valueSource: { type: 'computed', expression: 'filter:unreachable|count' },
+    },
+  ],
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search clusters...',
+      searchFields: ['name', 'context', 'server'],
+      storageKey: 'cluster-health',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    itemClick: 'drill',
+    columns: [
+      {
+        field: 'healthy',
+        header: 'Status',
+        render: 'status-badge',
+        width: 80,
+      },
+      {
+        field: 'name',
+        header: 'Cluster',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'nodeCount',
+        header: 'Nodes',
+        render: 'number',
+        align: 'right',
+        width: 60,
+      },
+      {
+        field: 'podCount',
+        header: 'Pods',
+        render: 'number',
+        align: 'right',
+        width: 60,
+      },
+    ],
+  },
+
+  // Drill-down
+  drillDown: {
+    action: 'openClusterDetail',
+    params: ['name'],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Server',
+    title: 'No clusters connected',
+    message: 'Connect a cluster to get started',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default clusterHealthConfig

--- a/web/src/config/cards/cluster-locations.ts
+++ b/web/src/config/cards/cluster-locations.ts
@@ -1,0 +1,25 @@
+/**
+ * Cluster Locations Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const clusterLocationsConfig: UnifiedCardConfig = {
+  type: 'cluster_locations',
+  title: 'Cluster Locations',
+  category: 'cluster-health',
+  description: 'Geographic distribution of clusters',
+  icon: 'MapPin',
+  iconColor: 'text-red-400',
+  defaultWidth: 8,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useClusterLocations' },
+  content: {
+    type: 'custom',
+    component: 'ClusterMap',
+  },
+  emptyState: { icon: 'MapPin', title: 'No Location Data', message: 'Cluster location data not available', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: true,
+  isLive: false,
+}
+export default clusterLocationsConfig

--- a/web/src/config/cards/cluster-metrics.ts
+++ b/web/src/config/cards/cluster-metrics.ts
@@ -1,0 +1,94 @@
+/**
+ * Cluster Metrics Card Configuration
+ *
+ * Shows cluster performance metrics over time using line/area charts.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const clusterMetricsConfig: UnifiedCardConfig = {
+  type: 'cluster_metrics',
+  title: 'Cluster Metrics',
+  category: 'compute',
+  description: 'CPU and memory metrics over time',
+
+  // Appearance
+  icon: 'Activity',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useCachedClusterMetrics',
+  },
+
+  // Inline stats
+  stats: [
+    {
+      id: 'currentCpu',
+      icon: 'Cpu',
+      color: 'text-cyan-400',
+      bgColor: 'bg-cyan-500/10',
+      label: 'CPU',
+      valueSource: { type: 'computed', expression: 'latest:cpu' },
+    },
+    {
+      id: 'currentMemory',
+      icon: 'MemoryStick',
+      color: 'text-purple-400',
+      bgColor: 'bg-purple-500/10',
+      label: 'Memory',
+      valueSource: { type: 'computed', expression: 'latest:memory' },
+    },
+  ],
+
+  // Content - Line chart visualization
+  content: {
+    type: 'chart',
+    chartType: 'area',
+    height: 250,
+    showLegend: true,
+    xAxis: {
+      field: 'time',
+      label: 'Time',
+    },
+    yAxis: {
+      label: 'Usage %',
+    },
+    series: [
+      {
+        field: 'cpu',
+        label: 'CPU Usage',
+        color: '#06b6d4', // cyan
+      },
+      {
+        field: 'memory',
+        label: 'Memory Usage',
+        color: '#a855f7', // purple
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Activity',
+    title: 'No metrics data',
+    message: 'Cluster metrics will appear here once data is available',
+    variant: 'neutral',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'chart',
+    rows: 1,
+    showSearch: false,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default clusterMetricsConfig

--- a/web/src/config/cards/cluster-network.ts
+++ b/web/src/config/cards/cluster-network.ts
@@ -1,0 +1,25 @@
+/**
+ * Cluster Network Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const clusterNetworkConfig: UnifiedCardConfig = {
+  type: 'cluster_network',
+  title: 'Cluster Network',
+  category: 'network',
+  description: 'Network topology visualization',
+  icon: 'Network',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 8,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useClusterNetwork' },
+  content: {
+    type: 'custom',
+    component: 'NetworkTopology',
+  },
+  emptyState: { icon: 'Network', title: 'No Network Data', message: 'Network data not available', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: true,
+  isLive: false,
+}
+export default clusterNetworkConfig

--- a/web/src/config/cards/cluster-resource-tree.ts
+++ b/web/src/config/cards/cluster-resource-tree.ts
@@ -1,0 +1,25 @@
+/**
+ * Cluster Resource Tree Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const clusterResourceTreeConfig: UnifiedCardConfig = {
+  type: 'cluster_resource_tree',
+  title: 'Resource Tree',
+  category: 'cluster-health',
+  description: 'Hierarchical view of cluster resources',
+  icon: 'GitBranch',
+  iconColor: 'text-purple-400',
+  defaultWidth: 12,
+  defaultHeight: 5,
+  dataSource: { type: 'hook', hook: 'useClusterResourceTree' },
+  content: {
+    type: 'custom',
+    component: 'ResourceTree',
+  },
+  emptyState: { icon: 'GitBranch', title: 'No Resources', message: 'Select a cluster to view resources', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default clusterResourceTreeConfig

--- a/web/src/config/cards/compliance-score.ts
+++ b/web/src/config/cards/compliance-score.ts
@@ -1,0 +1,29 @@
+/**
+ * Compliance Score Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const complianceScoreConfig: UnifiedCardConfig = {
+  type: 'compliance_score',
+  title: 'Compliance Score',
+  category: 'security',
+  description: 'Overall compliance posture score',
+  icon: 'Award',
+  iconColor: 'text-green-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useComplianceScore' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'overall', label: 'Overall', color: 'blue', format: 'percentage' },
+      { field: 'security', label: 'Security', color: 'red', format: 'percentage' },
+      { field: 'reliability', label: 'Reliability', color: 'green', format: 'percentage' },
+    ],
+  },
+  emptyState: { icon: 'Award', title: 'No Score', message: 'Compliance data not available', variant: 'info' },
+  loadingState: { type: 'stats', count: 3 },
+  isDemoData: true,
+  isLive: false,
+}
+export default complianceScoreConfig

--- a/web/src/config/cards/compute-overview.ts
+++ b/web/src/config/cards/compute-overview.ts
@@ -1,0 +1,29 @@
+/**
+ * Compute Overview Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const computeOverviewConfig: UnifiedCardConfig = {
+  type: 'compute_overview',
+  title: 'Compute Overview',
+  category: 'compute',
+  description: 'Compute resource summary',
+  icon: 'Cpu',
+  iconColor: 'text-blue-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useComputeOverview' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'nodes', label: 'Nodes', color: 'blue' },
+      { field: 'cpuUsage', label: 'CPU %', color: 'orange', format: 'percentage' },
+      { field: 'memoryUsage', label: 'Memory %', color: 'green', format: 'percentage' },
+    ],
+  },
+  emptyState: { icon: 'Cpu', title: 'No Data', message: 'No compute data available', variant: 'info' },
+  loadingState: { type: 'stats', count: 3 },
+  isDemoData: false,
+  isLive: true,
+}
+export default computeOverviewConfig

--- a/web/src/config/cards/configmap-status.ts
+++ b/web/src/config/cards/configmap-status.ts
@@ -1,0 +1,103 @@
+/**
+ * ConfigMap Status Card Configuration
+ *
+ * Displays Kubernetes ConfigMaps using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const configMapStatusConfig: UnifiedCardConfig = {
+  type: 'configmap_status',
+  title: 'ConfigMaps',
+  category: 'workloads',
+  description: 'Kubernetes ConfigMaps across clusters',
+
+  // Appearance
+  icon: 'FileText',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useConfigMaps',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search configmaps...',
+      searchFields: ['name', 'namespace', 'cluster'],
+      storageKey: 'configmap-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'configmap-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'dataKeys',
+        header: 'Keys',
+        render: 'number',
+        align: 'right',
+        width: 60,
+      },
+      {
+        field: 'creationTimestamp',
+        header: 'Age',
+        render: 'relative-time',
+        width: 80,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'FileText',
+    title: 'No ConfigMaps',
+    message: 'No ConfigMaps found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: true,
+  isLive: true,
+}
+
+export default configMapStatusConfig

--- a/web/src/config/cards/console-ai-health-check.ts
+++ b/web/src/config/cards/console-ai-health-check.ts
@@ -1,0 +1,22 @@
+/**
+ * Console AI Health Check Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const consoleAiHealthCheckConfig: UnifiedCardConfig = {
+  type: 'console_ai_health_check',
+  title: 'AI Health Check',
+  category: 'ai-ml',
+  description: 'AI-powered cluster health check',
+  icon: 'Stethoscope',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useConsoleAIHealthCheck' },
+  content: { type: 'custom', component: 'AIHealthCheckView' },
+  emptyState: { icon: 'Stethoscope', title: 'No Check', message: 'Run AI health check', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default consoleAiHealthCheckConfig

--- a/web/src/config/cards/console-ai-issues.ts
+++ b/web/src/config/cards/console-ai-issues.ts
@@ -1,0 +1,31 @@
+/**
+ * Console AI Issues Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const consoleAiIssuesConfig: UnifiedCardConfig = {
+  type: 'console_ai_issues',
+  title: 'AI Issues',
+  category: 'ai-ml',
+  description: 'AI-detected cluster issues',
+  icon: 'Bot',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useConsoleAIIssues' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'severity', header: 'Sev', render: 'status-badge', width: 60 },
+      { field: 'issue', header: 'Issue', primary: true, render: 'truncate' },
+      { field: 'cluster', header: 'Cluster', render: 'cluster-badge', width: 100 },
+      { field: 'confidence', header: 'Conf', render: 'percentage', width: 60 },
+    ],
+  },
+  emptyState: { icon: 'Bot', title: 'No Issues', message: 'No AI-detected issues', variant: 'success' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default consoleAiIssuesConfig

--- a/web/src/config/cards/console-ai-kubeconfig-audit.ts
+++ b/web/src/config/cards/console-ai-kubeconfig-audit.ts
@@ -1,0 +1,22 @@
+/**
+ * Console AI Kubeconfig Audit Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const consoleAiKubeconfigAuditConfig: UnifiedCardConfig = {
+  type: 'console_ai_kubeconfig_audit',
+  title: 'Kubeconfig Audit',
+  category: 'security',
+  description: 'AI kubeconfig security audit',
+  icon: 'FileKey',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useConsoleAIKubeconfigAudit' },
+  content: { type: 'custom', component: 'KubeconfigAuditView' },
+  emptyState: { icon: 'FileKey', title: 'No Audit', message: 'Run kubeconfig audit', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default consoleAiKubeconfigAuditConfig

--- a/web/src/config/cards/console-ai-offline-detection.ts
+++ b/web/src/config/cards/console-ai-offline-detection.ts
@@ -1,0 +1,30 @@
+/**
+ * Console AI Offline Detection Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const consoleAiOfflineDetectionConfig: UnifiedCardConfig = {
+  type: 'console_ai_offline_detection',
+  title: 'Offline Detection',
+  category: 'cluster-health',
+  description: 'AI-detected offline clusters',
+  icon: 'WifiOff',
+  iconColor: 'text-red-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useConsoleAIOfflineDetection' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'cluster', header: 'Cluster', primary: true, render: 'cluster-badge' },
+      { field: 'lastSeen', header: 'Last Seen', render: 'relative-time', width: 100 },
+      { field: 'reason', header: 'Reason', render: 'truncate', width: 150 },
+    ],
+  },
+  emptyState: { icon: 'WifiOff', title: 'All Online', message: 'All clusters are online', variant: 'success' },
+  loadingState: { type: 'list', rows: 3 },
+  isDemoData: false,
+  isLive: true,
+}
+export default consoleAiOfflineDetectionConfig

--- a/web/src/config/cards/container-tetris.ts
+++ b/web/src/config/cards/container-tetris.ts
@@ -1,0 +1,22 @@
+/**
+ * Container Tetris Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const containerTetrisConfig: UnifiedCardConfig = {
+  type: 'container_tetris',
+  title: 'Container Tetris',
+  category: 'games',
+  description: 'Container-themed Tetris game',
+  icon: 'Box',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 6,
+  defaultHeight: 5,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'ContainerTetris' },
+  emptyState: { icon: 'Box', title: 'Tetris', message: 'Start a new game', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default containerTetrisConfig

--- a/web/src/config/cards/crd-health.ts
+++ b/web/src/config/cards/crd-health.ts
@@ -1,0 +1,34 @@
+/**
+ * CRD Health Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const crdHealthConfig: UnifiedCardConfig = {
+  type: 'crd_health',
+  title: 'CRD Health',
+  category: 'operators',
+  description: 'Custom Resource Definition health status',
+  icon: 'FileCode',
+  iconColor: 'text-purple-400',
+  defaultWidth: 5,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useCRDHealth' },
+  filters: [
+    { field: 'search', type: 'text', placeholder: 'Search CRDs...', searchFields: ['name', 'group'], storageKey: 'crd-health' },
+  ],
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Name', primary: true, render: 'truncate' },
+      { field: 'group', header: 'Group', render: 'text', width: 120 },
+      { field: 'version', header: 'Version', render: 'text', width: 80 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'FileCode', title: 'No CRDs', message: 'No Custom Resource Definitions found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default crdHealthConfig

--- a/web/src/config/cards/cronjob-status.ts
+++ b/web/src/config/cards/cronjob-status.ts
@@ -1,0 +1,108 @@
+/**
+ * CronJob Status Card Configuration
+ *
+ * Displays Kubernetes CronJobs using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const cronJobStatusConfig: UnifiedCardConfig = {
+  type: 'cronjob_status',
+  title: 'CronJobs',
+  category: 'workloads',
+  description: 'Kubernetes CronJobs across clusters',
+
+  // Appearance
+  icon: 'Clock',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useCronJobs',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search cronjobs...',
+      searchFields: ['name', 'namespace', 'cluster', 'schedule'],
+      storageKey: 'cronjob-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'cronjob-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'schedule',
+        header: 'Schedule',
+        render: 'text',
+        width: 100,
+      },
+      {
+        field: 'suspend',
+        header: 'Suspended',
+        render: 'status-badge',
+        width: 80,
+      },
+      {
+        field: 'lastSchedule',
+        header: 'Last Run',
+        render: 'relative-time',
+        width: 80,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Clock',
+    title: 'No CronJobs',
+    message: 'No CronJobs found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: true,
+  isLive: true,
+}
+
+export default cronJobStatusConfig

--- a/web/src/config/cards/daemonset-status.ts
+++ b/web/src/config/cards/daemonset-status.ts
@@ -1,0 +1,111 @@
+/**
+ * DaemonSet Status Card Configuration
+ *
+ * Displays Kubernetes DaemonSets using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const daemonSetStatusConfig: UnifiedCardConfig = {
+  type: 'daemonset_status',
+  title: 'DaemonSets',
+  category: 'workloads',
+  description: 'Kubernetes DaemonSets across clusters',
+
+  // Appearance
+  icon: 'Layers',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useDaemonSets',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search daemonsets...',
+      searchFields: ['name', 'namespace', 'cluster'],
+      storageKey: 'daemonset-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'daemonset-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'numberReady',
+        header: 'Ready',
+        render: 'number',
+        align: 'right',
+        width: 60,
+      },
+      {
+        field: 'desiredNumberScheduled',
+        header: 'Desired',
+        render: 'number',
+        align: 'right',
+        width: 60,
+      },
+      {
+        field: 'numberAvailable',
+        header: 'Available',
+        render: 'number',
+        align: 'right',
+        width: 70,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Layers',
+    title: 'No DaemonSets',
+    message: 'No DaemonSets found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: true,
+  isLive: true,
+}
+
+export default daemonSetStatusConfig

--- a/web/src/config/cards/deployment-issues.ts
+++ b/web/src/config/cards/deployment-issues.ts
@@ -1,0 +1,114 @@
+/**
+ * Deployment Issues Card Configuration
+ *
+ * Displays Kubernetes Deployments with issues using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const deploymentIssuesConfig: UnifiedCardConfig = {
+  type: 'deployment_issues',
+  title: 'Deployment Issues',
+  category: 'workloads',
+  description: 'Kubernetes Deployments with replica or readiness issues',
+
+  // Appearance
+  icon: 'AlertTriangle',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useCachedDeploymentIssues',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search deployments...',
+      searchFields: ['name', 'namespace', 'cluster', 'reason', 'message'],
+      storageKey: 'deployment-issues',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'deployment-issues-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 5,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Deployment',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'reason',
+        header: 'Reason',
+        render: 'status-badge',
+        width: 120,
+      },
+      {
+        field: 'readyReplicas',
+        header: 'Ready',
+        render: 'replica-count',
+        width: 80,
+      },
+    ],
+  },
+
+  // Drill-down configuration
+  drillDown: {
+    action: 'drillToDeployment',
+    params: ['cluster', 'namespace', 'name'],
+    context: {
+      replicas: 'replicas',
+      readyReplicas: 'readyReplicas',
+      reason: 'reason',
+      message: 'message',
+    },
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'CheckCircle',
+    title: 'All deployments healthy',
+    message: 'No deployment issues detected',
+    variant: 'success',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 3,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default deploymentIssuesConfig

--- a/web/src/config/cards/deployment-missions.ts
+++ b/web/src/config/cards/deployment-missions.ts
@@ -1,0 +1,30 @@
+/**
+ * Deployment Missions Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const deploymentMissionsConfig: UnifiedCardConfig = {
+  type: 'deployment_missions',
+  title: 'Deployment Missions',
+  category: 'workloads',
+  description: 'Track deployment progress',
+  icon: 'Target',
+  iconColor: 'text-purple-400',
+  defaultWidth: 5,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useDeploymentMissions' },
+  content: {
+    type: 'list',
+    pageSize: 8,
+    columns: [
+      { field: 'name', header: 'Mission', primary: true, render: 'truncate' },
+      { field: 'progress', header: 'Progress', render: 'progress-bar', width: 100 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'Target', title: 'No Missions', message: 'No active deployment missions', variant: 'info' },
+  loadingState: { type: 'list', rows: 4 },
+  isDemoData: false,
+  isLive: true,
+}
+export default deploymentMissionsConfig

--- a/web/src/config/cards/deployment-progress.ts
+++ b/web/src/config/cards/deployment-progress.ts
@@ -1,0 +1,31 @@
+/**
+ * Deployment Progress Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const deploymentProgressConfig: UnifiedCardConfig = {
+  type: 'deployment_progress',
+  title: 'Deployment Progress',
+  category: 'workloads',
+  description: 'Track deployment rollout progress',
+  icon: 'RefreshCw',
+  iconColor: 'text-blue-400',
+  defaultWidth: 5,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useDeploymentProgress' },
+  content: {
+    type: 'list',
+    pageSize: 8,
+    columns: [
+      { field: 'name', header: 'Deployment', primary: true, render: 'truncate' },
+      { field: 'namespace', header: 'Namespace', render: 'namespace-badge', width: 100 },
+      { field: 'progress', header: 'Progress', render: 'progress-bar', width: 120 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'RefreshCw', title: 'No Rollouts', message: 'No deployments in progress', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default deploymentProgressConfig

--- a/web/src/config/cards/deployment-status.ts
+++ b/web/src/config/cards/deployment-status.ts
@@ -1,0 +1,128 @@
+/**
+ * Deployment Status Card Configuration
+ *
+ * Shows deployment health and replica status across clusters.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const deploymentStatusConfig: UnifiedCardConfig = {
+  type: 'deployment_status',
+  title: 'Deployment Status',
+  category: 'workloads',
+  description: 'Status of deployments showing replica counts and health',
+
+  // Appearance
+  icon: 'Layers',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useCachedDeployments',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search deployments...',
+      searchFields: ['name', 'namespace', 'cluster'],
+      storageKey: 'deployment-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'deployment-status-cluster',
+    },
+  ],
+
+  // Content - Table visualization
+  content: {
+    type: 'table',
+    pageSize: 10,
+    sortable: true,
+    defaultSort: 'name',
+    defaultDirection: 'asc',
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 120,
+        sortable: true,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 120,
+        sortable: true,
+      },
+      {
+        field: 'name',
+        header: 'Deployment',
+        primary: true,
+        sortable: true,
+      },
+      {
+        field: 'readyReplicas',
+        header: 'Ready',
+        render: 'number',
+        align: 'center',
+        width: 70,
+        sortable: true,
+      },
+      {
+        field: 'replicas',
+        header: 'Total',
+        render: 'number',
+        align: 'center',
+        width: 70,
+        sortable: true,
+      },
+      {
+        field: 'status',
+        header: 'Status',
+        render: 'status-badge',
+        width: 100,
+        sortable: true,
+      },
+    ],
+  },
+
+  // Drill-down
+  drillDown: {
+    action: 'drillToDeployment',
+    params: ['cluster', 'namespace', 'name'],
+    context: {
+      replicas: 'replicas',
+      readyReplicas: 'readyReplicas',
+    },
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Layers',
+    title: 'No deployments found',
+    message: 'No deployments in selected clusters',
+    variant: 'neutral',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'table',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default deploymentStatusConfig

--- a/web/src/config/cards/dynamic-card.ts
+++ b/web/src/config/cards/dynamic-card.ts
@@ -1,0 +1,22 @@
+/**
+ * Dynamic Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const dynamicCardConfig: UnifiedCardConfig = {
+  type: 'dynamic_card',
+  title: 'Dynamic Card',
+  category: 'utility',
+  description: 'User-defined dynamic card',
+  icon: 'Sparkles',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'DynamicCardRenderer' },
+  emptyState: { icon: 'Sparkles', title: 'Dynamic', message: 'Configure card', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default dynamicCardConfig

--- a/web/src/config/cards/event-stream.ts
+++ b/web/src/config/cards/event-stream.ts
@@ -1,0 +1,126 @@
+/**
+ * Event Stream Card Configuration
+ *
+ * Shows recent Kubernetes events across clusters.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const eventStreamConfig: UnifiedCardConfig = {
+  type: 'event_stream',
+  title: 'Event Stream',
+  category: 'live-trends',
+  description: 'Real-time stream of Kubernetes events across clusters',
+
+  // Appearance
+  icon: 'Activity',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useCachedEvents',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search events...',
+      searchFields: ['reason', 'message', 'involvedObject.name', 'involvedObject.kind'],
+      storageKey: 'event-stream',
+    },
+    {
+      field: 'type',
+      type: 'chips',
+      label: 'Type',
+      options: [
+        { value: 'Warning', label: 'Warning', color: 'text-yellow-400' },
+        { value: 'Normal', label: 'Normal', color: 'text-blue-400' },
+      ],
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'event-stream-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    itemClick: 'drill',
+    columns: [
+      {
+        field: 'type',
+        header: 'Type',
+        render: 'status-badge',
+        width: 80,
+      },
+      {
+        field: 'lastTimestamp',
+        header: 'Time',
+        render: 'relative-time',
+        width: 80,
+      },
+      {
+        field: 'involvedObject.kind',
+        header: 'Kind',
+        width: 80,
+      },
+      {
+        field: 'involvedObject.name',
+        header: 'Object',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'reason',
+        header: 'Reason',
+        width: 120,
+      },
+      {
+        field: 'message',
+        header: 'Message',
+        render: 'truncate',
+      },
+    ],
+  },
+
+  // Drill-down
+  drillDown: {
+    action: 'drillToEvent',
+    params: ['cluster', 'namespace', 'involvedObject.name', 'involvedObject.kind'],
+    context: {
+      reason: 'reason',
+      message: 'message',
+      type: 'type',
+    },
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Activity',
+    title: 'No recent events',
+    message: 'Cluster activity will appear here',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default eventStreamConfig

--- a/web/src/config/cards/event-summary.ts
+++ b/web/src/config/cards/event-summary.ts
@@ -1,0 +1,30 @@
+/**
+ * Event Summary Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const eventSummaryConfig: UnifiedCardConfig = {
+  type: 'event_summary',
+  title: 'Event Summary',
+  category: 'events',
+  description: 'Summary of Kubernetes events',
+  icon: 'Activity',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useEventSummary' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'total', label: 'Total', color: 'blue' },
+      { field: 'normal', label: 'Normal', color: 'green' },
+      { field: 'warning', label: 'Warning', color: 'yellow' },
+      { field: 'error', label: 'Error', color: 'red' },
+    ],
+  },
+  emptyState: { icon: 'Activity', title: 'No Events', message: 'No events recorded', variant: 'info' },
+  loadingState: { type: 'stats', count: 4 },
+  isDemoData: false,
+  isLive: true,
+}
+export default eventSummaryConfig

--- a/web/src/config/cards/events-timeline.ts
+++ b/web/src/config/cards/events-timeline.ts
@@ -1,0 +1,107 @@
+/**
+ * Events Timeline Card Configuration
+ *
+ * Shows event counts over time using a bar chart.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const eventsTimelineConfig: UnifiedCardConfig = {
+  type: 'events_timeline',
+  title: 'Events Timeline',
+  category: 'alerting',
+  description: 'Event frequency over time',
+
+  // Appearance
+  icon: 'Clock',
+  iconColor: 'text-amber-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useCachedEventsTimeline',
+  },
+
+  // Inline stats
+  stats: [
+    {
+      id: 'totalEvents',
+      icon: 'Bell',
+      color: 'text-amber-400',
+      bgColor: 'bg-amber-500/10',
+      label: 'Total',
+      valueSource: { type: 'computed', expression: 'sum:count' },
+    },
+    {
+      id: 'warningEvents',
+      icon: 'AlertTriangle',
+      color: 'text-orange-400',
+      bgColor: 'bg-orange-500/10',
+      label: 'Warnings',
+      valueSource: { type: 'computed', expression: 'sum:warnings' },
+    },
+    {
+      id: 'errorEvents',
+      icon: 'AlertCircle',
+      color: 'text-red-400',
+      bgColor: 'bg-red-500/10',
+      label: 'Errors',
+      valueSource: { type: 'computed', expression: 'sum:errors' },
+    },
+  ],
+
+  // Content - Bar chart visualization
+  content: {
+    type: 'chart',
+    chartType: 'bar',
+    height: 180,
+    showLegend: true,
+    xAxis: {
+      field: 'time',
+      label: 'Time',
+    },
+    yAxis: {
+      label: 'Events',
+    },
+    series: [
+      {
+        field: 'normal',
+        label: 'Normal',
+        color: '#22c55e', // green
+      },
+      {
+        field: 'warnings',
+        label: 'Warning',
+        color: '#f59e0b', // amber
+      },
+      {
+        field: 'errors',
+        label: 'Error',
+        color: '#ef4444', // red
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Clock',
+    title: 'No events',
+    message: 'Event history will appear here',
+    variant: 'neutral',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'chart',
+    rows: 1,
+    showSearch: false,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default eventsTimelineConfig

--- a/web/src/config/cards/external-secrets.ts
+++ b/web/src/config/cards/external-secrets.ts
@@ -1,0 +1,29 @@
+/**
+ * External Secrets Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const externalSecretsConfig: UnifiedCardConfig = {
+  type: 'external_secrets',
+  title: 'External Secrets',
+  category: 'security',
+  description: 'External Secrets Operator status',
+  icon: 'Key',
+  iconColor: 'text-purple-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useExternalSecrets' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'total', label: 'Total', color: 'blue' },
+      { field: 'ready', label: 'Ready', color: 'green' },
+      { field: 'failed', label: 'Failed', color: 'red' },
+    ],
+  },
+  emptyState: { icon: 'Key', title: 'No ESO', message: 'External Secrets not configured', variant: 'info' },
+  loadingState: { type: 'stats', count: 3 },
+  isDemoData: true,
+  isLive: false,
+}
+export default externalSecretsConfig

--- a/web/src/config/cards/falco-alerts.ts
+++ b/web/src/config/cards/falco-alerts.ts
@@ -1,0 +1,29 @@
+/**
+ * Falco Alerts Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const falcoAlertsConfig: UnifiedCardConfig = {
+  type: 'falco_alerts',
+  title: 'Falco Alerts',
+  category: 'security',
+  description: 'Runtime security alerts from Falco',
+  icon: 'AlertTriangle',
+  iconColor: 'text-red-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useFalcoAlerts' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'critical', label: 'Critical', color: 'red' },
+      { field: 'warning', label: 'Warning', color: 'yellow' },
+      { field: 'notice', label: 'Notice', color: 'blue' },
+    ],
+  },
+  emptyState: { icon: 'AlertTriangle', title: 'No Alerts', message: 'No Falco alerts', variant: 'success' },
+  loadingState: { type: 'stats', count: 3 },
+  isDemoData: true,
+  isLive: false,
+}
+export default falcoAlertsConfig

--- a/web/src/config/cards/flappy-pod.ts
+++ b/web/src/config/cards/flappy-pod.ts
@@ -1,0 +1,22 @@
+/**
+ * Flappy Pod Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const flappyPodConfig: UnifiedCardConfig = {
+  type: 'flappy_pod',
+  title: 'Flappy Pod',
+  category: 'games',
+  description: 'Flappy bird with pods',
+  icon: 'Bird',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'FlappyPod' },
+  emptyState: { icon: 'Bird', title: 'Flappy Pod', message: 'Press space to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default flappyPodConfig

--- a/web/src/config/cards/game-2048.ts
+++ b/web/src/config/cards/game-2048.ts
@@ -1,0 +1,22 @@
+/**
+ * 2048 Game Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const game2048Config: UnifiedCardConfig = {
+  type: 'game_2048',
+  title: 'Kube 2048',
+  category: 'games',
+  description: 'Classic 2048 sliding puzzle',
+  icon: 'Grid2X2',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'Game2048' },
+  emptyState: { icon: 'Grid2X2', title: '2048', message: 'Start a new game', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default game2048Config

--- a/web/src/config/cards/gateway-status.ts
+++ b/web/src/config/cards/gateway-status.ts
@@ -1,0 +1,31 @@
+/**
+ * Gateway Status Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const gatewayStatusConfig: UnifiedCardConfig = {
+  type: 'gateway_status',
+  title: 'Gateway Status',
+  category: 'network',
+  description: 'Gateway API resources',
+  icon: 'Router',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useGatewayStatus' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Gateway', primary: true, render: 'truncate' },
+      { field: 'class', header: 'Class', render: 'text', width: 100 },
+      { field: 'addresses', header: 'Addresses', render: 'number', width: 80 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'Router', title: 'No Gateways', message: 'No Gateway API resources', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default gatewayStatusConfig

--- a/web/src/config/cards/github-activity.ts
+++ b/web/src/config/cards/github-activity.ts
@@ -1,0 +1,31 @@
+/**
+ * GitHub Activity Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const githubActivityConfig: UnifiedCardConfig = {
+  type: 'github_activity',
+  title: 'GitHub Activity',
+  category: 'ci-cd',
+  description: 'Recent GitHub repository activity',
+  icon: 'Github',
+  iconColor: 'text-gray-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useGithubActivity' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'type', header: 'Event', render: 'text', width: 80 },
+      { field: 'repo', header: 'Repository', primary: true, render: 'truncate' },
+      { field: 'actor', header: 'Actor', render: 'text', width: 100 },
+      { field: 'timestamp', header: 'Time', render: 'relative-time', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'Github', title: 'No Activity', message: 'No recent GitHub activity', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default githubActivityConfig

--- a/web/src/config/cards/github-ci-monitor.ts
+++ b/web/src/config/cards/github-ci-monitor.ts
@@ -1,0 +1,22 @@
+/**
+ * GitHub CI Monitor Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const githubCiMonitorConfig: UnifiedCardConfig = {
+  type: 'github_ci_monitor',
+  title: 'GitHub Actions',
+  category: 'ci-cd',
+  description: 'GitHub Actions monitoring',
+  icon: 'Github',
+  iconColor: 'text-gray-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useGitHubCIMonitor' },
+  content: { type: 'custom', component: 'GitHubCIView' },
+  emptyState: { icon: 'Github', title: 'No Actions', message: 'GitHub Actions not configured', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default githubCiMonitorConfig

--- a/web/src/config/cards/gitops-drift.ts
+++ b/web/src/config/cards/gitops-drift.ts
@@ -1,0 +1,77 @@
+/**
+ * GitOps Drift Card Configuration
+ *
+ * Displays resources that have drifted from their Git source.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const gitopsDriftConfig: UnifiedCardConfig = {
+  type: 'gitops_drift',
+  title: 'GitOps Drift',
+  category: 'gitops',
+  description: 'Resources that have drifted from their declared state',
+  icon: 'GitBranch',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  dataSource: {
+    type: 'hook',
+    hook: 'useGitOpsDrift',
+  },
+
+  stats: [
+    {
+      id: 'drifted',
+      icon: 'AlertTriangle',
+      color: 'yellow',
+      label: 'Drifted',
+      bgColor: 'bg-yellow-500',
+      valueSource: { type: 'count' },
+    },
+  ],
+
+  content: {
+    type: 'list',
+    columns: [
+      {
+        field: 'status',
+        header: '',
+        width: 32,
+        render: 'status-badge',
+      },
+      {
+        field: 'resource',
+        header: 'Resource',
+        primary: true,
+      },
+      {
+        field: 'kind',
+        header: 'Kind',
+        width: 100,
+      },
+      {
+        field: 'lastSync',
+        header: 'Last Sync',
+        width: 100,
+        render: 'relative-time',
+      },
+    ],
+    pageSize: 6,
+  },
+
+  emptyState: {
+    icon: 'GitMerge',
+    title: 'No drift detected',
+    message: 'All resources are in sync',
+    variant: 'success',
+  },
+
+  drillDown: {
+    action: 'showGitOpsDrift',
+    params: ['resource', 'kind', 'namespace'],
+  },
+
+  isDemoData: true,
+}

--- a/web/src/config/cards/gpu-inventory.ts
+++ b/web/src/config/cards/gpu-inventory.ts
@@ -1,0 +1,35 @@
+/**
+ * GPU Inventory Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const gpuInventoryConfig: UnifiedCardConfig = {
+  type: 'gpu_inventory',
+  title: 'GPU Inventory',
+  category: 'compute',
+  description: 'Available GPU resources',
+  icon: 'Cpu',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useGPUInventory' },
+  filters: [
+    { field: 'search', type: 'text', placeholder: 'Search GPUs...', searchFields: ['name', 'model', 'cluster'], storageKey: 'gpu-inventory' },
+  ],
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'cluster', header: 'Cluster', render: 'cluster-badge', width: 100 },
+      { field: 'node', header: 'Node', render: 'text', width: 120 },
+      { field: 'model', header: 'Model', primary: true, render: 'truncate' },
+      { field: 'memory', header: 'Memory', render: 'bytes', width: 80 },
+      { field: 'utilization', header: 'Util %', render: 'percentage', width: 70 },
+    ],
+  },
+  emptyState: { icon: 'Cpu', title: 'No GPUs', message: 'No GPU resources found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default gpuInventoryConfig

--- a/web/src/config/cards/gpu-overview.ts
+++ b/web/src/config/cards/gpu-overview.ts
@@ -1,0 +1,30 @@
+/**
+ * GPU Overview Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const gpuOverviewConfig: UnifiedCardConfig = {
+  type: 'gpu_overview',
+  title: 'GPU Overview',
+  category: 'compute',
+  description: 'GPU resource summary',
+  icon: 'Cpu',
+  iconColor: 'text-green-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useGPUOverview' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'total', label: 'Total GPUs', color: 'blue' },
+      { field: 'available', label: 'Available', color: 'green' },
+      { field: 'inUse', label: 'In Use', color: 'orange' },
+      { field: 'avgUtilization', label: 'Avg Util %', color: 'purple', format: 'percentage' },
+    ],
+  },
+  emptyState: { icon: 'Cpu', title: 'No GPUs', message: 'No GPU data available', variant: 'info' },
+  loadingState: { type: 'stats', count: 4 },
+  isDemoData: true,
+  isLive: false,
+}
+export default gpuOverviewConfig

--- a/web/src/config/cards/gpu-status.ts
+++ b/web/src/config/cards/gpu-status.ts
@@ -1,0 +1,31 @@
+/**
+ * GPU Status Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const gpuStatusConfig: UnifiedCardConfig = {
+  type: 'gpu_status',
+  title: 'GPU Status',
+  category: 'compute',
+  description: 'GPU health and status',
+  icon: 'Activity',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useGPUStatus' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'GPU', primary: true, render: 'truncate' },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+      { field: 'temperature', header: 'Temp', render: 'text', width: 60, suffix: '°C' },
+      { field: 'power', header: 'Power', render: 'text', width: 60, suffix: 'W' },
+    ],
+  },
+  emptyState: { icon: 'Activity', title: 'No GPUs', message: 'No GPU status available', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default gpuStatusConfig

--- a/web/src/config/cards/gpu-usage-trend.ts
+++ b/web/src/config/cards/gpu-usage-trend.ts
@@ -1,0 +1,29 @@
+/**
+ * GPU Usage Trend Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const gpuUsageTrendConfig: UnifiedCardConfig = {
+  type: 'gpu_usage_trend',
+  title: 'GPU Usage Trend',
+  category: 'live-trends',
+  description: 'Historical GPU usage over time',
+  icon: 'BarChart2',
+  iconColor: 'text-green-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useGPUUsageTrend' },
+  content: {
+    type: 'chart',
+    chartType: 'area',
+    dataKey: 'timeseries',
+    xAxis: 'timestamp',
+    yAxis: ['memory', 'compute'],
+    colors: ['#10b981', '#3b82f6'],
+  },
+  emptyState: { icon: 'BarChart2', title: 'No Data', message: 'No GPU trend data', variant: 'info' },
+  loadingState: { type: 'chart' },
+  isDemoData: true,
+  isLive: true,
+}
+export default gpuUsageTrendConfig

--- a/web/src/config/cards/gpu-utilization.ts
+++ b/web/src/config/cards/gpu-utilization.ts
@@ -1,0 +1,29 @@
+/**
+ * GPU Utilization Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const gpuUtilizationConfig: UnifiedCardConfig = {
+  type: 'gpu_utilization',
+  title: 'GPU Utilization',
+  category: 'live-trends',
+  description: 'Real-time GPU utilization chart',
+  icon: 'TrendingUp',
+  iconColor: 'text-green-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useGPUUtilization' },
+  content: {
+    type: 'chart',
+    chartType: 'line',
+    dataKey: 'timeseries',
+    xAxis: 'timestamp',
+    yAxis: ['utilization'],
+    colors: ['#10b981'],
+  },
+  emptyState: { icon: 'TrendingUp', title: 'No Data', message: 'No GPU utilization data', variant: 'info' },
+  loadingState: { type: 'chart' },
+  isDemoData: true,
+  isLive: true,
+}
+export default gpuUtilizationConfig

--- a/web/src/config/cards/gpu-workloads.ts
+++ b/web/src/config/cards/gpu-workloads.ts
@@ -1,0 +1,31 @@
+/**
+ * GPU Workloads Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const gpuWorkloadsConfig: UnifiedCardConfig = {
+  type: 'gpu_workloads',
+  title: 'GPU Workloads',
+  category: 'compute',
+  description: 'Workloads using GPU resources',
+  icon: 'Zap',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useGPUWorkloads' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Workload', primary: true, render: 'truncate' },
+      { field: 'namespace', header: 'Namespace', render: 'namespace-badge', width: 100 },
+      { field: 'gpuCount', header: 'GPUs', render: 'number', width: 60 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'Zap', title: 'No Workloads', message: 'No GPU workloads found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default gpuWorkloadsConfig

--- a/web/src/config/cards/hardware-health.ts
+++ b/web/src/config/cards/hardware-health.ts
@@ -1,0 +1,41 @@
+/**
+ * Hardware Health Card Configuration
+ *
+ * Monitors hardware device disappearances on SuperMicro/HGX nodes.
+ * Tracks GPUs, NICs, NVMe, InfiniBand, MOFED drivers, GPU drivers, etc.
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const hardwareHealthConfig: UnifiedCardConfig = {
+  type: 'hardware_health',
+  title: 'Hardware Health',
+  category: 'cluster-health',
+  description: 'Track hardware device disappearances on SuperMicro/HGX nodes',
+  icon: 'Cpu',
+  iconColor: 'text-red-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useHardwareHealth' },
+  content: {
+    type: 'list',
+    pageSize: 5,
+    columns: [
+      { field: 'nodeName', header: 'Node', primary: true },
+      { field: 'deviceType', header: 'Device', width: 80 },
+      { field: 'cluster', header: 'Cluster', render: 'cluster-badge', width: 100 },
+      { field: 'droppedCount', header: 'Dropped', width: 60 },
+      { field: 'severity', header: 'Severity', render: 'severity-badge', width: 80 },
+    ],
+  },
+  emptyState: {
+    icon: 'CheckCircle',
+    title: 'All Healthy',
+    message: 'All hardware devices are healthy',
+    variant: 'success',
+  },
+  loadingState: { type: 'list', rows: 3 },
+  isDemoData: false,
+  isLive: true,
+}
+
+export default hardwareHealthConfig

--- a/web/src/config/cards/helm-history.ts
+++ b/web/src/config/cards/helm-history.ts
@@ -1,0 +1,32 @@
+/**
+ * Helm History Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const helmHistoryConfig: UnifiedCardConfig = {
+  type: 'helm_history',
+  title: 'Helm History',
+  category: 'gitops',
+  description: 'Helm release revision history',
+  icon: 'History',
+  iconColor: 'text-blue-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useHelmHistory' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'revision', header: 'Rev', render: 'number', width: 50 },
+      { field: 'chart', header: 'Chart', primary: true, render: 'truncate' },
+      { field: 'appVersion', header: 'App Ver', render: 'text', width: 80 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+      { field: 'updated', header: 'Updated', render: 'relative-time', width: 100 },
+    ],
+  },
+  emptyState: { icon: 'History', title: 'No History', message: 'No release history available', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: false,
+}
+export default helmHistoryConfig

--- a/web/src/config/cards/helm-release-status.ts
+++ b/web/src/config/cards/helm-release-status.ts
@@ -1,0 +1,120 @@
+/**
+ * Helm Release Status Card Configuration
+ *
+ * Displays Helm releases across clusters using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const helmReleaseStatusConfig: UnifiedCardConfig = {
+  type: 'helm_release_status',
+  title: 'Helm Release Status',
+  category: 'gitops',
+  description: 'Helm releases across clusters',
+
+  // Appearance
+  icon: 'Package',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useHelmReleases',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search releases...',
+      searchFields: ['name', 'namespace', 'chart', 'cluster'],
+      storageKey: 'helm-release-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'helm-release-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 5,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Release',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'chart',
+        header: 'Chart',
+        render: 'text',
+        width: 100,
+      },
+      {
+        field: 'status',
+        header: 'Status',
+        render: 'status-badge',
+        width: 90,
+      },
+      {
+        field: 'revision',
+        header: 'Rev',
+        render: 'number',
+        align: 'right',
+        width: 50,
+      },
+    ],
+  },
+
+  // Drill-down configuration
+  drillDown: {
+    action: 'drillToHelm',
+    params: ['cluster', 'namespace', 'name'],
+    context: {
+      chart: 'chart',
+      status: 'status',
+      revision: 'revision',
+    },
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Package',
+    title: 'No Helm releases',
+    message: 'No Helm releases found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 3,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default helmReleaseStatusConfig

--- a/web/src/config/cards/helm-values-diff.ts
+++ b/web/src/config/cards/helm-values-diff.ts
@@ -1,0 +1,25 @@
+/**
+ * Helm Values Diff Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const helmValuesDiffConfig: UnifiedCardConfig = {
+  type: 'helm_values_diff',
+  title: 'Helm Values Diff',
+  category: 'gitops',
+  description: 'Compare Helm values between revisions',
+  icon: 'FileDiff',
+  iconColor: 'text-purple-400',
+  defaultWidth: 8,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useHelmValuesDiff' },
+  content: {
+    type: 'custom',
+    component: 'DiffViewer',
+  },
+  emptyState: { icon: 'FileDiff', title: 'No Diff', message: 'Select revisions to compare', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default helmValuesDiffConfig

--- a/web/src/config/cards/hpa-status.ts
+++ b/web/src/config/cards/hpa-status.ts
@@ -1,0 +1,117 @@
+/**
+ * HPA Status Card Configuration
+ *
+ * Displays Kubernetes HorizontalPodAutoscalers using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const hpaStatusConfig: UnifiedCardConfig = {
+  type: 'hpa_status',
+  title: 'Autoscalers',
+  category: 'workloads',
+  description: 'Kubernetes HorizontalPodAutoscalers across clusters',
+
+  // Appearance
+  icon: 'TrendingUp',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useHPAs',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search HPAs...',
+      searchFields: ['name', 'namespace', 'cluster', 'targetRef'],
+      storageKey: 'hpa-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'hpa-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'targetRef',
+        header: 'Target',
+        render: 'text',
+        width: 100,
+      },
+      {
+        field: 'currentReplicas',
+        header: 'Current',
+        render: 'number',
+        align: 'right',
+        width: 60,
+      },
+      {
+        field: 'minReplicas',
+        header: 'Min',
+        render: 'number',
+        align: 'right',
+        width: 50,
+      },
+      {
+        field: 'maxReplicas',
+        header: 'Max',
+        render: 'number',
+        align: 'right',
+        width: 50,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'TrendingUp',
+    title: 'No Autoscalers',
+    message: 'No HPAs found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: true,
+  isLive: true,
+}
+
+export default hpaStatusConfig

--- a/web/src/config/cards/iframe-embed.ts
+++ b/web/src/config/cards/iframe-embed.ts
@@ -1,0 +1,22 @@
+/**
+ * Iframe Embed Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const iframeEmbedConfig: UnifiedCardConfig = {
+  type: 'iframe_embed',
+  title: 'Embed',
+  category: 'utility',
+  description: 'Embed external content',
+  icon: 'Globe',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'IframeEmbed' },
+  emptyState: { icon: 'Globe', title: 'Embed', message: 'Configure URL to embed', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default iframeEmbedConfig

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -1,0 +1,456 @@
+/**
+ * Card Configuration Registry - Auto-generated
+ */
+
+import type { UnifiedCardConfig, CardConfigRegistry } from '../../lib/unified/types'
+
+import { activeAlertsConfig } from './active-alerts'
+import { alertRulesConfig } from './alert-rules'
+import { appStatusConfig } from './app-status'
+import { argocdApplicationsConfig } from './argocd-applications'
+import { argocdHealthConfig } from './argocd-health'
+import { argocdSyncStatusConfig } from './argocd-sync-status'
+import { certManagerConfig } from './cert-manager'
+import { chartVersionsConfig } from './chart-versions'
+import { checkersConfig } from './checkers'
+import { clusterComparisonConfig } from './cluster-comparison'
+import { clusterCostsConfig } from './cluster-costs'
+import { clusterFocusConfig } from './cluster-focus'
+import { clusterGroupsConfig } from './cluster-groups'
+import { clusterHealthConfig } from './cluster-health'
+import { clusterHealthMonitorConfig } from './cluster-health-monitor'
+import { clusterLocationsConfig } from './cluster-locations'
+import { clusterMetricsConfig } from './cluster-metrics'
+import { clusterNetworkConfig } from './cluster-network'
+import { clusterResourceTreeConfig } from './cluster-resource-tree'
+import { complianceScoreConfig } from './compliance-score'
+import { computeOverviewConfig } from './compute-overview'
+import { configMapStatusConfig } from './configmap-status'
+import { consoleAiHealthCheckConfig } from './console-ai-health-check'
+import { consoleAiIssuesConfig } from './console-ai-issues'
+import { consoleAiKubeconfigAuditConfig } from './console-ai-kubeconfig-audit'
+import { consoleAiOfflineDetectionConfig } from './console-ai-offline-detection'
+import { containerTetrisConfig } from './container-tetris'
+import { crdHealthConfig } from './crd-health'
+import { cronJobStatusConfig } from './cronjob-status'
+import { daemonSetStatusConfig } from './daemonset-status'
+import { deploymentIssuesConfig } from './deployment-issues'
+import { deploymentMissionsConfig } from './deployment-missions'
+import { deploymentProgressConfig } from './deployment-progress'
+import { deploymentStatusConfig } from './deployment-status'
+import { dynamicCardConfig } from './dynamic-card'
+import { eventStreamConfig } from './event-stream'
+import { eventSummaryConfig } from './event-summary'
+import { eventsTimelineConfig } from './events-timeline'
+import { externalSecretsConfig } from './external-secrets'
+import { falcoAlertsConfig } from './falco-alerts'
+import { flappyPodConfig } from './flappy-pod'
+import { game2048Config } from './game-2048'
+import { gatewayStatusConfig } from './gateway-status'
+import { githubActivityConfig } from './github-activity'
+import { githubCiMonitorConfig } from './github-ci-monitor'
+import { gitopsDriftConfig } from './gitops-drift'
+import { gpuInventoryConfig } from './gpu-inventory'
+import { gpuOverviewConfig } from './gpu-overview'
+import { gpuStatusConfig } from './gpu-status'
+import { gpuUsageTrendConfig } from './gpu-usage-trend'
+import { gpuUtilizationConfig } from './gpu-utilization'
+import { gpuWorkloadsConfig } from './gpu-workloads'
+import { hardwareHealthConfig } from './hardware-health'
+import { helmHistoryConfig } from './helm-history'
+import { helmReleaseStatusConfig } from './helm-release-status'
+import { helmValuesDiffConfig } from './helm-values-diff'
+import { hpaStatusConfig } from './hpa-status'
+import { iframeEmbedConfig } from './iframe-embed'
+import { ingressStatusConfig } from './ingress-status'
+import { jobStatusConfig } from './job-status'
+import { kubeChessConfig } from './kube-chess'
+import { kubeCraftConfig } from './kube-craft'
+import { kubeDoomConfig } from './kube-doom'
+import { kubeGalagaConfig } from './kube-galaga'
+import { kubeKartConfig } from './kube-kart'
+import { kubeKongConfig } from './kube-kong'
+import { kubeManConfig } from './kube-man'
+import { kubePongConfig } from './kube-pong'
+import { kubeSnakeConfig } from './kube-snake'
+import { kubecostOverviewConfig } from './kubecost-overview'
+import { kubectlConfig } from './kubectl'
+import { kubedleConfig } from './kubedle'
+import { kubescapeScanConfig } from './kubescape-scan'
+import { kustomizationStatusConfig } from './kustomization-status'
+import { kyvernoPoliciesConfig } from './kyverno-policies'
+import { limitRangeStatusConfig } from './limit-range-status'
+import { llmInferenceConfig } from './llm-inference'
+import { llmModelsConfig } from './llm-models'
+import { llmdStackMonitorConfig } from './llmd-stack-monitor'
+import { matchGameConfig } from './match-game'
+import { mlJobsConfig } from './ml-jobs'
+import { mlNotebooksConfig } from './ml-notebooks'
+import { mobileBrowserConfig } from './mobile-browser'
+import { namespaceEventsConfig } from './namespace-events'
+import { namespaceMonitorConfig } from './namespace-monitor'
+import { namespaceOverviewConfig } from './namespace-overview'
+import { namespaceQuotasConfig } from './namespace-quotas'
+import { namespaceRbacConfig } from './namespace-rbac'
+import { namespaceStatusConfig } from './namespace-status'
+import { networkOverviewConfig } from './network-overview'
+import { networkPolicyStatusConfig } from './network-policy-status'
+import { networkUtilsConfig } from './network-utils'
+import { nodeInvadersConfig } from './node-invaders'
+import { nodeStatusConfig } from './node-status'
+import { opaPoliciesConfig } from './opa-policies'
+import { opencostOverviewConfig } from './opencost-overview'
+import { operatorStatusConfig } from './operator-status'
+import { operatorSubscriptionStatusConfig } from './operator-subscription-status'
+import { overlayComparisonConfig } from './overlay-comparison'
+import { podBrothersConfig } from './pod-brothers'
+import { podCrosserConfig } from './pod-crosser'
+import { podHealthTrendConfig } from './pod-health-trend'
+import { podIssuesConfig } from './pod-issues'
+import { podPitfallConfig } from './pod-pitfall'
+import { podSweeperConfig } from './pod-sweeper'
+import { policyViolationsConfig } from './policy-violations'
+import { providerHealthConfig } from './provider-health'
+import { prowCiMonitorConfig } from './prow-ci-monitor'
+import { prowHistoryConfig } from './prow-history'
+import { prowJobsConfig } from './prow-jobs'
+import { prowStatusConfig } from './prow-status'
+import { pvStatusConfig } from './pv-status'
+import { pvcStatusConfig } from './pvc-status'
+import { recentEventsConfig } from './recent-events'
+import { replicaSetStatusConfig } from './replicaset-status'
+import { resourceCapacityConfig } from './resource-capacity'
+import { resourceMarshallConfig } from './resource-marshall'
+import { resourceQuotaStatusConfig } from './resource-quota-status'
+import { resourceTrendConfig } from './resource-trend'
+import { resourceUsageConfig } from './resource-usage'
+import { roleBindingStatusConfig } from './role-binding-status'
+import { roleStatusConfig } from './role-status'
+import { rssFeedConfig } from './rss-feed'
+import { secretStatusConfig } from './secret-status'
+import { securityIssuesConfig } from './security-issues'
+import { serviceAccountStatusConfig } from './service-account-status'
+import { serviceExportsConfig } from './service-exports'
+import { serviceImportsConfig } from './service-imports'
+import { serviceStatusConfig } from './service-status'
+import { serviceTopologyConfig } from './service-topology'
+import { solitaireConfig } from './solitaire'
+import { statefulSetStatusConfig } from './statefulset-status'
+import { stockMarketTickerConfig } from './stock-market-ticker'
+import { storageOverviewConfig } from './storage-overview'
+import { sudokuGameConfig } from './sudoku-game'
+import { topPodsConfig } from './top-pods'
+import { trivyScanConfig } from './trivy-scan'
+import { upgradeStatusConfig } from './upgrade-status'
+import { userManagementConfig } from './user-management'
+import { vaultSecretsConfig } from './vault-secrets'
+import { warningEventsConfig } from './warning-events'
+import { weatherConfig } from './weather'
+import { workloadDeploymentConfig } from './workload-deployment'
+import { workloadMonitorConfig } from './workload-monitor'
+
+export const CARD_CONFIGS: CardConfigRegistry = {
+  active_alerts: activeAlertsConfig,
+  alert_rules: alertRulesConfig,
+  app_status: appStatusConfig,
+  argocd_applications: argocdApplicationsConfig,
+  argocd_health: argocdHealthConfig,
+  argocd_sync_status: argocdSyncStatusConfig,
+  cert_manager: certManagerConfig,
+  chart_versions: chartVersionsConfig,
+  checkers: checkersConfig,
+  cluster_comparison: clusterComparisonConfig,
+  cluster_costs: clusterCostsConfig,
+  cluster_focus: clusterFocusConfig,
+  cluster_groups: clusterGroupsConfig,
+  cluster_health: clusterHealthConfig,
+  cluster_health_monitor: clusterHealthMonitorConfig,
+  cluster_locations: clusterLocationsConfig,
+  cluster_metrics: clusterMetricsConfig,
+  cluster_network: clusterNetworkConfig,
+  cluster_resource_tree: clusterResourceTreeConfig,
+  compliance_score: complianceScoreConfig,
+  compute_overview: computeOverviewConfig,
+  configmap_status: configMapStatusConfig,
+  console_ai_health_check: consoleAiHealthCheckConfig,
+  console_ai_issues: consoleAiIssuesConfig,
+  console_ai_kubeconfig_audit: consoleAiKubeconfigAuditConfig,
+  console_ai_offline_detection: consoleAiOfflineDetectionConfig,
+  container_tetris: containerTetrisConfig,
+  crd_health: crdHealthConfig,
+  cronjob_status: cronJobStatusConfig,
+  daemonset_status: daemonSetStatusConfig,
+  deployment_issues: deploymentIssuesConfig,
+  deployment_missions: deploymentMissionsConfig,
+  deployment_progress: deploymentProgressConfig,
+  deployment_status: deploymentStatusConfig,
+  dynamic_card: dynamicCardConfig,
+  event_stream: eventStreamConfig,
+  event_summary: eventSummaryConfig,
+  events_timeline: eventsTimelineConfig,
+  external_secrets: externalSecretsConfig,
+  falco_alerts: falcoAlertsConfig,
+  flappy_pod: flappyPodConfig,
+  game_2048: game2048Config,
+  gateway_status: gatewayStatusConfig,
+  github_activity: githubActivityConfig,
+  github_ci_monitor: githubCiMonitorConfig,
+  gitops_drift: gitopsDriftConfig,
+  gpu_inventory: gpuInventoryConfig,
+  gpu_overview: gpuOverviewConfig,
+  gpu_status: gpuStatusConfig,
+  gpu_usage_trend: gpuUsageTrendConfig,
+  gpu_utilization: gpuUtilizationConfig,
+  gpu_workloads: gpuWorkloadsConfig,
+  hardware_health: hardwareHealthConfig,
+  helm_history: helmHistoryConfig,
+  helm_release_status: helmReleaseStatusConfig,
+  helm_values_diff: helmValuesDiffConfig,
+  hpa_status: hpaStatusConfig,
+  iframe_embed: iframeEmbedConfig,
+  ingress_status: ingressStatusConfig,
+  job_status: jobStatusConfig,
+  kube_chess: kubeChessConfig,
+  kube_craft: kubeCraftConfig,
+  kube_doom: kubeDoomConfig,
+  kube_galaga: kubeGalagaConfig,
+  kube_kart: kubeKartConfig,
+  kube_kong: kubeKongConfig,
+  kube_man: kubeManConfig,
+  kube_pong: kubePongConfig,
+  kube_snake: kubeSnakeConfig,
+  kubecost_overview: kubecostOverviewConfig,
+  kubectl: kubectlConfig,
+  kubedle: kubedleConfig,
+  kubescape_scan: kubescapeScanConfig,
+  kustomization_status: kustomizationStatusConfig,
+  kyverno_policies: kyvernoPoliciesConfig,
+  limit_range_status: limitRangeStatusConfig,
+  llm_inference: llmInferenceConfig,
+  llm_models: llmModelsConfig,
+  llmd_stack_monitor: llmdStackMonitorConfig,
+  match_game: matchGameConfig,
+  ml_jobs: mlJobsConfig,
+  ml_notebooks: mlNotebooksConfig,
+  mobile_browser: mobileBrowserConfig,
+  namespace_events: namespaceEventsConfig,
+  namespace_monitor: namespaceMonitorConfig,
+  namespace_overview: namespaceOverviewConfig,
+  namespace_quotas: namespaceQuotasConfig,
+  namespace_rbac: namespaceRbacConfig,
+  namespace_status: namespaceStatusConfig,
+  network_overview: networkOverviewConfig,
+  network_policy_status: networkPolicyStatusConfig,
+  network_utils: networkUtilsConfig,
+  node_invaders: nodeInvadersConfig,
+  node_status: nodeStatusConfig,
+  opa_policies: opaPoliciesConfig,
+  opencost_overview: opencostOverviewConfig,
+  operator_status: operatorStatusConfig,
+  operator_subscription_status: operatorSubscriptionStatusConfig,
+  overlay_comparison: overlayComparisonConfig,
+  pod_brothers: podBrothersConfig,
+  pod_crosser: podCrosserConfig,
+  pod_health_trend: podHealthTrendConfig,
+  pod_issues: podIssuesConfig,
+  pod_pitfall: podPitfallConfig,
+  pod_sweeper: podSweeperConfig,
+  policy_violations: policyViolationsConfig,
+  provider_health: providerHealthConfig,
+  prow_ci_monitor: prowCiMonitorConfig,
+  prow_history: prowHistoryConfig,
+  prow_jobs: prowJobsConfig,
+  prow_status: prowStatusConfig,
+  pv_status: pvStatusConfig,
+  pvc_status: pvcStatusConfig,
+  recent_events: recentEventsConfig,
+  replicaset_status: replicaSetStatusConfig,
+  resource_capacity: resourceCapacityConfig,
+  resource_marshall: resourceMarshallConfig,
+  resource_quota_status: resourceQuotaStatusConfig,
+  resource_trend: resourceTrendConfig,
+  resource_usage: resourceUsageConfig,
+  role_binding_status: roleBindingStatusConfig,
+  role_status: roleStatusConfig,
+  rss_feed: rssFeedConfig,
+  secret_status: secretStatusConfig,
+  security_issues: securityIssuesConfig,
+  service_account_status: serviceAccountStatusConfig,
+  service_exports: serviceExportsConfig,
+  service_imports: serviceImportsConfig,
+  service_status: serviceStatusConfig,
+  service_topology: serviceTopologyConfig,
+  solitaire: solitaireConfig,
+  statefulset_status: statefulSetStatusConfig,
+  stock_market_ticker: stockMarketTickerConfig,
+  storage_overview: storageOverviewConfig,
+  sudoku_game: sudokuGameConfig,
+  top_pods: topPodsConfig,
+  trivy_scan: trivyScanConfig,
+  upgrade_status: upgradeStatusConfig,
+  user_management: userManagementConfig,
+  vault_secrets: vaultSecretsConfig,
+  warning_events: warningEventsConfig,
+  weather: weatherConfig,
+  workload_deployment: workloadDeploymentConfig,
+  workload_monitor: workloadMonitorConfig,
+}
+
+export function getCardConfig(cardType: string): UnifiedCardConfig | undefined {
+  return CARD_CONFIGS[cardType]
+}
+
+export function hasUnifiedConfig(cardType: string): boolean {
+  return cardType in CARD_CONFIGS
+}
+
+export function getUnifiedCardTypes(): string[] {
+  return Object.keys(CARD_CONFIGS)
+}
+
+// Re-export configs
+export {
+  activeAlertsConfig,
+  alertRulesConfig,
+  appStatusConfig,
+  argocdApplicationsConfig,
+  argocdHealthConfig,
+  argocdSyncStatusConfig,
+  certManagerConfig,
+  chartVersionsConfig,
+  checkersConfig,
+  clusterComparisonConfig,
+  clusterCostsConfig,
+  clusterFocusConfig,
+  clusterGroupsConfig,
+  clusterHealthConfig,
+  clusterHealthMonitorConfig,
+  clusterLocationsConfig,
+  clusterMetricsConfig,
+  clusterNetworkConfig,
+  clusterResourceTreeConfig,
+  complianceScoreConfig,
+  computeOverviewConfig,
+  configMapStatusConfig,
+  consoleAiHealthCheckConfig,
+  consoleAiIssuesConfig,
+  consoleAiKubeconfigAuditConfig,
+  consoleAiOfflineDetectionConfig,
+  containerTetrisConfig,
+  crdHealthConfig,
+  cronJobStatusConfig,
+  daemonSetStatusConfig,
+  deploymentIssuesConfig,
+  deploymentMissionsConfig,
+  deploymentProgressConfig,
+  deploymentStatusConfig,
+  dynamicCardConfig,
+  eventStreamConfig,
+  eventSummaryConfig,
+  eventsTimelineConfig,
+  externalSecretsConfig,
+  falcoAlertsConfig,
+  flappyPodConfig,
+  game2048Config,
+  gatewayStatusConfig,
+  githubActivityConfig,
+  githubCiMonitorConfig,
+  gitopsDriftConfig,
+  gpuInventoryConfig,
+  gpuOverviewConfig,
+  gpuStatusConfig,
+  gpuUsageTrendConfig,
+  gpuUtilizationConfig,
+  gpuWorkloadsConfig,
+  helmHistoryConfig,
+  helmReleaseStatusConfig,
+  helmValuesDiffConfig,
+  hpaStatusConfig,
+  iframeEmbedConfig,
+  ingressStatusConfig,
+  jobStatusConfig,
+  kubeChessConfig,
+  kubeCraftConfig,
+  kubeDoomConfig,
+  kubeGalagaConfig,
+  kubeKartConfig,
+  kubeKongConfig,
+  kubeManConfig,
+  kubePongConfig,
+  kubeSnakeConfig,
+  kubecostOverviewConfig,
+  kubectlConfig,
+  kubedleConfig,
+  kubescapeScanConfig,
+  kustomizationStatusConfig,
+  kyvernoPoliciesConfig,
+  limitRangeStatusConfig,
+  llmInferenceConfig,
+  llmModelsConfig,
+  llmdStackMonitorConfig,
+  matchGameConfig,
+  mlJobsConfig,
+  mlNotebooksConfig,
+  mobileBrowserConfig,
+  namespaceEventsConfig,
+  namespaceMonitorConfig,
+  namespaceOverviewConfig,
+  namespaceQuotasConfig,
+  namespaceRbacConfig,
+  namespaceStatusConfig,
+  networkOverviewConfig,
+  networkPolicyStatusConfig,
+  networkUtilsConfig,
+  nodeInvadersConfig,
+  nodeStatusConfig,
+  opaPoliciesConfig,
+  opencostOverviewConfig,
+  operatorStatusConfig,
+  operatorSubscriptionStatusConfig,
+  overlayComparisonConfig,
+  podBrothersConfig,
+  podCrosserConfig,
+  podHealthTrendConfig,
+  podIssuesConfig,
+  podPitfallConfig,
+  podSweeperConfig,
+  policyViolationsConfig,
+  providerHealthConfig,
+  prowCiMonitorConfig,
+  prowHistoryConfig,
+  prowJobsConfig,
+  prowStatusConfig,
+  pvStatusConfig,
+  pvcStatusConfig,
+  recentEventsConfig,
+  replicaSetStatusConfig,
+  resourceCapacityConfig,
+  resourceMarshallConfig,
+  resourceQuotaStatusConfig,
+  resourceTrendConfig,
+  resourceUsageConfig,
+  roleBindingStatusConfig,
+  roleStatusConfig,
+  rssFeedConfig,
+  secretStatusConfig,
+  securityIssuesConfig,
+  serviceAccountStatusConfig,
+  serviceExportsConfig,
+  serviceImportsConfig,
+  serviceStatusConfig,
+  serviceTopologyConfig,
+  solitaireConfig,
+  statefulSetStatusConfig,
+  stockMarketTickerConfig,
+  storageOverviewConfig,
+  sudokuGameConfig,
+  topPodsConfig,
+  trivyScanConfig,
+  upgradeStatusConfig,
+  userManagementConfig,
+  vaultSecretsConfig,
+  warningEventsConfig,
+  weatherConfig,
+  workloadDeploymentConfig,
+  workloadMonitorConfig,
+}

--- a/web/src/config/cards/ingress-status.ts
+++ b/web/src/config/cards/ingress-status.ts
@@ -1,0 +1,102 @@
+/**
+ * Ingress Status Card Configuration
+ *
+ * Displays Kubernetes Ingresses using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const ingressStatusConfig: UnifiedCardConfig = {
+  type: 'ingress_status',
+  title: 'Ingress Status',
+  category: 'network',
+  description: 'Kubernetes Ingresses across clusters',
+
+  // Appearance
+  icon: 'Globe',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useIngresses',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search ingresses...',
+      searchFields: ['name', 'namespace', 'cluster', 'host'],
+      storageKey: 'ingress-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'ingress-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'host',
+        header: 'Host',
+        render: 'text',
+        width: 150,
+      },
+      {
+        field: 'class',
+        header: 'Class',
+        render: 'text',
+        width: 80,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Globe',
+    title: 'No Ingresses',
+    message: 'No Ingresses found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: true,
+  isLive: true,
+}
+
+export default ingressStatusConfig

--- a/web/src/config/cards/job-status.ts
+++ b/web/src/config/cards/job-status.ts
@@ -1,0 +1,109 @@
+/**
+ * Job Status Card Configuration
+ *
+ * Displays Kubernetes Jobs using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const jobStatusConfig: UnifiedCardConfig = {
+  type: 'job_status',
+  title: 'Jobs',
+  category: 'workloads',
+  description: 'Kubernetes Jobs across clusters',
+
+  // Appearance
+  icon: 'Play',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useJobs',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search jobs...',
+      searchFields: ['name', 'namespace', 'cluster'],
+      storageKey: 'job-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'job-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'status',
+        header: 'Status',
+        render: 'status-badge',
+        width: 90,
+      },
+      {
+        field: 'completions',
+        header: 'Done',
+        render: 'text',
+        align: 'right',
+        width: 60,
+      },
+      {
+        field: 'duration',
+        header: 'Duration',
+        render: 'text',
+        width: 80,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Play',
+    title: 'No Jobs',
+    message: 'No Jobs found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: true,
+  isLive: true,
+}
+
+export default jobStatusConfig

--- a/web/src/config/cards/kube-chess.ts
+++ b/web/src/config/cards/kube-chess.ts
@@ -1,0 +1,22 @@
+/**
+ * Kube Chess Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubeChessConfig: UnifiedCardConfig = {
+  type: 'kube_chess',
+  title: 'Kube Chess',
+  category: 'games',
+  description: 'Play chess against AI',
+  icon: 'Crown',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 5,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'KubeChess' },
+  emptyState: { icon: 'Crown', title: 'Kube Chess', message: 'Start a new game', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default kubeChessConfig

--- a/web/src/config/cards/kube-craft.ts
+++ b/web/src/config/cards/kube-craft.ts
@@ -1,0 +1,22 @@
+/**
+ * Kube Craft Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubeCraftConfig: UnifiedCardConfig = {
+  type: 'kube_craft',
+  title: 'Kube Craft',
+  category: 'games',
+  description: 'Minecraft-style building',
+  icon: 'Hammer',
+  iconColor: 'text-brown-400',
+  defaultWidth: 5,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'KubeCraft' },
+  emptyState: { icon: 'Hammer', title: 'Kube Craft', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default kubeCraftConfig

--- a/web/src/config/cards/kube-doom.ts
+++ b/web/src/config/cards/kube-doom.ts
@@ -1,0 +1,22 @@
+/**
+ * Kube Doom Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubeDoomConfig: UnifiedCardConfig = {
+  type: 'kube_doom',
+  title: 'Kube Doom',
+  category: 'games',
+  description: 'Doom-style FPS',
+  icon: 'Skull',
+  iconColor: 'text-red-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'KubeDoom' },
+  emptyState: { icon: 'Skull', title: 'Kube Doom', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default kubeDoomConfig

--- a/web/src/config/cards/kube-galaga.ts
+++ b/web/src/config/cards/kube-galaga.ts
@@ -1,0 +1,22 @@
+/**
+ * Kube Galaga Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubeGalagaConfig: UnifiedCardConfig = {
+  type: 'kube_galaga',
+  title: 'Kube Galaga',
+  category: 'games',
+  description: 'Galaga-style shooter',
+  icon: 'Crosshair',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 5,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'KubeGalaga' },
+  emptyState: { icon: 'Crosshair', title: 'Kube Galaga', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default kubeGalagaConfig

--- a/web/src/config/cards/kube-kart.ts
+++ b/web/src/config/cards/kube-kart.ts
@@ -1,0 +1,22 @@
+/**
+ * Kube Kart Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubeKartConfig: UnifiedCardConfig = {
+  type: 'kube_kart',
+  title: 'Kube Kart',
+  category: 'games',
+  description: 'Racing game',
+  icon: 'Car',
+  iconColor: 'text-red-400',
+  defaultWidth: 5,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'KubeKart' },
+  emptyState: { icon: 'Car', title: 'Kube Kart', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default kubeKartConfig

--- a/web/src/config/cards/kube-kong.ts
+++ b/web/src/config/cards/kube-kong.ts
@@ -1,0 +1,22 @@
+/**
+ * Kube Kong Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubeKongConfig: UnifiedCardConfig = {
+  type: 'kube_kong',
+  title: 'Kube Kong',
+  category: 'games',
+  description: 'Donkey Kong inspired game',
+  icon: 'Banana',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'KubeKong' },
+  emptyState: { icon: 'Banana', title: 'Kube Kong', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default kubeKongConfig

--- a/web/src/config/cards/kube-man.ts
+++ b/web/src/config/cards/kube-man.ts
@@ -1,0 +1,22 @@
+/**
+ * Kube-Man Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubeManConfig: UnifiedCardConfig = {
+  type: 'kube_man',
+  title: 'Kube-Man',
+  category: 'games',
+  description: 'Kubernetes Pac-Man clone',
+  icon: 'Ghost',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'KubeMan' },
+  emptyState: { icon: 'Ghost', title: 'Kube-Man', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default kubeManConfig

--- a/web/src/config/cards/kube-pong.ts
+++ b/web/src/config/cards/kube-pong.ts
@@ -1,0 +1,22 @@
+/**
+ * Kube Pong Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubePongConfig: UnifiedCardConfig = {
+  type: 'kube_pong',
+  title: 'Kube Pong',
+  category: 'games',
+  description: 'Classic Pong game',
+  icon: 'Minus',
+  iconColor: 'text-white',
+  defaultWidth: 5,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'KubePong' },
+  emptyState: { icon: 'Minus', title: 'Kube Pong', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default kubePongConfig

--- a/web/src/config/cards/kube-snake.ts
+++ b/web/src/config/cards/kube-snake.ts
@@ -1,0 +1,22 @@
+/**
+ * Kube Snake Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubeSnakeConfig: UnifiedCardConfig = {
+  type: 'kube_snake',
+  title: 'Kube Snake',
+  category: 'games',
+  description: 'Classic Snake game',
+  icon: 'Waves',
+  iconColor: 'text-green-400',
+  defaultWidth: 5,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'KubeSnake' },
+  emptyState: { icon: 'Waves', title: 'Kube Snake', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default kubeSnakeConfig

--- a/web/src/config/cards/kubecost-overview.ts
+++ b/web/src/config/cards/kubecost-overview.ts
@@ -1,0 +1,29 @@
+/**
+ * Kubecost Overview Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubecostOverviewConfig: UnifiedCardConfig = {
+  type: 'kubecost_overview',
+  title: 'Kubecost',
+  category: 'cost',
+  description: 'Kubecost cost allocation',
+  icon: 'Wallet',
+  iconColor: 'text-blue-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useKubecostOverview' },
+  content: {
+    type: 'chart',
+    chartType: 'donut',
+    dataKey: 'breakdown',
+    valueKey: 'cost',
+    labelKey: 'category',
+    colors: ['#3b82f6', '#10b981', '#f59e0b', '#ef4444'],
+  },
+  emptyState: { icon: 'Wallet', title: 'No Cost Data', message: 'Kubecost not configured', variant: 'info' },
+  loadingState: { type: 'chart' },
+  isDemoData: true,
+  isLive: false,
+}
+export default kubecostOverviewConfig

--- a/web/src/config/cards/kubectl.ts
+++ b/web/src/config/cards/kubectl.ts
@@ -1,0 +1,25 @@
+/**
+ * Kubectl Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubectlConfig: UnifiedCardConfig = {
+  type: 'kubectl',
+  title: 'Kubectl',
+  category: 'utility',
+  description: 'Interactive kubectl terminal',
+  icon: 'Terminal',
+  iconColor: 'text-green-400',
+  defaultWidth: 8,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useKubectl' },
+  content: {
+    type: 'custom',
+    component: 'KubectlTerminal',
+  },
+  emptyState: { icon: 'Terminal', title: 'Terminal', message: 'Enter kubectl commands', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default kubectlConfig

--- a/web/src/config/cards/kubedle.ts
+++ b/web/src/config/cards/kubedle.ts
@@ -1,0 +1,22 @@
+/**
+ * Kubedle Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubedleConfig: UnifiedCardConfig = {
+  type: 'kubedle',
+  title: 'Kubedle',
+  category: 'games',
+  description: 'Kubernetes word guessing game',
+  icon: 'Type',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'Kubedle' },
+  emptyState: { icon: 'Type', title: 'Kubedle', message: 'Start a new game', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default kubedleConfig

--- a/web/src/config/cards/kubescape-scan.ts
+++ b/web/src/config/cards/kubescape-scan.ts
@@ -1,0 +1,29 @@
+/**
+ * Kubescape Scan Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubescapeScanConfig: UnifiedCardConfig = {
+  type: 'kubescape_scan',
+  title: 'Kubescape Scan',
+  category: 'security',
+  description: 'Kubernetes security posture scan',
+  icon: 'ShieldAlert',
+  iconColor: 'text-purple-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useKubescapeScan' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'score', label: 'Score', color: 'blue', format: 'percentage' },
+      { field: 'passed', label: 'Passed', color: 'green' },
+      { field: 'failed', label: 'Failed', color: 'red' },
+    ],
+  },
+  emptyState: { icon: 'ShieldAlert', title: 'No Scans', message: 'No Kubescape scan data', variant: 'info' },
+  loadingState: { type: 'stats', count: 3 },
+  isDemoData: true,
+  isLive: false,
+}
+export default kubescapeScanConfig

--- a/web/src/config/cards/kustomization-status.ts
+++ b/web/src/config/cards/kustomization-status.ts
@@ -1,0 +1,31 @@
+/**
+ * Kustomization Status Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kustomizationStatusConfig: UnifiedCardConfig = {
+  type: 'kustomization_status',
+  title: 'Kustomizations',
+  category: 'gitops',
+  description: 'Flux Kustomization resources',
+  icon: 'Layers',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useKustomizationStatus' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Name', primary: true, render: 'truncate' },
+      { field: 'namespace', header: 'Namespace', render: 'namespace-badge', width: 100 },
+      { field: 'ready', header: 'Ready', render: 'status-badge', width: 70 },
+      { field: 'lastApplied', header: 'Applied', render: 'relative-time', width: 100 },
+    ],
+  },
+  emptyState: { icon: 'Layers', title: 'No Kustomizations', message: 'No Kustomization resources found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default kustomizationStatusConfig

--- a/web/src/config/cards/kyverno-policies.ts
+++ b/web/src/config/cards/kyverno-policies.ts
@@ -1,0 +1,34 @@
+/**
+ * Kyverno Policies Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kyvernoPoliciesConfig: UnifiedCardConfig = {
+  type: 'kyverno_policies',
+  title: 'Kyverno Policies',
+  category: 'security',
+  description: 'Kyverno policy resources',
+  icon: 'ShieldCheck',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useKyvernoPolicies' },
+  filters: [
+    { field: 'search', type: 'text', placeholder: 'Search policies...', searchFields: ['name', 'category'], storageKey: 'kyverno-policies' },
+  ],
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Policy', primary: true, render: 'truncate' },
+      { field: 'category', header: 'Category', render: 'text', width: 100 },
+      { field: 'validationFailures', header: 'Failures', render: 'number', width: 70 },
+      { field: 'background', header: 'Background', render: 'text', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'ShieldCheck', title: 'No Policies', message: 'No Kyverno policies found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default kyvernoPoliciesConfig

--- a/web/src/config/cards/limit-range-status.ts
+++ b/web/src/config/cards/limit-range-status.ts
@@ -1,0 +1,96 @@
+/**
+ * LimitRange Status Card Configuration
+ *
+ * Displays Kubernetes LimitRanges using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const limitRangeStatusConfig: UnifiedCardConfig = {
+  type: 'limit_range_status',
+  title: 'Limit Ranges',
+  category: 'namespaces',
+  description: 'Kubernetes LimitRanges across clusters',
+
+  // Appearance
+  icon: 'Sliders',
+  iconColor: 'text-teal-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useLimitRanges',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search limit ranges...',
+      searchFields: ['name', 'namespace', 'cluster'],
+      storageKey: 'limit-range-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'limit-range-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'type',
+        header: 'Type',
+        render: 'text',
+        width: 100,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Sliders',
+    title: 'No Limit Ranges',
+    message: 'No LimitRanges found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: true,
+  isLive: true,
+}
+
+export default limitRangeStatusConfig

--- a/web/src/config/cards/llm-inference.ts
+++ b/web/src/config/cards/llm-inference.ts
@@ -1,0 +1,31 @@
+/**
+ * LLM Inference Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const llmInferenceConfig: UnifiedCardConfig = {
+  type: 'llm_inference',
+  title: 'llm-d Inference',
+  category: 'ai-ml',
+  description: 'LLM inference endpoint status',
+  icon: 'Bot',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useLLMInference' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'model', header: 'Model', primary: true, render: 'truncate' },
+      { field: 'endpoint', header: 'Endpoint', render: 'text', width: 120 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+      { field: 'latency', header: 'Latency', render: 'text', width: 70, suffix: 'ms' },
+    ],
+  },
+  emptyState: { icon: 'Bot', title: 'No Endpoints', message: 'No LLM inference endpoints', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default llmInferenceConfig

--- a/web/src/config/cards/llm-models.ts
+++ b/web/src/config/cards/llm-models.ts
@@ -1,0 +1,31 @@
+/**
+ * LLM Models Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const llmModelsConfig: UnifiedCardConfig = {
+  type: 'llm_models',
+  title: 'llm-d Models',
+  category: 'ai-ml',
+  description: 'Deployed LLM models',
+  icon: 'Brain',
+  iconColor: 'text-pink-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useLLMModels' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Model', primary: true, render: 'truncate' },
+      { field: 'version', header: 'Version', render: 'text', width: 80 },
+      { field: 'replicas', header: 'Replicas', render: 'number', width: 70 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'Brain', title: 'No Models', message: 'No LLM models deployed', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default llmModelsConfig

--- a/web/src/config/cards/llmd-stack-monitor.ts
+++ b/web/src/config/cards/llmd-stack-monitor.ts
@@ -1,0 +1,22 @@
+/**
+ * LLMd Stack Monitor Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const llmdStackMonitorConfig: UnifiedCardConfig = {
+  type: 'llmd_stack_monitor',
+  title: 'llm-d Stack',
+  category: 'ai-ml',
+  description: 'LLM-d stack health monitoring',
+  icon: 'Layers',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useLLMdStackMonitor' },
+  content: { type: 'custom', component: 'LLMdStackView' },
+  emptyState: { icon: 'Layers', title: 'No Stack', message: 'LLM-d stack not detected', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default llmdStackMonitorConfig

--- a/web/src/config/cards/match-game.ts
+++ b/web/src/config/cards/match-game.ts
@@ -1,0 +1,22 @@
+/**
+ * Match Game Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const matchGameConfig: UnifiedCardConfig = {
+  type: 'match_game',
+  title: 'Kube Match',
+  category: 'games',
+  description: 'Memory matching game',
+  icon: 'Puzzle',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'MatchGame' },
+  emptyState: { icon: 'Puzzle', title: 'Match', message: 'Start a new game', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default matchGameConfig

--- a/web/src/config/cards/ml-jobs.ts
+++ b/web/src/config/cards/ml-jobs.ts
@@ -1,0 +1,31 @@
+/**
+ * ML Jobs Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const mlJobsConfig: UnifiedCardConfig = {
+  type: 'ml_jobs',
+  title: 'ML Jobs',
+  category: 'ai-ml',
+  description: 'Machine learning training jobs',
+  icon: 'Sparkles',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useMLJobs' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Job', primary: true, render: 'truncate' },
+      { field: 'type', header: 'Type', render: 'text', width: 80 },
+      { field: 'progress', header: 'Progress', render: 'progress-bar', width: 100 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'Sparkles', title: 'No Jobs', message: 'No ML jobs found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default mlJobsConfig

--- a/web/src/config/cards/ml-notebooks.ts
+++ b/web/src/config/cards/ml-notebooks.ts
@@ -1,0 +1,31 @@
+/**
+ * ML Notebooks Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const mlNotebooksConfig: UnifiedCardConfig = {
+  type: 'ml_notebooks',
+  title: 'ML Notebooks',
+  category: 'ai-ml',
+  description: 'Jupyter notebook instances',
+  icon: 'BookOpen',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useMLNotebooks' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Notebook', primary: true, render: 'truncate' },
+      { field: 'namespace', header: 'Namespace', render: 'namespace-badge', width: 100 },
+      { field: 'image', header: 'Image', render: 'truncate', width: 120 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'BookOpen', title: 'No Notebooks', message: 'No ML notebooks found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default mlNotebooksConfig

--- a/web/src/config/cards/mobile-browser.ts
+++ b/web/src/config/cards/mobile-browser.ts
@@ -1,0 +1,22 @@
+/**
+ * Mobile Browser Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const mobileBrowserConfig: UnifiedCardConfig = {
+  type: 'mobile_browser',
+  title: 'Mobile Browser',
+  category: 'utility',
+  description: 'Mobile web browser emulator',
+  icon: 'Smartphone',
+  iconColor: 'text-gray-400',
+  defaultWidth: 5,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'MobileBrowser' },
+  emptyState: { icon: 'Smartphone', title: 'Browser', message: 'Enter URL to browse', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default mobileBrowserConfig

--- a/web/src/config/cards/namespace-events.ts
+++ b/web/src/config/cards/namespace-events.ts
@@ -1,0 +1,31 @@
+/**
+ * Namespace Events Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const namespaceEventsConfig: UnifiedCardConfig = {
+  type: 'namespace_events',
+  title: 'Namespace Events',
+  category: 'events',
+  description: 'Events in selected namespace',
+  icon: 'Activity',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useNamespaceEvents' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'type', header: 'Type', render: 'status-badge', width: 80 },
+      { field: 'reason', header: 'Reason', render: 'text', width: 100 },
+      { field: 'message', header: 'Message', primary: true, render: 'truncate' },
+      { field: 'lastTimestamp', header: 'Time', render: 'relative-time', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'Activity', title: 'No Events', message: 'No events in namespace', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default namespaceEventsConfig

--- a/web/src/config/cards/namespace-monitor.ts
+++ b/web/src/config/cards/namespace-monitor.ts
@@ -1,0 +1,30 @@
+/**
+ * Namespace Monitor Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const namespaceMonitorConfig: UnifiedCardConfig = {
+  type: 'namespace_monitor',
+  title: 'Namespace Monitor',
+  category: 'namespaces',
+  description: 'Real-time namespace health monitoring',
+  icon: 'Monitor',
+  iconColor: 'text-green-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useNamespaceMonitor' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'healthy', label: 'Healthy', color: 'green' },
+      { field: 'warning', label: 'Warning', color: 'yellow' },
+      { field: 'critical', label: 'Critical', color: 'red' },
+      { field: 'unknown', label: 'Unknown', color: 'gray' },
+    ],
+  },
+  emptyState: { icon: 'Monitor', title: 'No Data', message: 'Select a namespace to monitor', variant: 'info' },
+  loadingState: { type: 'stats', count: 4 },
+  isDemoData: false,
+  isLive: true,
+}
+export default namespaceMonitorConfig

--- a/web/src/config/cards/namespace-overview.ts
+++ b/web/src/config/cards/namespace-overview.ts
@@ -1,0 +1,30 @@
+/**
+ * Namespace Overview Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const namespaceOverviewConfig: UnifiedCardConfig = {
+  type: 'namespace_overview',
+  title: 'Namespace Overview',
+  category: 'namespaces',
+  description: 'Namespace resource summary',
+  icon: 'FolderOpen',
+  iconColor: 'text-sky-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useNamespaceOverview' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'pods', label: 'Pods', color: 'blue' },
+      { field: 'deployments', label: 'Deployments', color: 'purple' },
+      { field: 'services', label: 'Services', color: 'green' },
+      { field: 'configmaps', label: 'ConfigMaps', color: 'orange' },
+    ],
+  },
+  emptyState: { icon: 'FolderOpen', title: 'Select Namespace', message: 'Select a namespace to view details', variant: 'info' },
+  loadingState: { type: 'stats', count: 4 },
+  isDemoData: false,
+  isLive: true,
+}
+export default namespaceOverviewConfig

--- a/web/src/config/cards/namespace-quotas.ts
+++ b/web/src/config/cards/namespace-quotas.ts
@@ -1,0 +1,31 @@
+/**
+ * Namespace Quotas Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const namespaceQuotasConfig: UnifiedCardConfig = {
+  type: 'namespace_quotas',
+  title: 'Namespace Quotas',
+  category: 'namespaces',
+  description: 'Resource quota usage by namespace',
+  icon: 'Gauge',
+  iconColor: 'text-amber-400',
+  defaultWidth: 5,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useNamespaceQuotas' },
+  content: {
+    type: 'list',
+    pageSize: 8,
+    columns: [
+      { field: 'resource', header: 'Resource', primary: true, render: 'text' },
+      { field: 'used', header: 'Used', render: 'text', width: 80 },
+      { field: 'hard', header: 'Limit', render: 'text', width: 80 },
+      { field: 'percentage', header: 'Usage', render: 'progress-bar', width: 100 },
+    ],
+  },
+  emptyState: { icon: 'Gauge', title: 'No Quotas', message: 'No resource quotas defined', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default namespaceQuotasConfig

--- a/web/src/config/cards/namespace-rbac.ts
+++ b/web/src/config/cards/namespace-rbac.ts
@@ -1,0 +1,31 @@
+/**
+ * Namespace RBAC Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const namespaceRbacConfig: UnifiedCardConfig = {
+  type: 'namespace_rbac',
+  title: 'Namespace RBAC',
+  category: 'security',
+  description: 'RBAC permissions in namespace',
+  icon: 'Shield',
+  iconColor: 'text-red-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useNamespaceRBAC' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'subject', header: 'Subject', primary: true, render: 'truncate' },
+      { field: 'type', header: 'Type', render: 'text', width: 80 },
+      { field: 'role', header: 'Role', render: 'text', width: 100 },
+      { field: 'scope', header: 'Scope', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'Shield', title: 'No RBAC', message: 'No RBAC bindings found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default namespaceRbacConfig

--- a/web/src/config/cards/namespace-status.ts
+++ b/web/src/config/cards/namespace-status.ts
@@ -1,0 +1,96 @@
+/**
+ * Namespace Status Card Configuration
+ *
+ * Displays Kubernetes Namespaces using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const namespaceStatusConfig: UnifiedCardConfig = {
+  type: 'namespace_status',
+  title: 'Namespaces',
+  category: 'namespaces',
+  description: 'Kubernetes Namespaces across clusters',
+
+  // Appearance
+  icon: 'FolderOpen',
+  iconColor: 'text-sky-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useNamespaces',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search namespaces...',
+      searchFields: ['name', 'cluster', 'status'],
+      storageKey: 'namespace-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'namespace-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'status',
+        header: 'Status',
+        render: 'status-badge',
+        width: 80,
+      },
+      {
+        field: 'creationTimestamp',
+        header: 'Age',
+        render: 'relative-time',
+        width: 80,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'FolderOpen',
+    title: 'No Namespaces',
+    message: 'No Namespaces found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: true,
+  isLive: true,
+}
+
+export default namespaceStatusConfig

--- a/web/src/config/cards/network-overview.ts
+++ b/web/src/config/cards/network-overview.ts
@@ -1,0 +1,69 @@
+/**
+ * Network Overview Card Configuration
+ *
+ * Displays network status and connectivity summary.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const networkOverviewConfig: UnifiedCardConfig = {
+  type: 'network_overview',
+  title: 'Network Overview',
+  category: 'network',
+  description: 'Network connectivity and service status',
+  icon: 'Network',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+
+  isDemoData: true, // Uses demo data hook in registerHooks.ts
+
+  dataSource: {
+    type: 'hook',
+    hook: 'useNetworkOverview',
+  },
+
+  content: {
+    type: 'status-grid',
+    columns: 2,
+    items: [
+      {
+        id: 'services',
+        label: 'Services',
+        valueSource: { type: 'field', path: 'serviceCount' },
+        icon: 'Globe',
+        color: 'blue',
+      },
+      {
+        id: 'ingresses',
+        label: 'Ingresses',
+        valueSource: { type: 'field', path: 'ingressCount' },
+        icon: 'ArrowRightLeft',
+        color: 'purple',
+      },
+      {
+        id: 'endpoints',
+        label: 'Endpoints',
+        valueSource: { type: 'field', path: 'endpointCount' },
+        icon: 'Link',
+        color: 'cyan',
+      },
+      {
+        id: 'policies',
+        label: 'Net Policies',
+        valueSource: { type: 'field', path: 'networkPolicyCount' },
+        icon: 'Shield',
+        color: 'green',
+      },
+    ],
+  },
+
+  emptyState: {
+    icon: 'Network',
+    title: 'No network data',
+    message: 'Network metrics not available',
+    variant: 'neutral',
+  },
+
+  isLive: true,
+}

--- a/web/src/config/cards/network-policy-status.ts
+++ b/web/src/config/cards/network-policy-status.ts
@@ -1,0 +1,102 @@
+/**
+ * NetworkPolicy Status Card Configuration
+ *
+ * Displays Kubernetes NetworkPolicies using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const networkPolicyStatusConfig: UnifiedCardConfig = {
+  type: 'network_policy_status',
+  title: 'Network Policies',
+  category: 'network',
+  description: 'Kubernetes NetworkPolicies across clusters',
+
+  // Appearance
+  icon: 'Shield',
+  iconColor: 'text-red-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useNetworkPolicies',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search network policies...',
+      searchFields: ['name', 'namespace', 'cluster'],
+      storageKey: 'network-policy-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'network-policy-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'podSelector',
+        header: 'Pod Selector',
+        render: 'text',
+        width: 120,
+      },
+      {
+        field: 'policyTypes',
+        header: 'Types',
+        render: 'text',
+        width: 100,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Shield',
+    title: 'No Network Policies',
+    message: 'No NetworkPolicies found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: true,
+  isLive: true,
+}
+
+export default networkPolicyStatusConfig

--- a/web/src/config/cards/network-utils.ts
+++ b/web/src/config/cards/network-utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Network Utils Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const networkUtilsConfig: UnifiedCardConfig = {
+  type: 'network_utils',
+  title: 'Network Utils',
+  category: 'utility',
+  description: 'Network diagnostic tools',
+  icon: 'Wifi',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 5,
+  defaultHeight: 3,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'NetworkUtils' },
+  emptyState: { icon: 'Wifi', title: 'Network Utils', message: 'Run network diagnostics', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default networkUtilsConfig

--- a/web/src/config/cards/node-invaders.ts
+++ b/web/src/config/cards/node-invaders.ts
@@ -1,0 +1,22 @@
+/**
+ * Node Invaders Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const nodeInvadersConfig: UnifiedCardConfig = {
+  type: 'node_invaders',
+  title: 'Node Invaders',
+  category: 'games',
+  description: 'Space Invaders with nodes',
+  icon: 'Rocket',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'NodeInvaders' },
+  emptyState: { icon: 'Rocket', title: 'Node Invaders', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default nodeInvadersConfig

--- a/web/src/config/cards/node-status.ts
+++ b/web/src/config/cards/node-status.ts
@@ -1,0 +1,110 @@
+/**
+ * Node Status Card Configuration
+ *
+ * Displays Kubernetes Nodes using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const nodeStatusConfig: UnifiedCardConfig = {
+  type: 'node_status',
+  title: 'Node Status',
+  category: 'compute',
+  description: 'Kubernetes Nodes across clusters',
+
+  // Appearance
+  icon: 'Server',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useNodes',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search nodes...',
+      searchFields: ['name', 'cluster', 'status'],
+      storageKey: 'node-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'node-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'status',
+        header: 'Status',
+        render: 'status-badge',
+        width: 80,
+      },
+      {
+        field: 'roles',
+        header: 'Roles',
+        render: 'text',
+        width: 100,
+      },
+      {
+        field: 'cpuCapacity',
+        header: 'CPU',
+        render: 'text',
+        align: 'right',
+        width: 60,
+      },
+      {
+        field: 'memoryCapacity',
+        header: 'Memory',
+        render: 'text',
+        align: 'right',
+        width: 80,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Server',
+    title: 'No Nodes',
+    message: 'No Nodes found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: true,
+  isLive: true,
+}
+
+export default nodeStatusConfig

--- a/web/src/config/cards/opa-policies.ts
+++ b/web/src/config/cards/opa-policies.ts
@@ -1,0 +1,34 @@
+/**
+ * OPA Policies Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const opaPoliciesConfig: UnifiedCardConfig = {
+  type: 'opa_policies',
+  title: 'OPA/Gatekeeper Policies',
+  category: 'security',
+  description: 'OPA Gatekeeper constraint templates',
+  icon: 'Shield',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useOPAPolicies' },
+  filters: [
+    { field: 'search', type: 'text', placeholder: 'Search policies...', searchFields: ['name', 'kind'], storageKey: 'opa-policies' },
+  ],
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Policy', primary: true, render: 'truncate' },
+      { field: 'kind', header: 'Kind', render: 'text', width: 120 },
+      { field: 'violations', header: 'Violations', render: 'number', width: 80 },
+      { field: 'enforcement', header: 'Mode', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'Shield', title: 'No Policies', message: 'No OPA policies found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default opaPoliciesConfig

--- a/web/src/config/cards/opencost-overview.ts
+++ b/web/src/config/cards/opencost-overview.ts
@@ -1,0 +1,29 @@
+/**
+ * OpenCost Overview Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const opencostOverviewConfig: UnifiedCardConfig = {
+  type: 'opencost_overview',
+  title: 'OpenCost',
+  category: 'cost',
+  description: 'OpenCost cost allocation',
+  icon: 'DollarSign',
+  iconColor: 'text-green-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useOpenCostOverview' },
+  content: {
+    type: 'chart',
+    chartType: 'bar',
+    dataKey: 'namespaces',
+    xAxis: 'namespace',
+    yAxis: ['cpu', 'memory', 'storage'],
+    colors: ['#3b82f6', '#10b981', '#f59e0b'],
+  },
+  emptyState: { icon: 'DollarSign', title: 'No Cost Data', message: 'OpenCost not configured', variant: 'info' },
+  loadingState: { type: 'chart' },
+  isDemoData: true,
+  isLive: false,
+}
+export default opencostOverviewConfig

--- a/web/src/config/cards/operator-status.ts
+++ b/web/src/config/cards/operator-status.ts
@@ -1,0 +1,113 @@
+/**
+ * Operator Status Card Configuration
+ *
+ * Displays Kubernetes Operators using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const operatorStatusConfig: UnifiedCardConfig = {
+  type: 'operator_status',
+  title: 'Operator Status',
+  category: 'operators',
+  description: 'OLM-managed Operators across clusters',
+
+  // Appearance
+  icon: 'Package',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useOperators',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search operators...',
+      searchFields: ['name', 'namespace', 'version', 'cluster'],
+      storageKey: 'operator-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'operator-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 5,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Operator',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'status',
+        header: 'Status',
+        render: 'status-badge',
+        width: 100,
+      },
+      {
+        field: 'version',
+        header: 'Version',
+        render: 'text',
+        width: 90,
+      },
+    ],
+  },
+
+  // Drill-down configuration
+  drillDown: {
+    action: 'drillToOperator',
+    params: ['cluster', 'namespace', 'name'],
+    context: {
+      status: 'status',
+      version: 'version',
+      upgradeAvailable: 'upgradeAvailable',
+    },
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Package',
+    title: 'No operators found',
+    message: 'No OLM-managed Operators in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 3,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default operatorStatusConfig

--- a/web/src/config/cards/operator-subscription-status.ts
+++ b/web/src/config/cards/operator-subscription-status.ts
@@ -1,0 +1,102 @@
+/**
+ * Operator Subscription Status Card Configuration
+ *
+ * Displays OLM Operator Subscriptions using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const operatorSubscriptionStatusConfig: UnifiedCardConfig = {
+  type: 'operator_subscription_status',
+  title: 'Operator Subscriptions',
+  category: 'operators',
+  description: 'OLM Operator Subscriptions across clusters',
+
+  // Appearance
+  icon: 'RefreshCw',
+  iconColor: 'text-violet-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useOperatorSubscriptions',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search subscriptions...',
+      searchFields: ['name', 'namespace', 'cluster', 'channel'],
+      storageKey: 'operator-subscription-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'operator-subscription-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'channel',
+        header: 'Channel',
+        render: 'text',
+        width: 80,
+      },
+      {
+        field: 'installPlanApproval',
+        header: 'Approval',
+        render: 'status-badge',
+        width: 90,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'RefreshCw',
+    title: 'No Subscriptions',
+    message: 'No Operator Subscriptions found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default operatorSubscriptionStatusConfig

--- a/web/src/config/cards/overlay-comparison.ts
+++ b/web/src/config/cards/overlay-comparison.ts
@@ -1,0 +1,25 @@
+/**
+ * Overlay Comparison Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const overlayComparisonConfig: UnifiedCardConfig = {
+  type: 'overlay_comparison',
+  title: 'Overlay Comparison',
+  category: 'gitops',
+  description: 'Compare Kustomize overlays',
+  icon: 'GitCompare',
+  iconColor: 'text-blue-400',
+  defaultWidth: 8,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useOverlayComparison' },
+  content: {
+    type: 'custom',
+    component: 'OverlayDiff',
+  },
+  emptyState: { icon: 'GitCompare', title: 'No Overlays', message: 'Select overlays to compare', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: true,
+  isLive: false,
+}
+export default overlayComparisonConfig

--- a/web/src/config/cards/pod-brothers.ts
+++ b/web/src/config/cards/pod-brothers.ts
@@ -1,0 +1,22 @@
+/**
+ * Pod Brothers Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const podBrothersConfig: UnifiedCardConfig = {
+  type: 'pod_brothers',
+  title: 'Pod Brothers',
+  category: 'games',
+  description: 'Mario Bros-style game',
+  icon: 'Users',
+  iconColor: 'text-red-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'PodBrothers' },
+  emptyState: { icon: 'Users', title: 'Pod Brothers', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default podBrothersConfig

--- a/web/src/config/cards/pod-crosser.ts
+++ b/web/src/config/cards/pod-crosser.ts
@@ -1,0 +1,22 @@
+/**
+ * Pod Crosser Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const podCrosserConfig: UnifiedCardConfig = {
+  type: 'pod_crosser',
+  title: 'Pod Crosser',
+  category: 'games',
+  description: 'Frogger-style game',
+  icon: 'Car',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'PodCrosser' },
+  emptyState: { icon: 'Car', title: 'Pod Crosser', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default podCrosserConfig

--- a/web/src/config/cards/pod-health-trend.ts
+++ b/web/src/config/cards/pod-health-trend.ts
@@ -1,0 +1,29 @@
+/**
+ * Pod Health Trend Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const podHealthTrendConfig: UnifiedCardConfig = {
+  type: 'pod_health_trend',
+  title: 'Pod Health Trend',
+  category: 'live-trends',
+  description: 'Pod health over time',
+  icon: 'HeartPulse',
+  iconColor: 'text-red-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'usePodHealthTrend' },
+  content: {
+    type: 'chart',
+    chartType: 'area',
+    dataKey: 'timeseries',
+    xAxis: 'timestamp',
+    yAxis: ['healthy', 'unhealthy'],
+    colors: ['#10b981', '#ef4444'],
+  },
+  emptyState: { icon: 'HeartPulse', title: 'No Data', message: 'No pod health data', variant: 'info' },
+  loadingState: { type: 'chart' },
+  isDemoData: false,
+  isLive: true,
+}
+export default podHealthTrendConfig

--- a/web/src/config/cards/pod-issues.ts
+++ b/web/src/config/cards/pod-issues.ts
@@ -1,0 +1,139 @@
+/**
+ * Pod Issues Card Configuration
+ *
+ * Displays pods with issues (CrashLoopBackOff, OOMKilled, etc.)
+ * using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const podIssuesConfig: UnifiedCardConfig = {
+  type: 'pod_issues',
+  title: 'Pod Issues',
+  category: 'workloads',
+  description: 'Pods with errors, crashes, or other issues requiring attention',
+
+  // Appearance
+  icon: 'AlertTriangle',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useCachedPodIssues',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search issues...',
+      searchFields: ['name', 'namespace', 'cluster', 'status'],
+      storageKey: 'pod-issues',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'pod-issues-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 5,
+    itemClick: 'drill',
+    // Sorting configuration
+    sortable: true,
+    defaultSort: 'status',
+    defaultDirection: 'asc',
+    sortOptions: [
+      { field: 'status', label: 'Status' },
+      { field: 'name', label: 'Name' },
+      { field: 'restarts', label: 'Restarts' },
+      { field: 'cluster', label: 'Cluster' },
+    ],
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Pod',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'status',
+        header: 'Status',
+        render: 'status-badge',
+        width: 120,
+      },
+      {
+        field: 'restarts',
+        header: 'Restarts',
+        render: 'number',
+        align: 'right',
+        width: 80,
+      },
+    ],
+    // AI Actions for Diagnose/Repair buttons
+    aiActions: {
+      resourceMapping: {
+        kind: 'Pod',
+        nameField: 'name',
+        namespaceField: 'namespace',
+        clusterField: 'cluster',
+        statusField: 'status',
+      },
+      issuesField: 'issues',
+      contextFields: ['restarts'],
+      showRepair: true,
+    },
+  },
+
+  // Drill-down
+  drillDown: {
+    action: 'drillToPod',
+    params: ['cluster', 'namespace', 'name'],
+    context: {
+      status: 'status',
+      restarts: 'restarts',
+      issues: 'issues',
+    },
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'CheckCircle',
+    title: 'All pods healthy',
+    message: 'No issues detected',
+    variant: 'success',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 3,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default podIssuesConfig

--- a/web/src/config/cards/pod-pitfall.ts
+++ b/web/src/config/cards/pod-pitfall.ts
@@ -1,0 +1,22 @@
+/**
+ * Pod Pitfall Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const podPitfallConfig: UnifiedCardConfig = {
+  type: 'pod_pitfall',
+  title: 'Pod Pitfall',
+  category: 'games',
+  description: 'Pitfall-style adventure',
+  icon: 'TreePine',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'PodPitfall' },
+  emptyState: { icon: 'TreePine', title: 'Pod Pitfall', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default podPitfallConfig

--- a/web/src/config/cards/pod-sweeper.ts
+++ b/web/src/config/cards/pod-sweeper.ts
@@ -1,0 +1,22 @@
+/**
+ * Pod Sweeper Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const podSweeperConfig: UnifiedCardConfig = {
+  type: 'pod_sweeper',
+  title: 'Pod Sweeper',
+  category: 'games',
+  description: 'Kubernetes-themed minesweeper',
+  icon: 'Bomb',
+  iconColor: 'text-gray-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'PodSweeper' },
+  emptyState: { icon: 'Bomb', title: 'Pod Sweeper', message: 'Start a new game', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default podSweeperConfig

--- a/web/src/config/cards/policy-violations.ts
+++ b/web/src/config/cards/policy-violations.ts
@@ -1,0 +1,31 @@
+/**
+ * Policy Violations Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const policyViolationsConfig: UnifiedCardConfig = {
+  type: 'policy_violations',
+  title: 'Policy Violations',
+  category: 'security',
+  description: 'Security policy violation summary',
+  icon: 'AlertOctagon',
+  iconColor: 'text-red-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'usePolicyViolations' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'resource', header: 'Resource', primary: true, render: 'truncate' },
+      { field: 'policy', header: 'Policy', render: 'text', width: 120 },
+      { field: 'severity', header: 'Severity', render: 'status-badge', width: 80 },
+      { field: 'timestamp', header: 'Time', render: 'relative-time', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'AlertOctagon', title: 'No Violations', message: 'No policy violations found', variant: 'success' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default policyViolationsConfig

--- a/web/src/config/cards/provider-health.ts
+++ b/web/src/config/cards/provider-health.ts
@@ -1,0 +1,31 @@
+/**
+ * Provider Health Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const providerHealthConfig: UnifiedCardConfig = {
+  type: 'provider_health',
+  title: 'Provider Health',
+  category: 'cluster-health',
+  description: 'Cloud and AI provider status',
+  icon: 'Cloud',
+  iconColor: 'text-sky-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useProviderHealth' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'provider', header: 'Provider', primary: true, render: 'truncate' },
+      { field: 'type', header: 'Type', render: 'text', width: 80 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+      { field: 'latency', header: 'Latency', render: 'text', width: 70, suffix: 'ms' },
+    ],
+  },
+  emptyState: { icon: 'Cloud', title: 'No Providers', message: 'No providers configured', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default providerHealthConfig

--- a/web/src/config/cards/prow-ci-monitor.ts
+++ b/web/src/config/cards/prow-ci-monitor.ts
@@ -1,0 +1,22 @@
+/**
+ * Prow CI Monitor Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const prowCiMonitorConfig: UnifiedCardConfig = {
+  type: 'prow_ci_monitor',
+  title: 'Prow CI',
+  category: 'ci-cd',
+  description: 'Prow CI system monitoring',
+  icon: 'GitBranch',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useProwCIMonitor' },
+  content: { type: 'custom', component: 'ProwCIView' },
+  emptyState: { icon: 'GitBranch', title: 'No Prow', message: 'Prow CI not detected', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default prowCiMonitorConfig

--- a/web/src/config/cards/prow-history.ts
+++ b/web/src/config/cards/prow-history.ts
@@ -1,0 +1,31 @@
+/**
+ * Prow History Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const prowHistoryConfig: UnifiedCardConfig = {
+  type: 'prow_history',
+  title: 'Prow History',
+  category: 'ci-cd',
+  description: 'Prow job execution history',
+  icon: 'History',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useProwHistory' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'job', header: 'Job', primary: true, render: 'truncate' },
+      { field: 'result', header: 'Result', render: 'status-badge', width: 80 },
+      { field: 'duration', header: 'Duration', render: 'duration', width: 80 },
+      { field: 'finished', header: 'Finished', render: 'relative-time', width: 100 },
+    ],
+  },
+  emptyState: { icon: 'History', title: 'No History', message: 'No Prow history available', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default prowHistoryConfig

--- a/web/src/config/cards/prow-jobs.ts
+++ b/web/src/config/cards/prow-jobs.ts
@@ -1,0 +1,34 @@
+/**
+ * Prow Jobs Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const prowJobsConfig: UnifiedCardConfig = {
+  type: 'prow_jobs',
+  title: 'Prow Jobs',
+  category: 'ci-cd',
+  description: 'Prow CI job status',
+  icon: 'GitPullRequest',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useProwJobs' },
+  filters: [
+    { field: 'search', type: 'text', placeholder: 'Search jobs...', searchFields: ['name', 'type'], storageKey: 'prow-jobs' },
+  ],
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Job', primary: true, render: 'truncate' },
+      { field: 'type', header: 'Type', render: 'text', width: 80 },
+      { field: 'state', header: 'State', render: 'status-badge', width: 80 },
+      { field: 'startTime', header: 'Started', render: 'relative-time', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'GitPullRequest', title: 'No Jobs', message: 'No Prow jobs found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default prowJobsConfig

--- a/web/src/config/cards/prow-status.ts
+++ b/web/src/config/cards/prow-status.ts
@@ -1,0 +1,30 @@
+/**
+ * Prow Status Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const prowStatusConfig: UnifiedCardConfig = {
+  type: 'prow_status',
+  title: 'Prow Status',
+  category: 'ci-cd',
+  description: 'Prow CI system status',
+  icon: 'Activity',
+  iconColor: 'text-green-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useProwStatus' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'running', label: 'Running', color: 'blue' },
+      { field: 'passed', label: 'Passed', color: 'green' },
+      { field: 'failed', label: 'Failed', color: 'red' },
+      { field: 'pending', label: 'Pending', color: 'yellow' },
+    ],
+  },
+  emptyState: { icon: 'Activity', title: 'No Status', message: 'Prow status unavailable', variant: 'info' },
+  loadingState: { type: 'stats', count: 4 },
+  isDemoData: false,
+  isLive: true,
+}
+export default prowStatusConfig

--- a/web/src/config/cards/pv-status.ts
+++ b/web/src/config/cards/pv-status.ts
@@ -1,0 +1,102 @@
+/**
+ * PersistentVolume Status Card Configuration
+ *
+ * Displays Kubernetes PersistentVolumes using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const pvStatusConfig: UnifiedCardConfig = {
+  type: 'pv_status',
+  title: 'Persistent Volumes',
+  category: 'storage',
+  description: 'Kubernetes PersistentVolumes across clusters',
+
+  // Appearance
+  icon: 'HardDrive',
+  iconColor: 'text-amber-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'usePVs',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search PVs...',
+      searchFields: ['name', 'cluster', 'storageClass', 'status'],
+      storageKey: 'pv-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'pv-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'capacity',
+        header: 'Capacity',
+        render: 'text',
+        width: 80,
+      },
+      {
+        field: 'status',
+        header: 'Status',
+        render: 'status-badge',
+        width: 90,
+      },
+      {
+        field: 'storageClass',
+        header: 'Storage Class',
+        render: 'text',
+        width: 120,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'HardDrive',
+    title: 'No Persistent Volumes',
+    message: 'No PVs found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: true,
+  isLive: true,
+}
+
+export default pvStatusConfig

--- a/web/src/config/cards/pvc-status.ts
+++ b/web/src/config/cards/pvc-status.ts
@@ -1,0 +1,121 @@
+/**
+ * PVC Status Card Configuration
+ *
+ * Displays Persistent Volume Claims using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const pvcStatusConfig: UnifiedCardConfig = {
+  type: 'pvc_status',
+  title: 'PVC Status',
+  category: 'storage',
+  description: 'Persistent Volume Claims across clusters',
+
+  // Appearance
+  icon: 'HardDrive',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'usePVCs',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search PVCs...',
+      searchFields: ['name', 'namespace', 'cluster', 'storageClass'],
+      storageKey: 'pvc-status-unified',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'pvc-status-unified-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    itemClick: 'drill',
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'status',
+        header: 'Status',
+        render: 'status-badge',
+        width: 80,
+      },
+      {
+        field: 'capacity',
+        header: 'Capacity',
+        render: 'text',
+        align: 'right',
+        width: 80,
+      },
+      {
+        field: 'storageClass',
+        header: 'Class',
+        render: 'text',
+        width: 100,
+      },
+    ],
+  },
+
+  // Drill-down
+  drillDown: {
+    action: 'drillToPVC',
+    params: ['cluster', 'namespace', 'name'],
+    context: {
+      status: 'status',
+      capacity: 'capacity',
+      storageClass: 'storageClass',
+    },
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'HardDrive',
+    title: 'No PVCs found',
+    message: 'No Persistent Volume Claims in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: true,
+  isLive: true,
+}
+
+export default pvcStatusConfig

--- a/web/src/config/cards/recent-events.ts
+++ b/web/src/config/cards/recent-events.ts
@@ -1,0 +1,107 @@
+/**
+ * Recent Events Card Configuration
+ *
+ * Displays Kubernetes events from the last hour using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const recentEventsConfig: UnifiedCardConfig = {
+  type: 'recent_events',
+  title: 'Recent Events',
+  category: 'live-trends',
+  description: 'Kubernetes events from the last hour',
+
+  // Appearance
+  icon: 'Clock',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useRecentEvents',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search events...',
+      searchFields: ['reason', 'message', 'object', 'namespace'],
+      storageKey: 'recent-events',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'recent-events-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 5,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'type',
+        header: 'Type',
+        render: 'status-badge',
+        width: 80,
+      },
+      {
+        field: 'reason',
+        header: 'Reason',
+        width: 100,
+      },
+      {
+        field: 'object',
+        header: 'Object',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'lastSeen',
+        header: 'Time',
+        render: 'relative-time',
+        width: 80,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Activity',
+    title: 'No recent events',
+    message: 'No events in the last hour',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 3,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default recentEventsConfig

--- a/web/src/config/cards/replicaset-status.ts
+++ b/web/src/config/cards/replicaset-status.ts
@@ -1,0 +1,104 @@
+/**
+ * ReplicaSet Status Card Configuration
+ *
+ * Displays Kubernetes ReplicaSets using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const replicaSetStatusConfig: UnifiedCardConfig = {
+  type: 'replicaset_status',
+  title: 'ReplicaSets',
+  category: 'workloads',
+  description: 'Kubernetes ReplicaSets across clusters',
+
+  // Appearance
+  icon: 'Copy',
+  iconColor: 'text-indigo-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useReplicaSets',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search replicasets...',
+      searchFields: ['name', 'namespace', 'cluster'],
+      storageKey: 'replicaset-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'replicaset-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'readyReplicas',
+        header: 'Ready',
+        render: 'number',
+        align: 'right',
+        width: 60,
+      },
+      {
+        field: 'replicas',
+        header: 'Desired',
+        render: 'number',
+        align: 'right',
+        width: 60,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Copy',
+    title: 'No ReplicaSets',
+    message: 'No ReplicaSets found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: true,
+  isLive: true,
+}
+
+export default replicaSetStatusConfig

--- a/web/src/config/cards/resource-capacity.ts
+++ b/web/src/config/cards/resource-capacity.ts
@@ -1,0 +1,29 @@
+/**
+ * Resource Capacity Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const resourceCapacityConfig: UnifiedCardConfig = {
+  type: 'resource_capacity',
+  title: 'Resource Capacity',
+  category: 'compute',
+  description: 'Cluster resource capacity overview',
+  icon: 'BarChart3',
+  iconColor: 'text-blue-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useResourceCapacity' },
+  content: {
+    type: 'chart',
+    chartType: 'bar',
+    dataKey: 'clusters',
+    xAxis: 'cluster',
+    yAxis: ['cpu', 'memory', 'storage'],
+    colors: ['#3b82f6', '#10b981', '#f59e0b'],
+  },
+  emptyState: { icon: 'BarChart3', title: 'No Data', message: 'No capacity data available', variant: 'info' },
+  loadingState: { type: 'chart' },
+  isDemoData: true,
+  isLive: false,
+}
+export default resourceCapacityConfig

--- a/web/src/config/cards/resource-marshall.ts
+++ b/web/src/config/cards/resource-marshall.ts
@@ -1,0 +1,22 @@
+/**
+ * Resource Marshall Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const resourceMarshallConfig: UnifiedCardConfig = {
+  type: 'resource_marshall',
+  title: 'Resource Marshall',
+  category: 'workloads',
+  description: 'Dependency tree explorer',
+  icon: 'GitBranch',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useResourceMarshall' },
+  content: { type: 'custom', component: 'ResourceMarshallTree' },
+  emptyState: { icon: 'GitBranch', title: 'No Resources', message: 'Select a resource to explore', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default resourceMarshallConfig

--- a/web/src/config/cards/resource-quota-status.ts
+++ b/web/src/config/cards/resource-quota-status.ts
@@ -1,0 +1,102 @@
+/**
+ * ResourceQuota Status Card Configuration
+ *
+ * Displays Kubernetes ResourceQuotas using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const resourceQuotaStatusConfig: UnifiedCardConfig = {
+  type: 'resource_quota_status',
+  title: 'Resource Quotas',
+  category: 'namespaces',
+  description: 'Kubernetes ResourceQuotas across clusters',
+
+  // Appearance
+  icon: 'Gauge',
+  iconColor: 'text-rose-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useResourceQuotas',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search quotas...',
+      searchFields: ['name', 'namespace', 'cluster'],
+      storageKey: 'resource-quota-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'resource-quota-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'cpuUsed',
+        header: 'CPU Used',
+        render: 'text',
+        width: 80,
+      },
+      {
+        field: 'memoryUsed',
+        header: 'Memory Used',
+        render: 'text',
+        width: 100,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Gauge',
+    title: 'No Resource Quotas',
+    message: 'No ResourceQuotas found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: true,
+  isLive: true,
+}
+
+export default resourceQuotaStatusConfig

--- a/web/src/config/cards/resource-trend.ts
+++ b/web/src/config/cards/resource-trend.ts
@@ -1,0 +1,29 @@
+/**
+ * Resource Trend Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const resourceTrendConfig: UnifiedCardConfig = {
+  type: 'resource_trend',
+  title: 'Resource Trend',
+  category: 'live-trends',
+  description: 'Resource usage over time',
+  icon: 'TrendingUp',
+  iconColor: 'text-blue-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useResourceTrend' },
+  content: {
+    type: 'chart',
+    chartType: 'line',
+    dataKey: 'timeseries',
+    xAxis: 'timestamp',
+    yAxis: ['cpu', 'memory'],
+    colors: ['#f59e0b', '#3b82f6'],
+  },
+  emptyState: { icon: 'TrendingUp', title: 'No Data', message: 'No resource trend data', variant: 'info' },
+  loadingState: { type: 'chart' },
+  isDemoData: false,
+  isLive: true,
+}
+export default resourceTrendConfig

--- a/web/src/config/cards/resource-usage.ts
+++ b/web/src/config/cards/resource-usage.ts
@@ -1,0 +1,122 @@
+/**
+ * Resource Usage Card Configuration
+ *
+ * Shows CPU and memory usage across clusters.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const resourceUsageConfig: UnifiedCardConfig = {
+  type: 'resource_usage',
+  title: 'Resource Usage',
+  category: 'compute',
+  description: 'CPU and memory utilization across clusters',
+
+  // Appearance
+  icon: 'Cpu',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useCachedResourceUsage',
+  },
+
+  // Inline stats
+  stats: [
+    {
+      id: 'avgCpu',
+      icon: 'Cpu',
+      color: 'text-cyan-400',
+      bgColor: 'bg-cyan-500/10',
+      label: 'Avg CPU',
+      valueSource: { type: 'computed', expression: 'avg:cpuPercent' },
+    },
+    {
+      id: 'avgMemory',
+      icon: 'MemoryStick',
+      color: 'text-purple-400',
+      bgColor: 'bg-purple-500/10',
+      label: 'Avg Memory',
+      valueSource: { type: 'computed', expression: 'avg:memoryPercent' },
+    },
+  ],
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search...',
+      searchFields: ['cluster', 'nodeName'],
+      storageKey: 'resource-usage',
+    },
+  ],
+
+  // Content - Table visualization
+  content: {
+    type: 'table',
+    pageSize: 10,
+    sortable: true,
+    defaultSort: 'cpuPercent',
+    defaultDirection: 'desc',
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 120,
+        sortable: true,
+      },
+      {
+        field: 'nodeName',
+        header: 'Node',
+        primary: true,
+        sortable: true,
+      },
+      {
+        field: 'cpuPercent',
+        header: 'CPU',
+        render: 'progress-bar',
+        width: 150,
+        sortable: true,
+      },
+      {
+        field: 'memoryPercent',
+        header: 'Memory',
+        render: 'progress-bar',
+        width: 150,
+        sortable: true,
+      },
+    ],
+  },
+
+  // Drill-down
+  drillDown: {
+    action: 'drillToNode',
+    params: ['cluster', 'nodeName'],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Cpu',
+    title: 'No resource data',
+    message: 'Resource metrics will appear here',
+    variant: 'neutral',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'table',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default resourceUsageConfig

--- a/web/src/config/cards/role-binding-status.ts
+++ b/web/src/config/cards/role-binding-status.ts
@@ -1,0 +1,102 @@
+/**
+ * Role Binding Status Card Configuration
+ *
+ * Displays Kubernetes RoleBindings and ClusterRoleBindings using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const roleBindingStatusConfig: UnifiedCardConfig = {
+  type: 'role_binding_status',
+  title: 'Role Bindings',
+  category: 'security',
+  description: 'Kubernetes RoleBindings and ClusterRoleBindings across clusters',
+
+  // Appearance
+  icon: 'Link',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useK8sRoleBindings',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search bindings...',
+      searchFields: ['name', 'namespace', 'cluster', 'roleName'],
+      storageKey: 'role-binding-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'role-binding-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'roleName',
+        header: 'Role',
+        render: 'text',
+        width: 100,
+      },
+      {
+        field: 'isCluster',
+        header: 'Scope',
+        render: 'text',
+        width: 80,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Link',
+    title: 'No Role Bindings',
+    message: 'No RoleBindings found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: true,
+  isLive: true,
+}
+
+export default roleBindingStatusConfig

--- a/web/src/config/cards/role-status.ts
+++ b/web/src/config/cards/role-status.ts
@@ -1,0 +1,103 @@
+/**
+ * Role Status Card Configuration
+ *
+ * Displays Kubernetes Roles and ClusterRoles using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const roleStatusConfig: UnifiedCardConfig = {
+  type: 'role_status',
+  title: 'Roles',
+  category: 'security',
+  description: 'Kubernetes Roles and ClusterRoles across clusters',
+
+  // Appearance
+  icon: 'Key',
+  iconColor: 'text-amber-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useK8sRoles',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search roles...',
+      searchFields: ['name', 'namespace', 'cluster'],
+      storageKey: 'role-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'role-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'isCluster',
+        header: 'Scope',
+        render: 'text',
+        width: 80,
+      },
+      {
+        field: 'ruleCount',
+        header: 'Rules',
+        render: 'number',
+        align: 'right',
+        width: 60,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Key',
+    title: 'No Roles',
+    message: 'No Roles found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: true,
+  isLive: true,
+}
+
+export default roleStatusConfig

--- a/web/src/config/cards/rss-feed.ts
+++ b/web/src/config/cards/rss-feed.ts
@@ -1,0 +1,30 @@
+/**
+ * RSS Feed Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const rssFeedConfig: UnifiedCardConfig = {
+  type: 'rss_feed',
+  title: 'RSS Feed',
+  category: 'utility',
+  description: 'RSS/Atom feed reader',
+  icon: 'Rss',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useRSSFeed' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'title', header: 'Title', primary: true, render: 'truncate' },
+      { field: 'source', header: 'Source', render: 'text', width: 100 },
+      { field: 'pubDate', header: 'Published', render: 'relative-time', width: 100 },
+    ],
+  },
+  emptyState: { icon: 'Rss', title: 'No Feed', message: 'No RSS feed configured', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default rssFeedConfig

--- a/web/src/config/cards/secret-status.ts
+++ b/web/src/config/cards/secret-status.ts
@@ -1,0 +1,103 @@
+/**
+ * Secret Status Card Configuration
+ *
+ * Displays Kubernetes Secrets using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const secretStatusConfig: UnifiedCardConfig = {
+  type: 'secret_status',
+  title: 'Secrets',
+  category: 'security',
+  description: 'Kubernetes Secrets across clusters',
+
+  // Appearance
+  icon: 'Key',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useSecrets',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search secrets...',
+      searchFields: ['name', 'namespace', 'cluster', 'type'],
+      storageKey: 'secret-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'secret-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'type',
+        header: 'Type',
+        render: 'text',
+        width: 120,
+      },
+      {
+        field: 'dataKeys',
+        header: 'Keys',
+        render: 'number',
+        align: 'right',
+        width: 60,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Key',
+    title: 'No Secrets',
+    message: 'No Secrets found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: true,
+  isLive: true,
+}
+
+export default secretStatusConfig

--- a/web/src/config/cards/security-issues.ts
+++ b/web/src/config/cards/security-issues.ts
@@ -1,0 +1,81 @@
+/**
+ * Security Issues Card Configuration
+ *
+ * Displays security vulnerabilities and issues across clusters.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const securityIssuesConfig: UnifiedCardConfig = {
+  type: 'security_issues',
+  title: 'Security Issues',
+  category: 'security',
+  description: 'Security vulnerabilities and issues detected across clusters',
+  icon: 'Shield',
+  iconColor: 'text-red-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  isDemoData: true, // Uses demo data hook in registerHooks.ts
+
+  dataSource: {
+    type: 'hook',
+    hook: 'useSecurityIssues',
+  },
+
+  content: {
+    type: 'list',
+    columns: [
+      {
+        field: 'severity',
+        header: 'Severity',
+        width: 80,
+        render: 'status-badge',
+      },
+      {
+        field: 'type',
+        header: 'Type',
+        width: 120,
+      },
+      {
+        field: 'resource',
+        header: 'Resource',
+        primary: true,
+      },
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        width: 100,
+        render: 'cluster-badge',
+      },
+    ],
+    pageSize: 8,
+  },
+
+  filters: [
+    {
+      field: 'severity',
+      label: 'Severity',
+      type: 'select',
+      options: [
+        { value: 'all', label: 'All' },
+        { value: 'critical', label: 'Critical' },
+        { value: 'high', label: 'High' },
+        { value: 'medium', label: 'Medium' },
+        { value: 'low', label: 'Low' },
+      ],
+    },
+  ],
+
+  emptyState: {
+    icon: 'ShieldCheck',
+    title: 'No security issues',
+    message: 'All resources are secure',
+    variant: 'success',
+  },
+
+  drillDown: {
+    action: 'showSecurityIssue',
+    params: ['resource', 'type', 'severity'],
+  },
+}

--- a/web/src/config/cards/service-account-status.ts
+++ b/web/src/config/cards/service-account-status.ts
@@ -1,0 +1,103 @@
+/**
+ * ServiceAccount Status Card Configuration
+ *
+ * Displays Kubernetes ServiceAccounts using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const serviceAccountStatusConfig: UnifiedCardConfig = {
+  type: 'service_account_status',
+  title: 'Service Accounts',
+  category: 'security',
+  description: 'Kubernetes ServiceAccounts across clusters',
+
+  // Appearance
+  icon: 'UserCircle',
+  iconColor: 'text-emerald-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useServiceAccounts',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search service accounts...',
+      searchFields: ['name', 'namespace', 'cluster'],
+      storageKey: 'service-account-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'service-account-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'secretCount',
+        header: 'Secrets',
+        render: 'number',
+        align: 'right',
+        width: 70,
+      },
+      {
+        field: 'creationTimestamp',
+        header: 'Age',
+        render: 'relative-time',
+        width: 80,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'UserCircle',
+    title: 'No Service Accounts',
+    message: 'No ServiceAccounts found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: true,
+  isLive: true,
+}
+
+export default serviceAccountStatusConfig

--- a/web/src/config/cards/service-exports.ts
+++ b/web/src/config/cards/service-exports.ts
@@ -1,0 +1,31 @@
+/**
+ * Service Exports Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const serviceExportsConfig: UnifiedCardConfig = {
+  type: 'service_exports',
+  title: 'Service Exports',
+  category: 'network',
+  description: 'Multi-cluster service exports',
+  icon: 'ArrowUpFromLine',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useServiceExports' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Service', primary: true, render: 'truncate' },
+      { field: 'namespace', header: 'Namespace', render: 'namespace-badge', width: 100 },
+      { field: 'cluster', header: 'Cluster', render: 'cluster-badge', width: 100 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'ArrowUpFromLine', title: 'No Exports', message: 'No service exports found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default serviceExportsConfig

--- a/web/src/config/cards/service-imports.ts
+++ b/web/src/config/cards/service-imports.ts
@@ -1,0 +1,31 @@
+/**
+ * Service Imports Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const serviceImportsConfig: UnifiedCardConfig = {
+  type: 'service_imports',
+  title: 'Service Imports',
+  category: 'network',
+  description: 'Multi-cluster service imports',
+  icon: 'ArrowDownToLine',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useServiceImports' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Service', primary: true, render: 'truncate' },
+      { field: 'namespace', header: 'Namespace', render: 'namespace-badge', width: 100 },
+      { field: 'sourceCluster', header: 'Source', render: 'cluster-badge', width: 100 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'ArrowDownToLine', title: 'No Imports', message: 'No service imports found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default serviceImportsConfig

--- a/web/src/config/cards/service-status.ts
+++ b/web/src/config/cards/service-status.ts
@@ -1,0 +1,108 @@
+/**
+ * Service Status Card Configuration
+ *
+ * Displays Kubernetes Services using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const serviceStatusConfig: UnifiedCardConfig = {
+  type: 'service_status',
+  title: 'Service Status',
+  category: 'network',
+  description: 'Kubernetes Services across clusters',
+
+  // Appearance
+  icon: 'Network',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useServices',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search services...',
+      searchFields: ['name', 'namespace', 'cluster', 'type'],
+      storageKey: 'service-status-unified',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'service-status-unified-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'type',
+        header: 'Type',
+        render: 'status-badge',
+        width: 100,
+      },
+      {
+        field: 'clusterIP',
+        header: 'Cluster IP',
+        render: 'text',
+        width: 120,
+      },
+      {
+        field: 'ports',
+        header: 'Ports',
+        render: 'text',
+        width: 100,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Network',
+    title: 'No services found',
+    message: 'No Services in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: true,
+  isLive: true,
+}
+
+export default serviceStatusConfig

--- a/web/src/config/cards/service-topology.ts
+++ b/web/src/config/cards/service-topology.ts
@@ -1,0 +1,22 @@
+/**
+ * Service Topology Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const serviceTopologyConfig: UnifiedCardConfig = {
+  type: 'service_topology',
+  title: 'Service Topology',
+  category: 'network',
+  description: 'Service connectivity visualization',
+  icon: 'Network',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 8,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useServiceTopology' },
+  content: { type: 'custom', component: 'ServiceTopologyGraph' },
+  emptyState: { icon: 'Network', title: 'No Topology', message: 'Service topology data unavailable', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: true,
+  isLive: false,
+}
+export default serviceTopologyConfig

--- a/web/src/config/cards/solitaire.ts
+++ b/web/src/config/cards/solitaire.ts
@@ -1,0 +1,22 @@
+/**
+ * Solitaire Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const solitaireConfig: UnifiedCardConfig = {
+  type: 'solitaire',
+  title: 'Solitaire',
+  category: 'games',
+  description: 'Classic card solitaire',
+  icon: 'Club',
+  iconColor: 'text-red-400',
+  defaultWidth: 8,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'Solitaire' },
+  emptyState: { icon: 'Club', title: 'Solitaire', message: 'Start a new game', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default solitaireConfig

--- a/web/src/config/cards/statefulset-status.ts
+++ b/web/src/config/cards/statefulset-status.ts
@@ -1,0 +1,109 @@
+/**
+ * StatefulSet Status Card Configuration
+ *
+ * Displays Kubernetes StatefulSets using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const statefulSetStatusConfig: UnifiedCardConfig = {
+  type: 'statefulset_status',
+  title: 'StatefulSets',
+  category: 'workloads',
+  description: 'Kubernetes StatefulSets across clusters',
+
+  // Appearance
+  icon: 'Database',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useStatefulSets',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search statefulsets...',
+      searchFields: ['name', 'namespace', 'cluster'],
+      storageKey: 'statefulset-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'statefulset-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'readyReplicas',
+        header: 'Ready',
+        render: 'replica-count',
+        width: 70,
+      },
+      {
+        field: 'replicas',
+        header: 'Desired',
+        render: 'number',
+        align: 'right',
+        width: 60,
+      },
+      {
+        field: 'creationTimestamp',
+        header: 'Age',
+        render: 'relative-time',
+        width: 80,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Database',
+    title: 'No StatefulSets',
+    message: 'No StatefulSets found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: true,
+  isLive: true,
+}
+
+export default statefulSetStatusConfig

--- a/web/src/config/cards/stock-market-ticker.ts
+++ b/web/src/config/cards/stock-market-ticker.ts
@@ -1,0 +1,25 @@
+/**
+ * Stock Market Ticker Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const stockMarketTickerConfig: UnifiedCardConfig = {
+  type: 'stock_market_ticker',
+  title: 'Stock Ticker',
+  category: 'utility',
+  description: 'Live stock market data',
+  icon: 'TrendingUp',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useStockMarketTicker' },
+  content: {
+    type: 'custom',
+    component: 'StockTicker',
+  },
+  emptyState: { icon: 'TrendingUp', title: 'No Data', message: 'Stock data unavailable', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default stockMarketTickerConfig

--- a/web/src/config/cards/storage-overview.ts
+++ b/web/src/config/cards/storage-overview.ts
@@ -1,0 +1,69 @@
+/**
+ * Storage Overview Card Configuration
+ *
+ * Displays storage usage and PVC status summary.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const storageOverviewConfig: UnifiedCardConfig = {
+  type: 'storage_overview',
+  title: 'Storage Overview',
+  category: 'storage',
+  description: 'Storage capacity and usage across clusters',
+  icon: 'HardDrive',
+  iconColor: 'text-purple-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+
+  isDemoData: true, // Uses demo data hook in registerHooks.ts
+
+  dataSource: {
+    type: 'hook',
+    hook: 'useStorageOverview',
+  },
+
+  content: {
+    type: 'status-grid',
+    columns: 2,
+    items: [
+      {
+        id: 'total-capacity',
+        label: 'Total Capacity',
+        valueSource: { type: 'field', path: 'totalCapacity' },
+        icon: 'Database',
+        color: 'purple',
+      },
+      {
+        id: 'used',
+        label: 'Used',
+        valueSource: { type: 'field', path: 'usedStorage' },
+        icon: 'HardDrive',
+        color: 'blue',
+      },
+      {
+        id: 'pvcs',
+        label: 'PVCs',
+        valueSource: { type: 'field', path: 'pvcCount' },
+        icon: 'Layers',
+        color: 'cyan',
+      },
+      {
+        id: 'unbound',
+        label: 'Unbound',
+        valueSource: { type: 'field', path: 'unboundCount' },
+        icon: 'AlertCircle',
+        color: 'yellow',
+      },
+    ],
+  },
+
+  emptyState: {
+    icon: 'HardDrive',
+    title: 'No storage data',
+    message: 'Storage metrics not available',
+    variant: 'neutral',
+  },
+
+  isLive: true,
+}

--- a/web/src/config/cards/sudoku-game.ts
+++ b/web/src/config/cards/sudoku-game.ts
@@ -1,0 +1,22 @@
+/**
+ * Sudoku Game Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const sudokuGameConfig: UnifiedCardConfig = {
+  type: 'sudoku_game',
+  title: 'Sudoku',
+  category: 'games',
+  description: 'Classic Sudoku puzzle game',
+  icon: 'Grid3X3',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'SudokuGame' },
+  emptyState: { icon: 'Grid3X3', title: 'Sudoku', message: 'Start a new game', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default sudokuGameConfig

--- a/web/src/config/cards/top-pods.ts
+++ b/web/src/config/cards/top-pods.ts
@@ -1,0 +1,84 @@
+/**
+ * Top Pods Card Configuration
+ *
+ * Displays pods with highest resource consumption.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const topPodsConfig: UnifiedCardConfig = {
+  type: 'top_pods',
+  title: 'Top Pods',
+  category: 'workloads',
+  description: 'Pods consuming the most resources',
+  icon: 'TrendingUp',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  isDemoData: true, // Uses demo data hook in registerHooks.ts
+
+  dataSource: {
+    type: 'hook',
+    hook: 'useTopPods',
+  },
+
+  filters: [
+    {
+      field: 'metric',
+      label: 'Sort By',
+      type: 'select',
+      options: [
+        { value: 'cpu', label: 'CPU' },
+        { value: 'memory', label: 'Memory' },
+      ],
+    },
+  ],
+
+  content: {
+    type: 'table',
+    columns: [
+      {
+        field: 'name',
+        header: 'Pod',
+        primary: true,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        width: 120,
+      },
+      {
+        field: 'cpu',
+        header: 'CPU',
+        width: 80,
+        render: 'percentage',
+      },
+      {
+        field: 'memory',
+        header: 'Memory',
+        width: 80,
+        render: 'percentage',
+      },
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        width: 100,
+        render: 'cluster-badge',
+      },
+    ],
+    sortable: true,
+  },
+
+  emptyState: {
+    icon: 'Box',
+    title: 'No pod data',
+    message: 'Pod metrics not available',
+    variant: 'neutral',
+  },
+
+  drillDown: {
+    action: 'showPodDetails',
+    params: ['name', 'namespace', 'cluster'],
+  },
+}

--- a/web/src/config/cards/trivy-scan.ts
+++ b/web/src/config/cards/trivy-scan.ts
@@ -1,0 +1,30 @@
+/**
+ * Trivy Scan Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const trivyScanConfig: UnifiedCardConfig = {
+  type: 'trivy_scan',
+  title: 'Trivy Vulnerabilities',
+  category: 'security',
+  description: 'Container vulnerability scan results',
+  icon: 'Bug',
+  iconColor: 'text-orange-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useTrivyScan' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'critical', label: 'Critical', color: 'red' },
+      { field: 'high', label: 'High', color: 'orange' },
+      { field: 'medium', label: 'Medium', color: 'yellow' },
+      { field: 'low', label: 'Low', color: 'blue' },
+    ],
+  },
+  emptyState: { icon: 'Bug', title: 'No Scans', message: 'No vulnerability scan data', variant: 'info' },
+  loadingState: { type: 'stats', count: 4 },
+  isDemoData: true,
+  isLive: false,
+}
+export default trivyScanConfig

--- a/web/src/config/cards/upgrade-status.ts
+++ b/web/src/config/cards/upgrade-status.ts
@@ -1,0 +1,31 @@
+/**
+ * Upgrade Status Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const upgradeStatusConfig: UnifiedCardConfig = {
+  type: 'upgrade_status',
+  title: 'Upgrade Status',
+  category: 'cluster-health',
+  description: 'Cluster upgrade availability',
+  icon: 'ArrowUpCircle',
+  iconColor: 'text-green-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useUpgradeStatus' },
+  content: {
+    type: 'list',
+    pageSize: 8,
+    columns: [
+      { field: 'cluster', header: 'Cluster', render: 'cluster-badge', width: 100 },
+      { field: 'currentVersion', header: 'Current', render: 'text', width: 80 },
+      { field: 'availableVersion', header: 'Available', render: 'text', width: 80 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'ArrowUpCircle', title: 'All Current', message: 'All clusters are up to date', variant: 'success' },
+  loadingState: { type: 'list', rows: 4 },
+  isDemoData: true,
+  isLive: false,
+}
+export default upgradeStatusConfig

--- a/web/src/config/cards/user-management.ts
+++ b/web/src/config/cards/user-management.ts
@@ -1,0 +1,22 @@
+/**
+ * User Management Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const userManagementConfig: UnifiedCardConfig = {
+  type: 'user_management',
+  title: 'User Management',
+  category: 'security',
+  description: 'Manage console users',
+  icon: 'Users',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useUserManagement' },
+  content: { type: 'custom', component: 'UserManagementUI' },
+  emptyState: { icon: 'Users', title: 'No Users', message: 'No users configured', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default userManagementConfig

--- a/web/src/config/cards/vault-secrets.ts
+++ b/web/src/config/cards/vault-secrets.ts
@@ -1,0 +1,29 @@
+/**
+ * Vault Secrets Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const vaultSecretsConfig: UnifiedCardConfig = {
+  type: 'vault_secrets',
+  title: 'Vault Secrets',
+  category: 'security',
+  description: 'HashiCorp Vault secret status',
+  icon: 'Lock',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useVaultSecrets' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'total', label: 'Total', color: 'blue' },
+      { field: 'synced', label: 'Synced', color: 'green' },
+      { field: 'failed', label: 'Failed', color: 'red' },
+    ],
+  },
+  emptyState: { icon: 'Lock', title: 'No Vault', message: 'Vault not configured', variant: 'info' },
+  loadingState: { type: 'stats', count: 3 },
+  isDemoData: true,
+  isLive: false,
+}
+export default vaultSecretsConfig

--- a/web/src/config/cards/warning-events.ts
+++ b/web/src/config/cards/warning-events.ts
@@ -1,0 +1,109 @@
+/**
+ * Warning Events Card Configuration
+ *
+ * Displays Kubernetes warning events using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const warningEventsConfig: UnifiedCardConfig = {
+  type: 'warning_events',
+  title: 'Warning Events',
+  category: 'live-trends',
+  description: 'Kubernetes warning events requiring attention',
+
+  // Appearance
+  icon: 'AlertTriangle',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useWarningEvents',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search warnings...',
+      searchFields: ['reason', 'message', 'object', 'namespace'],
+      storageKey: 'warning-events',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'warning-events-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 5,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'reason',
+        header: 'Reason',
+        render: 'status-badge',
+        width: 120,
+      },
+      {
+        field: 'object',
+        header: 'Object',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'count',
+        header: 'Count',
+        render: 'number',
+        align: 'right',
+        width: 60,
+      },
+      {
+        field: 'lastSeen',
+        header: 'Last Seen',
+        render: 'relative-time',
+        width: 80,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'CheckCircle',
+    title: 'No warnings',
+    message: 'All systems operating normally',
+    variant: 'success',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 3,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default warningEventsConfig

--- a/web/src/config/cards/weather.ts
+++ b/web/src/config/cards/weather.ts
@@ -1,0 +1,25 @@
+/**
+ * Weather Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const weatherConfig: UnifiedCardConfig = {
+  type: 'weather',
+  title: 'Weather',
+  category: 'utility',
+  description: 'Current weather conditions',
+  icon: 'Cloud',
+  iconColor: 'text-sky-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useWeather' },
+  content: {
+    type: 'custom',
+    component: 'WeatherDisplay',
+  },
+  emptyState: { icon: 'Cloud', title: 'No Weather', message: 'Weather data unavailable', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default weatherConfig

--- a/web/src/config/cards/workload-deployment.ts
+++ b/web/src/config/cards/workload-deployment.ts
@@ -1,0 +1,22 @@
+/**
+ * Workload Deployment Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const workloadDeploymentConfig: UnifiedCardConfig = {
+  type: 'workload_deployment',
+  title: 'Workload Deployment',
+  category: 'workloads',
+  description: 'Deploy workloads to clusters',
+  icon: 'Upload',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useWorkloadDeployment' },
+  content: { type: 'custom', component: 'WorkloadDeploymentUI' },
+  emptyState: { icon: 'Upload', title: 'Deploy', message: 'Select workload to deploy', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default workloadDeploymentConfig

--- a/web/src/config/cards/workload-monitor.ts
+++ b/web/src/config/cards/workload-monitor.ts
@@ -1,0 +1,22 @@
+/**
+ * Workload Monitor Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const workloadMonitorConfig: UnifiedCardConfig = {
+  type: 'workload_monitor',
+  title: 'Workload Monitor',
+  category: 'workloads',
+  description: 'Live workload health monitoring',
+  icon: 'Monitor',
+  iconColor: 'text-green-400',
+  defaultWidth: 8,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useWorkloadMonitor' },
+  content: { type: 'custom', component: 'WorkloadMonitorView' },
+  emptyState: { icon: 'Monitor', title: 'No Workloads', message: 'No workloads to monitor', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default workloadMonitorConfig

--- a/web/src/config/dashboards/ai-agents.ts
+++ b/web/src/config/dashboards/ai-agents.ts
@@ -1,0 +1,37 @@
+/**
+ * AI Agents (Kagenti) Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const aiAgentsDashboardConfig: UnifiedDashboardConfig = {
+  id: 'ai-agents',
+  name: 'AI Agents',
+  subtitle: 'Kagenti agent platform — deploy, secure, and manage AI agents',
+  route: '/ai-agents',
+  statsType: 'ai-agents',
+  cards: [
+    // Hero overview card
+    { id: 'kagenti-status-1', cardType: 'kagenti_status', title: 'Kagenti Overview', position: { w: 4, h: 5 } },
+    // Agent fleet table
+    { id: 'kagenti-fleet-1', cardType: 'kagenti_agent_fleet', title: 'Agent Fleet', position: { w: 8, h: 5 } },
+    // Build pipeline
+    { id: 'kagenti-builds-1', cardType: 'kagenti_build_pipeline', title: 'Build Pipeline', position: { w: 4, h: 4 } },
+    // Tool registry
+    { id: 'kagenti-tools-1', cardType: 'kagenti_tool_registry', title: 'MCP Tool Registry', position: { w: 4, h: 4 } },
+    // Agent discovery
+    { id: 'kagenti-discovery-1', cardType: 'kagenti_agent_discovery', title: 'Agent Discovery', position: { w: 4, h: 4 } },
+    // Security posture
+    { id: 'kagenti-security-1', cardType: 'kagenti_security', title: 'Security Posture', position: { w: 4, h: 4 } },
+    // Agent topology
+    { id: 'kagenti-topology-1', cardType: 'kagenti_topology', title: 'Agent Topology', position: { w: 8, h: 4 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+  },
+  storageKey: 'ai-agents-dashboard-cards',
+}
+
+export default aiAgentsDashboardConfig

--- a/web/src/config/dashboards/ai-ml.ts
+++ b/web/src/config/dashboards/ai-ml.ts
@@ -1,0 +1,44 @@
+/**
+ * AI/ML Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const aiMlDashboardConfig: UnifiedDashboardConfig = {
+  id: 'ai-ml',
+  name: 'AI/ML Workloads',
+  subtitle: 'LLM inference, ML jobs, and notebooks',
+  route: '/ai-ml',
+  statsType: 'ai-ml',
+  cards: [
+    // Stunning LLM-d visualization cards (hero row - all 1/3 width)
+    { id: 'llmd-flow-1', cardType: 'llmd_flow', title: 'llm-d Request Flow', position: { w: 4, h: 5 } },
+    { id: 'kvcache-monitor-1', cardType: 'kvcache_monitor', title: 'KV Cache Monitor', position: { w: 4, h: 5 } },
+    { id: 'epp-routing-1', cardType: 'epp_routing', title: 'EPP Routing', position: { w: 4, h: 5 } },
+
+    // Architecture and routing visualizations
+    { id: 'pd-disagg-1', cardType: 'pd_disaggregation', title: 'P/D Disaggregation', position: { w: 6, h: 4 } },
+
+    // Performance and intelligence
+    { id: 'llmd-benchmarks-1', cardType: 'llmd_benchmarks', title: 'Benchmarks', position: { w: 6, h: 4 } },
+    { id: 'llmd-ai-insights-1', cardType: 'llmd_ai_insights', title: 'AI Insights', position: { w: 6, h: 4 } },
+
+    // Configuration and existing cards
+    { id: 'llmd-configurator-1', cardType: 'llmd_configurator', title: 'Configurator', position: { w: 4, h: 4 } },
+    { id: 'llm-models-1', cardType: 'llm_models', position: { w: 4, h: 3 } },
+    { id: 'llm-inference-1', cardType: 'llm_inference', position: { w: 4, h: 3 } },
+    { id: 'llmd-stack-monitor-1', cardType: 'llmd_stack_monitor', position: { w: 4, h: 3 } },
+    { id: 'ml-jobs-1', cardType: 'ml_jobs', position: { w: 4, h: 3 } },
+    { id: 'ml-notebooks-1', cardType: 'ml_notebooks', position: { w: 4, h: 3 } },
+    { id: 'gpu-overview-1', cardType: 'gpu_overview', position: { w: 4, h: 3 } },
+    { id: 'hardware-health-1', cardType: 'hardware_health', title: 'Hardware Health', position: { w: 6, h: 3 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+  },
+  storageKey: 'ai-ml-dashboard-cards',
+}
+
+export default aiMlDashboardConfig

--- a/web/src/config/dashboards/alerts.ts
+++ b/web/src/config/dashboards/alerts.ts
@@ -1,0 +1,28 @@
+/**
+ * Alerts Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const alertsDashboardConfig: UnifiedDashboardConfig = {
+  id: 'alerts',
+  name: 'Alerts',
+  subtitle: 'Alert management and configuration',
+  route: '/alerts',
+  statsType: 'alerts',
+  cards: [
+    { id: 'active-alerts-1', cardType: 'active_alerts', position: { w: 8, h: 4 } },
+    { id: 'alert-rules-1', cardType: 'alert_rules', position: { w: 4, h: 3 } },
+    { id: 'falco-alerts-1', cardType: 'falco_alerts', position: { w: 6, h: 3 } },
+    { id: 'warning-events-1', cardType: 'warning_events', position: { w: 6, h: 3 } },
+    { id: 'event-summary-1', cardType: 'event_summary', position: { w: 6, h: 3 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 15000,
+  },
+  storageKey: 'alerts-dashboard-cards',
+}
+
+export default alertsDashboardConfig

--- a/web/src/config/dashboards/arcade.ts
+++ b/web/src/config/dashboards/arcade.ts
@@ -1,0 +1,51 @@
+/**
+ * Arcade Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const arcadeDashboardConfig: UnifiedDashboardConfig = {
+  id: 'arcade',
+  name: 'Arcade',
+  subtitle: 'Games and entertainment',
+  route: '/arcade',
+  statsType: 'arcade',
+  cards: [
+    // Strategy games (featured)
+    { id: 'checkers-1', cardType: 'checkers', title: 'Kube Checkers', position: { w: 5, h: 4 } },
+    { id: 'chess-1', cardType: 'kube_chess', title: 'Kube Chess', position: { w: 5, h: 4 } },
+    { id: 'sudoku-1', cardType: 'sudoku_game', title: 'Kube Sudoku', position: { w: 6, h: 4 } },
+    // Classic arcade games
+    { id: 'tetris-1', cardType: 'container_tetris', title: 'Container Tetris', position: { w: 6, h: 4 } },
+    { id: 'invaders-1', cardType: 'node_invaders', title: 'Node Invaders', position: { w: 6, h: 4 } },
+    { id: 'pacman-1', cardType: 'kube_man', title: 'Kube-Man', position: { w: 6, h: 4 } },
+    { id: 'kong-1', cardType: 'kube_kong', title: 'Kube Kong', position: { w: 6, h: 4 } },
+    { id: 'crosser-1', cardType: 'pod_crosser', title: 'Pod Crosser', position: { w: 6, h: 4 } },
+    { id: 'pitfall-1', cardType: 'pod_pitfall', title: 'Pod Pitfall', position: { w: 6, h: 4 } },
+    { id: 'brothers-1', cardType: 'pod_brothers', title: 'Pod Brothers', position: { w: 6, h: 4 } },
+    { id: 'galaga-1', cardType: 'kube_galaga', title: 'Kube Galaga', position: { w: 5, h: 4 } },
+    // Action & racing games
+    { id: 'pong-1', cardType: 'kube_pong', title: 'Kube Pong', position: { w: 5, h: 4 } },
+    { id: 'snake-1', cardType: 'kube_snake', title: 'Kube Snake', position: { w: 5, h: 4 } },
+    { id: 'kart-1', cardType: 'kube_kart', title: 'Kube Kart', position: { w: 5, h: 4 } },
+    // Puzzle games
+    { id: '2048-1', cardType: 'game_2048', title: 'Kube 2048', position: { w: 4, h: 4 } },
+    { id: 'sweeper-1', cardType: 'pod_sweeper', title: 'Pod Sweeper', position: { w: 6, h: 4 } },
+    { id: 'kubedle-1', cardType: 'kubedle', title: 'Kubedle', position: { w: 4, h: 4 } },
+    { id: 'match-1', cardType: 'match_game', title: 'Kube Match', position: { w: 6, h: 4 } },
+    { id: 'solitaire-1', cardType: 'solitaire', title: 'Kube Solitaire', position: { w: 6, h: 4 } },
+    // Flappy
+    { id: 'flappy-1', cardType: 'flappy_pod', title: 'Flappy Pod', position: { w: 5, h: 4 } },
+    // Craft
+    { id: 'craft-1', cardType: 'kube_craft', title: 'Kube Craft', position: { w: 6, h: 4 } },
+    // FPS
+    { id: 'doom-1', cardType: 'kube_doom', title: 'Kube Doom', position: { w: 6, h: 4 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: false,
+  },
+  storageKey: 'kubestellar-arcade-cards',
+}
+
+export default arcadeDashboardConfig

--- a/web/src/config/dashboards/ci-cd.ts
+++ b/web/src/config/dashboards/ci-cd.ts
@@ -1,0 +1,31 @@
+/**
+ * CI/CD Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const ciCdDashboardConfig: UnifiedDashboardConfig = {
+  id: 'ci-cd',
+  name: 'CI/CD',
+  subtitle: 'Continuous integration and deployment pipelines',
+  route: '/ci-cd',
+  statsType: 'ci-cd',
+  cards: [
+    // Top row: Prow overview cards
+    { id: 'prow-status-1', cardType: 'prow_status', title: 'Prow Status', position: { w: 4, h: 3 } },
+    { id: 'prow-jobs-1', cardType: 'prow_jobs', title: 'Prow Jobs', position: { w: 5, h: 4 } },
+    { id: 'prow-ci-monitor-1', cardType: 'prow_ci_monitor', title: 'Prow CI Monitor', position: { w: 6, h: 4 } },
+    // Second row: History and GitHub integration
+    { id: 'prow-history-1', cardType: 'prow_history', title: 'Prow History', position: { w: 4, h: 3 } },
+    { id: 'github-ci-monitor-1', cardType: 'github_ci_monitor', title: 'GitHub CI Monitor', position: { w: 6, h: 4 } },
+    { id: 'github-activity-1', cardType: 'github_activity', title: 'GitHub Activity', position: { w: 5, h: 4 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 60000,
+  },
+  storageKey: 'ci-cd-dashboard-cards',
+}
+
+export default ciCdDashboardConfig

--- a/web/src/config/dashboards/clusters.ts
+++ b/web/src/config/dashboards/clusters.ts
@@ -1,0 +1,31 @@
+/**
+ * Clusters Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const clustersDashboardConfig: UnifiedDashboardConfig = {
+  id: 'clusters',
+  name: 'My Clusters',
+  subtitle: 'Multi-cluster overview and management',
+  route: '/clusters',
+  statsType: 'clusters',
+  cards: [
+    { id: 'offline-detection-1', cardType: 'console_ai_offline_detection', position: { w: 6, h: 3 } },
+    { id: 'hardware-health-1', cardType: 'hardware_health', position: { w: 6, h: 3 } },
+    { id: 'cluster-health-1', cardType: 'cluster_health', position: { w: 8, h: 4 } },
+    { id: 'cluster-groups-1', cardType: 'cluster_groups', position: { w: 4, h: 4 } },
+    { id: 'cluster-metrics-1', cardType: 'cluster_metrics', position: { w: 6, h: 3 } },
+    { id: 'cluster-comparison-1', cardType: 'cluster_comparison', position: { w: 6, h: 3 } },
+    { id: 'provider-health-1', cardType: 'provider_health', position: { w: 4, h: 3 } },
+    { id: 'cluster-locations-1', cardType: 'cluster_locations', position: { w: 8, h: 4 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+  },
+  storageKey: 'clusters-dashboard-cards',
+}
+
+export default clustersDashboardConfig

--- a/web/src/config/dashboards/compliance.ts
+++ b/web/src/config/dashboards/compliance.ts
@@ -1,0 +1,29 @@
+/**
+ * Compliance Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const complianceDashboardConfig: UnifiedDashboardConfig = {
+  id: 'compliance',
+  name: 'Compliance',
+  subtitle: 'Security posture and compliance metrics',
+  route: '/compliance',
+  statsType: 'compliance',
+  cards: [
+    { id: 'compliance-score-1', cardType: 'compliance_score', position: { w: 4, h: 3 } },
+    { id: 'policy-violations-1', cardType: 'policy_violations', position: { w: 8, h: 4 } },
+    { id: 'opa-policies-1', cardType: 'opa_policies', position: { w: 6, h: 3 } },
+    { id: 'kyverno-policies-1', cardType: 'kyverno_policies', position: { w: 6, h: 3 } },
+    { id: 'kubescape-scan-1', cardType: 'kubescape_scan', position: { w: 6, h: 3 } },
+    { id: 'trivy-scan-1', cardType: 'trivy_scan', position: { w: 6, h: 3 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 60000,
+  },
+  storageKey: 'compliance-dashboard-cards',
+}
+
+export default complianceDashboardConfig

--- a/web/src/config/dashboards/compute.ts
+++ b/web/src/config/dashboards/compute.ts
@@ -1,0 +1,114 @@
+/**
+ * Compute Dashboard Configuration
+ *
+ * Dashboard focused on compute resources: clusters, nodes, pods.
+ */
+
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const computeDashboardConfig: UnifiedDashboardConfig = {
+  id: 'compute',
+  name: 'Compute',
+  subtitle: 'Cluster and node resources',
+  route: '/compute',
+
+  statsType: 'compute',
+  stats: {
+    type: 'compute',
+    title: 'Compute Resources',
+    collapsible: true,
+    showConfigButton: true,
+    blocks: [
+      {
+        id: 'clusters',
+        name: 'Clusters',
+        icon: 'Server',
+        color: 'purple',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalClusters' },
+      },
+      {
+        id: 'nodes',
+        name: 'Nodes',
+        icon: 'Box',
+        color: 'cyan',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalNodes' },
+      },
+      {
+        id: 'pods',
+        name: 'Pods',
+        icon: 'Layers',
+        color: 'blue',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalPods' },
+      },
+      {
+        id: 'cpu-usage',
+        name: 'CPU Usage',
+        icon: 'Cpu',
+        color: 'orange',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.cpuUsagePercent' },
+        format: 'percentage',
+      },
+      {
+        id: 'memory-usage',
+        name: 'Memory',
+        icon: 'MemoryStick',
+        color: 'green',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.memoryUsagePercent' },
+        format: 'percentage',
+      },
+    ],
+  },
+
+  cards: [
+    {
+      id: 'compute-1',
+      cardType: 'cluster_health',
+      position: { w: 4, h: 3, x: 0, y: 0 },
+    },
+    {
+      id: 'compute-2',
+      cardType: 'resource_usage',
+      position: { w: 4, h: 3, x: 4, y: 0 },
+    },
+    {
+      id: 'compute-3',
+      cardType: 'top_pods',
+      position: { w: 4, h: 3, x: 8, y: 0 },
+    },
+    {
+      id: 'compute-4',
+      cardType: 'cluster_metrics',
+      position: { w: 6, h: 3, x: 0, y: 3 },
+    },
+    {
+      id: 'compute-5',
+      cardType: 'pod_issues',
+      position: { w: 6, h: 3, x: 6, y: 3 },
+    },
+  ],
+
+  availableCardTypes: [
+    'cluster_health',
+    'resource_usage',
+    'top_pods',
+    'pod_issues',
+    'cluster_metrics',
+    'deployment_status',
+  ],
+
+  features: {
+    dragDrop: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+    addCard: true,
+  },
+
+  storageKey: 'kubestellar-unified-compute-dashboard',
+}
+
+export default computeDashboardConfig

--- a/web/src/config/dashboards/cost.ts
+++ b/web/src/config/dashboards/cost.ts
@@ -1,0 +1,28 @@
+/**
+ * Cost Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const costDashboardConfig: UnifiedDashboardConfig = {
+  id: 'cost',
+  name: 'Cost Management',
+  subtitle: 'Cluster cost analysis and optimization',
+  route: '/cost',
+  statsType: 'cost',
+  cards: [
+    { id: 'cluster-costs-1', cardType: 'cluster_costs', position: { w: 8, h: 4 } },
+    { id: 'kubecost-overview-1', cardType: 'kubecost_overview', position: { w: 4, h: 3 } },
+    { id: 'opencost-overview-1', cardType: 'opencost_overview', position: { w: 4, h: 3 } },
+    { id: 'resource-capacity-1', cardType: 'resource_capacity', position: { w: 6, h: 3 } },
+    { id: 'resource-trend-1', cardType: 'resource_trend', position: { w: 6, h: 3 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 300000, // 5 minutes
+  },
+  storageKey: 'cost-dashboard-cards',
+}
+
+export default costDashboardConfig

--- a/web/src/config/dashboards/data-compliance.ts
+++ b/web/src/config/dashboards/data-compliance.ts
@@ -1,0 +1,27 @@
+/**
+ * Data Compliance Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const dataComplianceDashboardConfig: UnifiedDashboardConfig = {
+  id: 'data-compliance',
+  name: 'Data Compliance',
+  subtitle: 'Data protection and compliance posture',
+  route: '/data-compliance',
+  statsType: 'data-compliance',
+  cards: [
+    { id: 'vault-secrets-1', cardType: 'vault_secrets', title: 'HashiCorp Vault', position: { w: 4, h: 3 } },
+    { id: 'external-secrets-1', cardType: 'external_secrets', title: 'External Secrets', position: { w: 4, h: 3 } },
+    { id: 'cert-manager-1', cardType: 'cert_manager', title: 'Cert-Manager', position: { w: 4, h: 3 } },
+    { id: 'namespace-rbac-1', cardType: 'namespace_rbac', title: 'Access Controls', position: { w: 6, h: 4 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+  },
+  storageKey: 'data-compliance-dashboard-cards',
+}
+
+export default dataComplianceDashboardConfig

--- a/web/src/config/dashboards/deploy.ts
+++ b/web/src/config/dashboards/deploy.ts
@@ -1,0 +1,45 @@
+/**
+ * Deploy Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const deployDashboardConfig: UnifiedDashboardConfig = {
+  id: 'deploy',
+  name: 'Deploy',
+  subtitle: 'Workload deployment and management',
+  route: '/deploy',
+  statsType: 'deploy',
+  cards: [
+    // Top row: Workloads, Cluster Groups, Missions (1/3 each)
+    { id: 'workload-deployment-1', cardType: 'workload_deployment', title: 'Workloads', position: { w: 4, h: 4 } },
+    { id: 'cluster-groups-1', cardType: 'cluster_groups', title: 'Cluster Groups', position: { w: 4, h: 4 } },
+    { id: 'deployment-missions-1', cardType: 'deployment_missions', title: 'Deployment Missions', position: { w: 4, h: 4 } },
+    // Resource Marshall
+    { id: 'resource-marshall-1', cardType: 'resource_marshall', title: 'Resource Marshall', position: { w: 6, h: 4 } },
+    // Deployment Status
+    { id: 'deployment-status-1', cardType: 'deployment_status', title: 'Deployment Status', position: { w: 6, h: 4 } },
+    { id: 'deployment-progress-1', cardType: 'deployment_progress', title: 'Deployment Progress', position: { w: 5, h: 4 } },
+    { id: 'deployment-issues-1', cardType: 'deployment_issues', title: 'Deployment Issues', position: { w: 6, h: 4 } },
+    // GitOps
+    { id: 'gitops-drift-1', cardType: 'gitops_drift', title: 'GitOps Drift', position: { w: 6, h: 4 } },
+    { id: 'argocd-apps-1', cardType: 'argocd_applications', title: 'ArgoCD Applications', position: { w: 6, h: 4 } },
+    { id: 'argocd-sync-1', cardType: 'argocd_sync_status', title: 'ArgoCD Sync Status', position: { w: 6, h: 4 } },
+    { id: 'argocd-health-1', cardType: 'argocd_health', title: 'ArgoCD Health', position: { w: 6, h: 4 } },
+    // Helm
+    { id: 'helm-release-1', cardType: 'helm_release_status', title: 'Helm Releases', position: { w: 6, h: 4 } },
+    { id: 'helm-history-1', cardType: 'helm_history', title: 'Helm History', position: { w: 8, h: 4 } },
+    { id: 'chart-versions-1', cardType: 'chart_versions', title: 'Chart Versions', position: { w: 6, h: 4 } },
+    // Kustomize
+    { id: 'kustomization-1', cardType: 'kustomization_status', title: 'Kustomization Status', position: { w: 6, h: 4 } },
+    { id: 'overlay-1', cardType: 'overlay_comparison', title: 'Overlay Comparison', position: { w: 6, h: 4 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+  },
+  storageKey: 'kubestellar-deploy-cards',
+}
+
+export default deployDashboardConfig

--- a/web/src/config/dashboards/deployments.ts
+++ b/web/src/config/dashboards/deployments.ts
@@ -1,0 +1,29 @@
+/**
+ * Deployments Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const deploymentsDashboardConfig: UnifiedDashboardConfig = {
+  id: 'deployments',
+  name: 'Deployments',
+  subtitle: 'Deployment status and rollout management',
+  route: '/deployments',
+  statsType: 'deployments',
+  cards: [
+    { id: 'deployment-status-1', cardType: 'deployment_status', position: { w: 8, h: 4 } },
+    { id: 'deployment-issues-1', cardType: 'deployment_issues', position: { w: 4, h: 3 } },
+    { id: 'deployment-progress-1', cardType: 'deployment_progress', position: { w: 6, h: 3 } },
+    { id: 'replicaset-status-1', cardType: 'replicaset_status', position: { w: 6, h: 3 } },
+    { id: 'hpa-status-1', cardType: 'hpa_status', position: { w: 6, h: 3 } },
+    { id: 'workload-deployment-1', cardType: 'workload_deployment', position: { w: 6, h: 3 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 15000,
+  },
+  storageKey: 'deployments-dashboard-cards',
+}
+
+export default deploymentsDashboardConfig

--- a/web/src/config/dashboards/events.ts
+++ b/web/src/config/dashboards/events.ts
@@ -1,0 +1,97 @@
+/**
+ * Events Dashboard Configuration
+ *
+ * Dashboard focused on Kubernetes events monitoring.
+ */
+
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const eventsDashboardConfig: UnifiedDashboardConfig = {
+  id: 'events',
+  name: 'Events',
+  subtitle: 'Kubernetes events monitoring',
+  route: '/events',
+
+  statsType: 'events',
+  stats: {
+    type: 'events',
+    title: 'Event Activity',
+    collapsible: true,
+    showConfigButton: true,
+    blocks: [
+      {
+        id: 'total-events',
+        name: 'Total',
+        icon: 'Activity',
+        color: 'blue',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalEvents' },
+      },
+      {
+        id: 'warning-events',
+        name: 'Warnings',
+        icon: 'AlertTriangle',
+        color: 'yellow',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.warningCount' },
+      },
+      {
+        id: 'error-events',
+        name: 'Errors',
+        icon: 'AlertCircle',
+        color: 'red',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.errorCount' },
+      },
+      {
+        id: 'normal-events',
+        name: 'Normal',
+        icon: 'CheckCircle2',
+        color: 'green',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.normalCount' },
+      },
+    ],
+  },
+
+  cards: [
+    {
+      id: 'events-1',
+      cardType: 'event_stream',
+      position: { w: 6, h: 4, x: 0, y: 0 },
+    },
+    {
+      id: 'events-2',
+      cardType: 'warning_events',
+      position: { w: 6, h: 4, x: 6, y: 0 },
+    },
+    {
+      id: 'events-3',
+      cardType: 'recent_events',
+      position: { w: 6, h: 3, x: 0, y: 4 },
+    },
+    {
+      id: 'events-4',
+      cardType: 'events_timeline',
+      position: { w: 6, h: 3, x: 6, y: 4 },
+    },
+  ],
+
+  availableCardTypes: [
+    'event_stream',
+    'warning_events',
+    'recent_events',
+    'events_timeline',
+  ],
+
+  features: {
+    dragDrop: true,
+    autoRefresh: true,
+    autoRefreshInterval: 10000,
+    addCard: true,
+  },
+
+  storageKey: 'kubestellar-unified-events-dashboard',
+}
+
+export default eventsDashboardConfig

--- a/web/src/config/dashboards/gitops.ts
+++ b/web/src/config/dashboards/gitops.ts
@@ -1,0 +1,97 @@
+/**
+ * GitOps Dashboard Configuration
+ *
+ * Dashboard focused on GitOps sync status and deployments.
+ */
+
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const gitopsDashboardConfig: UnifiedDashboardConfig = {
+  id: 'gitops',
+  name: 'GitOps',
+  subtitle: 'Deployment and sync status',
+  route: '/gitops',
+
+  statsType: 'gitops',
+  stats: {
+    type: 'gitops',
+    title: 'GitOps Status',
+    collapsible: true,
+    showConfigButton: true,
+    blocks: [
+      {
+        id: 'deployments',
+        name: 'Deployments',
+        icon: 'Rocket',
+        color: 'blue',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalDeployments' },
+      },
+      {
+        id: 'synced',
+        name: 'Synced',
+        icon: 'CheckCircle2',
+        color: 'green',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.syncedCount' },
+      },
+      {
+        id: 'drifted',
+        name: 'Drifted',
+        icon: 'AlertTriangle',
+        color: 'yellow',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.driftedCount' },
+      },
+      {
+        id: 'failed',
+        name: 'Failed',
+        icon: 'XCircle',
+        color: 'red',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.failedCount' },
+      },
+    ],
+  },
+
+  cards: [
+    {
+      id: 'gitops-1',
+      cardType: 'deployment_status',
+      position: { w: 6, h: 3, x: 0, y: 0 },
+    },
+    {
+      id: 'gitops-2',
+      cardType: 'gitops_drift',
+      position: { w: 6, h: 3, x: 6, y: 0 },
+    },
+    {
+      id: 'gitops-3',
+      cardType: 'event_stream',
+      position: { w: 6, h: 4, x: 0, y: 3 },
+    },
+    {
+      id: 'gitops-4',
+      cardType: 'events_timeline',
+      position: { w: 6, h: 3, x: 6, y: 3 },
+    },
+  ],
+
+  availableCardTypes: [
+    'deployment_status',
+    'gitops_drift',
+    'event_stream',
+    'events_timeline',
+  ],
+
+  features: {
+    dragDrop: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+    addCard: true,
+  },
+
+  storageKey: 'kubestellar-unified-gitops-dashboard',
+}
+
+export default gitopsDashboardConfig

--- a/web/src/config/dashboards/gpu.ts
+++ b/web/src/config/dashboards/gpu.ts
@@ -1,0 +1,30 @@
+/**
+ * GPU Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const gpuDashboardConfig: UnifiedDashboardConfig = {
+  id: 'gpu',
+  name: 'GPU Reservations',
+  subtitle: 'GPU resource allocation and utilization',
+  route: '/gpu-reservations',
+  statsType: 'gpu',
+  cards: [
+    { id: 'gpu-overview-1', cardType: 'gpu_overview', position: { w: 4, h: 3 } },
+    { id: 'gpu-status-1', cardType: 'gpu_status', position: { w: 8, h: 4 } },
+    { id: 'gpu-inventory-1', cardType: 'gpu_inventory', position: { w: 6, h: 3 } },
+    { id: 'gpu-utilization-1', cardType: 'gpu_utilization', position: { w: 6, h: 3 } },
+    { id: 'gpu-usage-trend-1', cardType: 'gpu_usage_trend', position: { w: 6, h: 3 } },
+    { id: 'gpu-workloads-1', cardType: 'gpu_workloads', position: { w: 6, h: 3 } },
+    { id: 'hardware-health-1', cardType: 'hardware_health', title: 'Hardware Health', position: { w: 6, h: 3 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+  },
+  storageKey: 'gpu-dashboard-cards',
+}
+
+export default gpuDashboardConfig

--- a/web/src/config/dashboards/helm.ts
+++ b/web/src/config/dashboards/helm.ts
@@ -1,0 +1,27 @@
+/**
+ * Helm Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const helmDashboardConfig: UnifiedDashboardConfig = {
+  id: 'helm',
+  name: 'Helm Releases',
+  subtitle: 'Helm chart versions, releases, and values',
+  route: '/helm',
+  statsType: 'helm',
+  cards: [
+    { id: 'helm-release-status-1', cardType: 'helm_release_status', position: { w: 8, h: 4 } },
+    { id: 'chart-versions-1', cardType: 'chart_versions', position: { w: 4, h: 3 } },
+    { id: 'helm-history-1', cardType: 'helm_history', position: { w: 6, h: 3 } },
+    { id: 'helm-values-diff-1', cardType: 'helm_values_diff', position: { w: 6, h: 4 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 60000,
+  },
+  storageKey: 'helm-dashboard-cards',
+}
+
+export default helmDashboardConfig

--- a/web/src/config/dashboards/index.ts
+++ b/web/src/config/dashboards/index.ts
@@ -1,0 +1,152 @@
+/**
+ * Dashboard Configuration Registry
+ *
+ * Central registry for all unified dashboard configurations.
+ */
+
+import type { UnifiedDashboardConfig, DashboardConfigRegistry } from '../../lib/unified/types'
+import { mainDashboardConfig } from './main'
+import { computeDashboardConfig } from './compute'
+import { securityDashboardConfig } from './security'
+import { gitopsDashboardConfig } from './gitops'
+import { storageDashboardConfig } from './storage'
+import { networkDashboardConfig } from './network'
+import { eventsDashboardConfig } from './events'
+import { workloadsDashboardConfig } from './workloads'
+import { operatorsDashboardConfig } from './operators'
+import { clustersDashboardConfig } from './clusters'
+import { complianceDashboardConfig } from './compliance'
+import { costDashboardConfig } from './cost'
+import { gpuDashboardConfig } from './gpu'
+import { nodesDashboardConfig } from './nodes'
+import { deploymentsDashboardConfig } from './deployments'
+import { podsDashboardConfig } from './pods'
+import { servicesDashboardConfig } from './services'
+import { helmDashboardConfig } from './helm'
+import { alertsDashboardConfig } from './alerts'
+import { aiMlDashboardConfig } from './ai-ml'
+import { ciCdDashboardConfig } from './ci-cd'
+import { logsDashboardConfig } from './logs'
+import { dataComplianceDashboardConfig } from './data-compliance'
+import { arcadeDashboardConfig } from './arcade'
+import { deployDashboardConfig } from './deploy'
+import { aiAgentsDashboardConfig } from './ai-agents'
+
+/**
+ * Registry of all unified dashboard configurations
+ */
+export const DASHBOARD_CONFIGS: DashboardConfigRegistry = {
+  main: mainDashboardConfig,
+  compute: computeDashboardConfig,
+  security: securityDashboardConfig,
+  gitops: gitopsDashboardConfig,
+  storage: storageDashboardConfig,
+  network: networkDashboardConfig,
+  events: eventsDashboardConfig,
+  workloads: workloadsDashboardConfig,
+  operators: operatorsDashboardConfig,
+  clusters: clustersDashboardConfig,
+  compliance: complianceDashboardConfig,
+  cost: costDashboardConfig,
+  gpu: gpuDashboardConfig,
+  nodes: nodesDashboardConfig,
+  deployments: deploymentsDashboardConfig,
+  pods: podsDashboardConfig,
+  services: servicesDashboardConfig,
+  helm: helmDashboardConfig,
+  alerts: alertsDashboardConfig,
+  'ai-ml': aiMlDashboardConfig,
+  'ci-cd': ciCdDashboardConfig,
+  logs: logsDashboardConfig,
+  'data-compliance': dataComplianceDashboardConfig,
+  arcade: arcadeDashboardConfig,
+  deploy: deployDashboardConfig,
+  'ai-agents': aiAgentsDashboardConfig,
+}
+
+/**
+ * Get a dashboard configuration by ID
+ */
+export function getDashboardConfig(dashboardId: string): UnifiedDashboardConfig | undefined {
+  return DASHBOARD_CONFIGS[dashboardId]
+}
+
+/**
+ * Check if a dashboard ID has a unified configuration
+ */
+export function hasUnifiedDashboardConfig(dashboardId: string): boolean {
+  return dashboardId in DASHBOARD_CONFIGS
+}
+
+/**
+ * Get all registered dashboard IDs
+ */
+export function getUnifiedDashboardIds(): string[] {
+  return Object.keys(DASHBOARD_CONFIGS)
+}
+
+/**
+ * Get default cards for a dashboard in the legacy format used by DashboardPage
+ * Converts from UnifiedDashboardConfig.cards to the legacy { type, title, position } format
+ */
+export function getDefaultCards(dashboardId: string): Array<{ type: string; title?: string; position: { w: number; h: number } }> {
+  const config = DASHBOARD_CONFIGS[dashboardId]
+  if (!config?.cards) return []
+
+  return config.cards.map(card => ({
+    type: card.cardType,
+    title: card.title,
+    position: { w: card.position.w, h: card.position.h },
+  }))
+}
+
+/**
+ * Get default cards for a dashboard in the Dashboard.tsx format
+ * Converts from UnifiedDashboardConfig.cards to { id, card_type, config, position } format
+ */
+export function getDefaultCardsForDashboard(dashboardId: string): Array<{ id: string; card_type: string; config: Record<string, unknown>; position: { x: number; y: number; w: number; h: number } }> {
+  const config = DASHBOARD_CONFIGS[dashboardId]
+  if (!config?.cards) return []
+
+  return config.cards.map((card, index) => ({
+    id: card.id || `default-${index}`,
+    card_type: card.cardType,
+    config: {},
+    position: {
+      x: card.position.x ?? (index % 3) * 4,
+      y: card.position.y ?? Math.floor(index / 3) * 3,
+      w: card.position.w,
+      h: card.position.h,
+    },
+  }))
+}
+
+// Re-export individual configs
+export {
+  mainDashboardConfig,
+  computeDashboardConfig,
+  securityDashboardConfig,
+  gitopsDashboardConfig,
+  storageDashboardConfig,
+  networkDashboardConfig,
+  eventsDashboardConfig,
+  workloadsDashboardConfig,
+  operatorsDashboardConfig,
+  clustersDashboardConfig,
+  complianceDashboardConfig,
+  costDashboardConfig,
+  gpuDashboardConfig,
+  nodesDashboardConfig,
+  deploymentsDashboardConfig,
+  podsDashboardConfig,
+  servicesDashboardConfig,
+  helmDashboardConfig,
+  alertsDashboardConfig,
+  aiMlDashboardConfig,
+  ciCdDashboardConfig,
+  logsDashboardConfig,
+  dataComplianceDashboardConfig,
+  arcadeDashboardConfig,
+  deployDashboardConfig,
+  aiAgentsDashboardConfig,
+}

--- a/web/src/config/dashboards/logs.ts
+++ b/web/src/config/dashboards/logs.ts
@@ -1,0 +1,26 @@
+/**
+ * Logs Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const logsDashboardConfig: UnifiedDashboardConfig = {
+  id: 'logs',
+  name: 'Logs',
+  subtitle: 'Event streams and cluster logs',
+  route: '/logs',
+  statsType: 'logs',
+  cards: [
+    { id: 'event-stream-1', cardType: 'event_stream', title: 'Event Stream', position: { w: 12, h: 4 } },
+    { id: 'namespace-events-1', cardType: 'namespace_events', title: 'Namespace Events', position: { w: 6, h: 3 } },
+    { id: 'events-timeline-1', cardType: 'events_timeline', title: 'Events Timeline', position: { w: 6, h: 3 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+  },
+  storageKey: 'kubestellar-logs-cards',
+}
+
+export default logsDashboardConfig

--- a/web/src/config/dashboards/main.ts
+++ b/web/src/config/dashboards/main.ts
@@ -1,0 +1,152 @@
+/**
+ * Main Dashboard Configuration
+ *
+ * The primary dashboard showing cluster overview with key metrics
+ * and status cards.
+ */
+
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const mainDashboardConfig: UnifiedDashboardConfig = {
+  id: 'main',
+  name: 'Dashboard',
+  subtitle: 'Multi-cluster overview',
+  route: '/',
+
+  // Stats configuration
+  statsType: 'dashboard',
+  stats: {
+    type: 'dashboard',
+    title: 'Overview',
+    collapsible: true,
+    showConfigButton: true,
+    blocks: [
+      {
+        id: 'clusters',
+        name: 'Clusters',
+        icon: 'Server',
+        color: 'purple',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalClusters' },
+      },
+      {
+        id: 'healthy',
+        name: 'Healthy',
+        icon: 'CheckCircle2',
+        color: 'green',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.healthyClusters' },
+      },
+      {
+        id: 'pods',
+        name: 'Pods',
+        icon: 'Layers',
+        color: 'blue',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalPods' },
+      },
+      {
+        id: 'nodes',
+        name: 'Nodes',
+        icon: 'Box',
+        color: 'cyan',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalNodes' },
+      },
+      {
+        id: 'namespaces',
+        name: 'Namespaces',
+        icon: 'FolderTree',
+        color: 'purple',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalNamespaces' },
+      },
+      {
+        id: 'errors',
+        name: 'Errors',
+        icon: 'XCircle',
+        color: 'red',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.errorCount' },
+      },
+    ],
+  },
+
+  // Default cards
+  cards: [
+    {
+      id: 'default-offline',
+      cardType: 'console_ai_offline_detection',
+      position: { w: 6, h: 3, x: 0, y: 0 },
+    },
+    {
+      id: 'default-hardware',
+      cardType: 'hardware_health',
+      position: { w: 6, h: 3, x: 6, y: 0 },
+    },
+    {
+      id: 'default-1',
+      cardType: 'cluster_health',
+      position: { w: 4, h: 3, x: 0, y: 3 },
+    },
+    {
+      id: 'default-2',
+      cardType: 'resource_usage',
+      position: { w: 4, h: 3, x: 4, y: 3 },
+    },
+    {
+      id: 'default-3',
+      cardType: 'pod_issues',
+      position: { w: 4, h: 3, x: 8, y: 3 },
+    },
+    {
+      id: 'default-4',
+      cardType: 'cluster_metrics',
+      position: { w: 6, h: 3, x: 0, y: 6 },
+    },
+    {
+      id: 'default-5',
+      cardType: 'event_stream',
+      position: { w: 6, h: 4, x: 6, y: 6 },
+    },
+    {
+      id: 'default-6',
+      cardType: 'deployment_status',
+      position: { w: 6, h: 3, x: 0, y: 9 },
+    },
+    {
+      id: 'default-7',
+      cardType: 'events_timeline',
+      position: { w: 6, h: 3, x: 6, y: 10 },
+    },
+  ],
+
+  // Available card types for add menu
+  availableCardTypes: [
+    'console_ai_offline_detection',
+    'hardware_health',
+    'cluster_health',
+    'resource_usage',
+    'pod_issues',
+    'deployment_status',
+    'event_stream',
+    'cluster_metrics',
+    'events_timeline',
+  ],
+
+  // Features
+  features: {
+    dragDrop: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+    addCard: true,
+    templates: true,
+    recommendations: true,
+    floatingActions: true,
+  },
+
+  // Persistence
+  storageKey: 'kubestellar-unified-main-dashboard',
+}
+
+export default mainDashboardConfig

--- a/web/src/config/dashboards/network.ts
+++ b/web/src/config/dashboards/network.ts
@@ -1,0 +1,97 @@
+/**
+ * Network Dashboard Configuration
+ *
+ * Dashboard focused on networking resources: Services, Ingresses, NetworkPolicies.
+ */
+
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const networkDashboardConfig: UnifiedDashboardConfig = {
+  id: 'network',
+  name: 'Network',
+  subtitle: 'Networking resources',
+  route: '/network',
+
+  statsType: 'network',
+  stats: {
+    type: 'network',
+    title: 'Network Resources',
+    collapsible: true,
+    showConfigButton: true,
+    blocks: [
+      {
+        id: 'services',
+        name: 'Services',
+        icon: 'Globe',
+        color: 'blue',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalServices' },
+      },
+      {
+        id: 'ingresses',
+        name: 'Ingresses',
+        icon: 'ArrowRightLeft',
+        color: 'purple',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalIngresses' },
+      },
+      {
+        id: 'network-policies',
+        name: 'Policies',
+        icon: 'Shield',
+        color: 'orange',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalNetworkPolicies' },
+      },
+      {
+        id: 'endpoints',
+        name: 'Endpoints',
+        icon: 'CircleDot',
+        color: 'green',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalEndpoints' },
+      },
+    ],
+  },
+
+  cards: [
+    {
+      id: 'network-1',
+      cardType: 'network_overview',
+      position: { w: 4, h: 3, x: 0, y: 0 },
+    },
+    {
+      id: 'network-2',
+      cardType: 'service_status',
+      position: { w: 8, h: 3, x: 4, y: 0 },
+    },
+    {
+      id: 'network-3',
+      cardType: 'ingress_status',
+      position: { w: 6, h: 3, x: 0, y: 3 },
+    },
+    {
+      id: 'network-4',
+      cardType: 'network_policy_status',
+      position: { w: 6, h: 3, x: 6, y: 3 },
+    },
+  ],
+
+  availableCardTypes: [
+    'network_overview',
+    'service_status',
+    'ingress_status',
+    'network_policy_status',
+  ],
+
+  features: {
+    dragDrop: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+    addCard: true,
+  },
+
+  storageKey: 'kubestellar-unified-network-dashboard',
+}
+
+export default networkDashboardConfig

--- a/web/src/config/dashboards/nodes.ts
+++ b/web/src/config/dashboards/nodes.ts
@@ -1,0 +1,28 @@
+/**
+ * Nodes Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const nodesDashboardConfig: UnifiedDashboardConfig = {
+  id: 'nodes',
+  name: 'Nodes',
+  subtitle: 'Node status, capacity, and management',
+  route: '/nodes',
+  statsType: 'nodes',
+  cards: [
+    { id: 'node-status-1', cardType: 'node_status', position: { w: 12, h: 4 } },
+    { id: 'resource-usage-1', cardType: 'resource_usage', position: { w: 6, h: 3 } },
+    { id: 'resource-capacity-1', cardType: 'resource_capacity', position: { w: 6, h: 3 } },
+    { id: 'top-pods-1', cardType: 'top_pods', position: { w: 6, h: 3 } },
+    { id: 'upgrade-status-1', cardType: 'upgrade_status', position: { w: 6, h: 3 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+  },
+  storageKey: 'nodes-dashboard-cards',
+}
+
+export default nodesDashboardConfig

--- a/web/src/config/dashboards/operators.ts
+++ b/web/src/config/dashboards/operators.ts
@@ -1,0 +1,98 @@
+/**
+ * Operators Dashboard Configuration
+ *
+ * Dashboard focused on operator resources: Operators, Subscriptions, CRDs.
+ */
+
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const operatorsDashboardConfig: UnifiedDashboardConfig = {
+  id: 'operators',
+  name: 'Operators',
+  subtitle: 'Operator lifecycle management',
+  route: '/operators',
+
+  statsType: 'operators',
+  stats: {
+    type: 'operators',
+    title: 'Operator Resources',
+    collapsible: true,
+    showConfigButton: true,
+    blocks: [
+      {
+        id: 'operators',
+        name: 'Operators',
+        icon: 'Settings',
+        color: 'purple',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalOperators' },
+      },
+      {
+        id: 'subscriptions',
+        name: 'Subscriptions',
+        icon: 'RefreshCw',
+        color: 'blue',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalSubscriptions' },
+      },
+      {
+        id: 'healthy',
+        name: 'Healthy',
+        icon: 'CheckCircle2',
+        color: 'green',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.healthyCount' },
+      },
+      {
+        id: 'degraded',
+        name: 'Degraded',
+        icon: 'AlertTriangle',
+        color: 'yellow',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.degradedCount' },
+      },
+    ],
+  },
+
+  cards: [
+    {
+      id: 'operators-1',
+      cardType: 'operator_status',
+      position: { w: 6, h: 3, x: 0, y: 0 },
+    },
+    {
+      id: 'operators-2',
+      cardType: 'operator_subscription_status',
+      position: { w: 6, h: 3, x: 6, y: 0 },
+    },
+    {
+      id: 'operators-3',
+      cardType: 'helm_release_status',
+      position: { w: 6, h: 3, x: 0, y: 3 },
+    },
+    {
+      id: 'operators-4',
+      cardType: 'configmap_status',
+      position: { w: 6, h: 3, x: 6, y: 3 },
+    },
+  ],
+
+  availableCardTypes: [
+    'operator_status',
+    'operator_subscription_status',
+    'helm_release_status',
+    'configmap_status',
+    'secret_status',
+  ],
+
+  features: {
+    dragDrop: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+    addCard: true,
+  },
+
+  storageKey: 'kubestellar-unified-operators-dashboard',
+}
+
+export default operatorsDashboardConfig

--- a/web/src/config/dashboards/pods.ts
+++ b/web/src/config/dashboards/pods.ts
@@ -1,0 +1,29 @@
+/**
+ * Pods Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const podsDashboardConfig: UnifiedDashboardConfig = {
+  id: 'pods',
+  name: 'Pods',
+  subtitle: 'Pod status, logs, and troubleshooting',
+  route: '/pods',
+  statsType: 'pods',
+  cards: [
+    { id: 'pod-issues-1', cardType: 'pod_issues', position: { w: 8, h: 4 } },
+    { id: 'pod-health-trend-1', cardType: 'pod_health_trend', position: { w: 4, h: 3 } },
+    { id: 'top-pods-1', cardType: 'top_pods', position: { w: 6, h: 3 } },
+    { id: 'warning-events-1', cardType: 'warning_events', position: { w: 6, h: 3 } },
+    { id: 'resource-usage-1', cardType: 'resource_usage', position: { w: 6, h: 3 } },
+    { id: 'namespace-overview-1', cardType: 'namespace_overview', position: { w: 6, h: 3 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 15000,
+  },
+  storageKey: 'pods-dashboard-cards',
+}
+
+export default podsDashboardConfig

--- a/web/src/config/dashboards/security.ts
+++ b/web/src/config/dashboards/security.ts
@@ -1,0 +1,95 @@
+/**
+ * Security Dashboard Configuration
+ *
+ * Dashboard focused on security posture and compliance.
+ */
+
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const securityDashboardConfig: UnifiedDashboardConfig = {
+  id: 'security',
+  name: 'Security',
+  subtitle: 'Security posture overview',
+  route: '/security',
+
+  statsType: 'security',
+  stats: {
+    type: 'security',
+    title: 'Security Status',
+    collapsible: true,
+    showConfigButton: true,
+    blocks: [
+      {
+        id: 'critical',
+        name: 'Critical',
+        icon: 'AlertTriangle',
+        color: 'red',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.criticalIssues' },
+      },
+      {
+        id: 'high',
+        name: 'High',
+        icon: 'AlertCircle',
+        color: 'orange',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.highIssues' },
+      },
+      {
+        id: 'medium',
+        name: 'Medium',
+        icon: 'Info',
+        color: 'yellow',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.mediumIssues' },
+      },
+      {
+        id: 'policies',
+        name: 'Policies',
+        icon: 'Shield',
+        color: 'blue',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalPolicies' },
+      },
+      {
+        id: 'compliant',
+        name: 'Compliant',
+        icon: 'CheckCircle2',
+        color: 'green',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.compliancePercent' },
+        format: 'percentage',
+      },
+    ],
+  },
+
+  cards: [
+    {
+      id: 'security-1',
+      cardType: 'security_issues',
+      position: { w: 6, h: 3, x: 0, y: 0 },
+    },
+    {
+      id: 'security-2',
+      cardType: 'active_alerts',
+      position: { w: 6, h: 3, x: 6, y: 0 },
+    },
+  ],
+
+  availableCardTypes: [
+    'security_issues',
+    'active_alerts',
+    'pod_issues',
+  ],
+
+  features: {
+    dragDrop: true,
+    autoRefresh: true,
+    autoRefreshInterval: 60000,
+    addCard: true,
+  },
+
+  storageKey: 'kubestellar-unified-security-dashboard',
+}
+
+export default securityDashboardConfig

--- a/web/src/config/dashboards/services.ts
+++ b/web/src/config/dashboards/services.ts
@@ -1,0 +1,29 @@
+/**
+ * Services Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const servicesDashboardConfig: UnifiedDashboardConfig = {
+  id: 'services',
+  name: 'Services',
+  subtitle: 'Service status and configuration',
+  route: '/services',
+  statsType: 'services',
+  cards: [
+    { id: 'service-status-1', cardType: 'service_status', position: { w: 8, h: 4 } },
+    { id: 'ingress-status-1', cardType: 'ingress_status', position: { w: 4, h: 3 } },
+    { id: 'gateway-status-1', cardType: 'gateway_status', position: { w: 6, h: 3 } },
+    { id: 'service-exports-1', cardType: 'service_exports', position: { w: 6, h: 3 } },
+    { id: 'service-imports-1', cardType: 'service_imports', position: { w: 6, h: 3 } },
+    { id: 'service-topology-1', cardType: 'service_topology', position: { w: 6, h: 4 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+  },
+  storageKey: 'services-dashboard-cards',
+}
+
+export default servicesDashboardConfig

--- a/web/src/config/dashboards/storage.ts
+++ b/web/src/config/dashboards/storage.ts
@@ -1,0 +1,107 @@
+/**
+ * Storage Dashboard Configuration
+ *
+ * Dashboard focused on storage resources: PVCs, PVs, StorageClasses.
+ */
+
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const storageDashboardConfig: UnifiedDashboardConfig = {
+  id: 'storage',
+  name: 'Storage',
+  subtitle: 'Persistent storage resources',
+  route: '/storage',
+
+  statsType: 'storage',
+  stats: {
+    type: 'storage',
+    title: 'Storage Resources',
+    collapsible: true,
+    showConfigButton: true,
+    blocks: [
+      {
+        id: 'pvcs',
+        name: 'PVCs',
+        icon: 'Database',
+        color: 'blue',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalPVCs' },
+      },
+      {
+        id: 'pvs',
+        name: 'PVs',
+        icon: 'HardDrive',
+        color: 'purple',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalPVs' },
+      },
+      {
+        id: 'bound',
+        name: 'Bound',
+        icon: 'CheckCircle2',
+        color: 'green',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.boundCount' },
+      },
+      {
+        id: 'pending',
+        name: 'Pending',
+        icon: 'Clock',
+        color: 'yellow',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.pendingCount' },
+      },
+      {
+        id: 'storage-usage',
+        name: 'Usage',
+        icon: 'Percent',
+        color: 'orange',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.storageUsagePercent' },
+        format: 'percentage',
+      },
+    ],
+  },
+
+  cards: [
+    {
+      id: 'storage-1',
+      cardType: 'storage_overview',
+      position: { w: 4, h: 3, x: 0, y: 0 },
+    },
+    {
+      id: 'storage-2',
+      cardType: 'pvc_status',
+      position: { w: 8, h: 3, x: 4, y: 0 },
+    },
+    {
+      id: 'storage-3',
+      cardType: 'pv_status',
+      position: { w: 6, h: 3, x: 0, y: 3 },
+    },
+    {
+      id: 'storage-4',
+      cardType: 'resource_quota_status',
+      position: { w: 6, h: 3, x: 6, y: 3 },
+    },
+  ],
+
+  availableCardTypes: [
+    'storage_overview',
+    'pvc_status',
+    'pv_status',
+    'resource_quota_status',
+    'limit_range_status',
+  ],
+
+  features: {
+    dragDrop: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+    addCard: true,
+  },
+
+  storageKey: 'kubestellar-unified-storage-dashboard',
+}
+
+export default storageDashboardConfig

--- a/web/src/config/dashboards/workloads.ts
+++ b/web/src/config/dashboards/workloads.ts
@@ -1,0 +1,119 @@
+/**
+ * Workloads Dashboard Configuration
+ *
+ * Dashboard focused on workload resources: Deployments, StatefulSets, DaemonSets, Jobs.
+ */
+
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const workloadsDashboardConfig: UnifiedDashboardConfig = {
+  id: 'workloads',
+  name: 'Workloads',
+  subtitle: 'Application workloads',
+  route: '/workloads',
+
+  statsType: 'workloads',
+  stats: {
+    type: 'workloads',
+    title: 'Workload Resources',
+    collapsible: true,
+    showConfigButton: true,
+    blocks: [
+      {
+        id: 'deployments',
+        name: 'Deployments',
+        icon: 'Package',
+        color: 'blue',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalDeployments' },
+      },
+      {
+        id: 'statefulsets',
+        name: 'StatefulSets',
+        icon: 'Database',
+        color: 'purple',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalStatefulSets' },
+      },
+      {
+        id: 'daemonsets',
+        name: 'DaemonSets',
+        icon: 'Layers',
+        color: 'cyan',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalDaemonSets' },
+      },
+      {
+        id: 'jobs',
+        name: 'Jobs',
+        icon: 'Zap',
+        color: 'orange',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalJobs' },
+      },
+      {
+        id: 'cronjobs',
+        name: 'CronJobs',
+        icon: 'Clock',
+        color: 'green',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalCronJobs' },
+      },
+    ],
+  },
+
+  cards: [
+    {
+      id: 'workloads-1',
+      cardType: 'deployment_status',
+      position: { w: 6, h: 3, x: 0, y: 0 },
+    },
+    {
+      id: 'workloads-2',
+      cardType: 'deployment_issues',
+      position: { w: 6, h: 3, x: 6, y: 0 },
+    },
+    {
+      id: 'workloads-3',
+      cardType: 'statefulset_status',
+      position: { w: 6, h: 3, x: 0, y: 3 },
+    },
+    {
+      id: 'workloads-4',
+      cardType: 'daemonset_status',
+      position: { w: 6, h: 3, x: 6, y: 3 },
+    },
+    {
+      id: 'workloads-5',
+      cardType: 'job_status',
+      position: { w: 6, h: 3, x: 0, y: 6 },
+    },
+    {
+      id: 'workloads-6',
+      cardType: 'cronjob_status',
+      position: { w: 6, h: 3, x: 6, y: 6 },
+    },
+  ],
+
+  availableCardTypes: [
+    'deployment_status',
+    'deployment_issues',
+    'statefulset_status',
+    'daemonset_status',
+    'job_status',
+    'cronjob_status',
+    'replicaset_status',
+    'hpa_status',
+  ],
+
+  features: {
+    dragDrop: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+    addCard: true,
+  },
+
+  storageKey: 'kubestellar-unified-workloads-dashboard',
+}
+
+export default workloadsDashboardConfig

--- a/web/src/lib/unified/card/UnifiedCard.tsx
+++ b/web/src/lib/unified/card/UnifiedCard.tsx
@@ -1,0 +1,384 @@
+/**
+ * UnifiedCard - Single component that renders any card type from configuration
+ *
+ * This component accepts a UnifiedCardConfig and renders the appropriate
+ * visualization based on the content.type field. All variations come from
+ * configuration, not code branches.
+ *
+ * Usage:
+ *   <UnifiedCard config={podIssuesConfig} />
+ *   <UnifiedCard config={clusterHealthConfig} title="Custom Title" />
+ */
+
+import { useMemo, useCallback, ReactNode } from 'react'
+import { AlertTriangle, Info } from 'lucide-react'
+import type {
+  UnifiedCardConfig,
+  UnifiedCardProps,
+  CardContent,
+} from '../types'
+import { useDataSource } from './hooks/useDataSource'
+import { useCardFiltering } from './hooks/useCardFiltering'
+import { ListVisualization } from './visualizations/ListVisualization'
+import { TableVisualization } from './visualizations/TableVisualization'
+import { ChartVisualization } from './visualizations/ChartVisualization'
+import { StatusGridVisualization } from './visualizations/StatusGridVisualization'
+import { useDrillDownActions } from '../../../hooks/useDrillDown'
+import { useReportCardDataState } from '../../../components/cards/CardDataContext'
+
+/**
+ * UnifiedCard - Renders any card type from config
+ */
+export function UnifiedCard({
+  config,
+  instanceConfig,
+  title: _titleOverride,
+  className,
+  overrideData,
+}: UnifiedCardProps) {
+  // Merge instance config with base config
+  const mergedConfig = useMemo(() => {
+    if (!instanceConfig) return config
+    return {
+      ...config,
+      // Instance config can override certain fields
+      ...instanceConfig,
+    } as UnifiedCardConfig
+  }, [config, instanceConfig])
+
+  // Fetch data using the configured data source (skipped if overrideData provided)
+  const { data: fetchedData, isLoading, error, refetch } = useDataSource(
+    mergedConfig.dataSource,
+    { skip: !!overrideData }
+  )
+
+  // Use override data if provided, otherwise use fetched data
+  const data = overrideData ?? fetchedData
+
+  // Determine if we have any data
+  const hasAnyData = Array.isArray(data) ? data.length > 0 : !!data
+
+  // Report loading state to CardWrapper for refresh icon animation and skeleton coordination
+  // This enables the refresh icon to spin while data is loading
+  useReportCardDataState({
+    isFailed: !!error,
+    consecutiveFailures: error ? 1 : 0,
+    errorMessage: error?.message,
+    isLoading: isLoading && !hasAnyData,      // Initial load - show skeleton
+    isRefreshing: isLoading && hasAnyData,     // Refresh - spin refresh icon
+    hasData: !isLoading || hasAnyData,         // True once loading completes or has cached data
+    isDemoData: mergedConfig.isDemoData,       // From card config
+  })
+
+  // Apply filtering if configured
+  const { filteredData, filterControls } = useCardFiltering(
+    data,
+    mergedConfig.filters
+  )
+
+  // Get drill-down actions
+  const drillDownActions = useDrillDownActions()
+
+  // Create drill-down handler based on config
+  const handleDrillDown = useCallback(
+    (item: Record<string, unknown>) => {
+      const drillDown = mergedConfig.drillDown
+      if (!drillDown) return
+
+      // Get the action function from useDrillDownActions
+      const actionFn = drillDownActions[drillDown.action as keyof typeof drillDownActions]
+      if (typeof actionFn !== 'function') {
+        console.warn(`Drill-down action "${drillDown.action}" not found`)
+        return
+      }
+
+      // Extract params from item using the configured param names
+      const params = drillDown.params.map((param) => item[param])
+
+      // Add context data if configured
+      const contextData: Record<string, unknown> = {}
+      if (drillDown.context) {
+        for (const [key, fieldPath] of Object.entries(drillDown.context)) {
+          contextData[key] = item[fieldPath]
+        }
+      }
+
+      // Call the action with params + context
+      // Action signatures vary, so we spread params and pass context as last arg
+      ;(actionFn as (...args: unknown[]) => void)(...params, contextData)
+    },
+    [mergedConfig.drillDown, drillDownActions]
+  )
+
+  // Determine what to render
+  const content = useMemo(() => {
+    // Error state
+    if (error) {
+      return (
+        <ErrorState
+          message={error.message}
+          onRetry={refetch}
+        />
+      )
+    }
+
+    // Loading state
+    if (isLoading) {
+      return <LoadingState config={mergedConfig.loadingState} />
+    }
+
+    // Empty state
+    if (!filteredData || filteredData.length === 0) {
+      return <EmptyState config={mergedConfig.emptyState} />
+    }
+
+    // Render the appropriate visualization based on content type
+    return renderContent(mergedConfig.content, filteredData, mergedConfig, handleDrillDown)
+  }, [error, isLoading, filteredData, mergedConfig, refetch, handleDrillDown])
+
+  return (
+    <div className={className}>
+      {/* Filter controls (if any) */}
+      {filterControls}
+
+      {/* Inline stats (if configured) */}
+      {mergedConfig.stats && mergedConfig.stats.length > 0 && (
+        <InlineStats stats={mergedConfig.stats} data={filteredData} />
+      )}
+
+      {/* Main content */}
+      {content}
+
+      {/* Footer (if configured) */}
+      {mergedConfig.footer && (
+        <CardFooter config={mergedConfig.footer} data={filteredData} />
+      )}
+    </div>
+  )
+}
+
+/**
+ * Render the appropriate visualization based on content.type
+ */
+function renderContent(
+  content: CardContent,
+  data: unknown[],
+  config: UnifiedCardConfig,
+  onDrillDown?: (item: Record<string, unknown>) => void
+): ReactNode {
+  switch (content.type) {
+    case 'list':
+      return (
+        <ListVisualization
+          content={content}
+          data={data}
+          drillDown={config.drillDown}
+          onDrillDown={onDrillDown}
+        />
+      )
+
+    case 'table':
+      return (
+        <TableVisualization
+          content={content}
+          data={data}
+          drillDown={config.drillDown}
+          onDrillDown={onDrillDown}
+        />
+      )
+
+    case 'chart':
+      return (
+        <ChartVisualization
+          content={content}
+          data={data}
+        />
+      )
+
+    case 'status-grid':
+      return (
+        <StatusGridVisualization
+          content={content}
+          data={data}
+        />
+      )
+
+    case 'custom':
+      // TODO: Load from component registry
+      return (
+        <PlaceholderVisualization
+          type={`custom: ${content.componentName}`}
+          itemCount={data.length}
+        />
+      )
+
+    default:
+      return (
+        <div className="text-gray-400 text-sm p-4">
+          Unknown content type: {(content as { type: string }).type}
+        </div>
+      )
+  }
+}
+
+/**
+ * Placeholder visualization while actual implementations are built
+ */
+function PlaceholderVisualization({
+  type,
+  itemCount,
+  columns,
+}: {
+  type: string
+  itemCount: number
+  columns?: number
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center p-6 text-gray-500 border border-dashed border-gray-700 rounded-lg m-2">
+      <Info className="w-8 h-8 mb-2 text-blue-400" />
+      <div className="text-sm font-medium">Visualization: {type}</div>
+      <div className="text-xs mt-1">
+        {itemCount} items{columns ? `, ${columns} columns` : ''}
+      </div>
+      <div className="text-xs mt-2 text-gray-600">
+        (Implementation pending - PR 2/4)
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Loading state component
+ */
+function LoadingState({
+  config,
+}: {
+  config?: UnifiedCardConfig['loadingState']
+}) {
+  const rows = config?.rows ?? 3
+  const showSearch = config?.showSearch ?? true
+
+  return (
+    <div className="p-2 space-y-2 animate-pulse">
+      {showSearch && (
+        <div className="h-8 bg-gray-800 rounded w-full" />
+      )}
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="flex items-center gap-2">
+          <div className="h-4 bg-gray-800 rounded w-16" />
+          <div className="h-4 bg-gray-800 rounded flex-1" />
+          <div className="h-4 bg-gray-800 rounded w-20" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/**
+ * Empty state component
+ */
+function EmptyState({
+  config,
+}: {
+  config?: UnifiedCardConfig['emptyState']
+}) {
+  // TODO: Use dynamic icon lookup based on config?.icon (using Info for now)
+  const title = config?.title ?? 'No data'
+  const message = config?.message
+  const variant = config?.variant ?? 'neutral'
+
+  const variantColors = {
+    success: 'text-green-400',
+    info: 'text-blue-400',
+    warning: 'text-yellow-400',
+    neutral: 'text-gray-400',
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center p-6 text-center">
+      <div className={`mb-2 ${variantColors[variant]}`}>
+        <Info className="w-8 h-8" />
+      </div>
+      <div className="text-sm font-medium text-gray-300">{title}</div>
+      {message && (
+        <div className="text-xs text-gray-500 mt-1">{message}</div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Error state component
+ */
+function ErrorState({
+  message,
+  onRetry,
+}: {
+  message: string
+  onRetry?: () => void
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center p-6 text-center">
+      <AlertTriangle className="w-8 h-8 text-red-400 mb-2" />
+      <div className="text-sm font-medium text-gray-300">Error loading data</div>
+      <div className="text-xs text-gray-500 mt-1">{message}</div>
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="mt-3 px-3 py-1 text-xs bg-gray-800 hover:bg-gray-700 rounded transition-colors"
+        >
+          Retry
+        </button>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Inline stats displayed at top of card
+ */
+function InlineStats({
+  stats,
+  data: _data,
+}: {
+  stats: NonNullable<UnifiedCardConfig['stats']>
+  data: unknown[] | undefined
+}) {
+  // TODO: Implement value resolution from stats config
+  return (
+    <div className="flex items-center gap-3 px-2 py-1.5 border-b border-gray-800">
+      {stats.map((stat) => (
+        <div key={stat.id} className="flex items-center gap-1.5 text-xs">
+          <div className={`w-2 h-2 rounded-full ${stat.bgColor ?? 'bg-gray-600'}`} />
+          <span className="text-gray-400">{stat.label}:</span>
+          <span className="font-medium text-gray-200">--</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/**
+ * Card footer component
+ */
+function CardFooter({
+  config,
+  data,
+}: {
+  config: NonNullable<UnifiedCardConfig['footer']>
+  data: unknown[] | undefined
+}) {
+  return (
+    <div className="flex items-center justify-between px-2 py-1.5 text-xs text-gray-500 border-t border-gray-800">
+      {config.showTotal && data && (
+        <span>{data.length} items</span>
+      )}
+      {config.text && <span>{config.text}</span>}
+      {config.pagination && (
+        <span className="text-gray-600">Pagination placeholder</span>
+      )}
+    </div>
+  )
+}
+
+export default UnifiedCard

--- a/web/src/lib/unified/card/UnifiedCardAdapter.tsx
+++ b/web/src/lib/unified/card/UnifiedCardAdapter.tsx
@@ -1,0 +1,421 @@
+/**
+ * UnifiedCardAdapter
+ *
+ * A bridge component that enables gradual migration from legacy card components
+ * to the UnifiedCard framework. Cards can opt-in to using UnifiedCard rendering
+ * by being added to the UNIFIED_READY_CARDS set.
+ *
+ * Usage:
+ *   <UnifiedCardAdapter cardType="pod_issues" cardId="abc" />
+ *
+ * Migration path:
+ *   1. Add card type to UNIFIED_READY_CARDS set
+ *   2. Verify rendering matches legacy component
+ *   3. Eventually deprecate legacy component
+ */
+
+import { useMemo } from 'react'
+import { UnifiedCard } from './UnifiedCard'
+import { getCardConfig } from '../../../config/cards'
+import type { CardComponentProps } from '../../../components/cards/cardRegistry'
+
+/**
+ * Cards that have been validated to work correctly with UnifiedCard.
+ *
+ * Before adding a card here:
+ * 1. Verify the card config in config/cards/*.ts is complete
+ * 2. Test that UnifiedCard renders data correctly
+ * 3. Verify filtering, pagination, and drill-down work
+ * 4. Compare rendering with legacy component
+ */
+export const UNIFIED_READY_CARDS = new Set<string>([
+  // =====================================================================
+  // Phase 6 Batch 1 - Simple list cards with registered hooks
+  // =====================================================================
+
+  // Core workload cards
+  'pod_issues',           // useCachedPodIssues
+  'deployment_issues',    // useCachedDeploymentIssues
+
+  // Event cards
+  'event_stream',         // useCachedEvents
+  'warning_events',       // useWarningEvents
+  'recent_events',        // useRecentEvents
+
+  // Resource status cards
+  'service_status',       // useServices
+  'pvc_status',           // usePVCs
+  'operator_status',      // useOperators
+  'helm_release_status',  // useHelmReleases
+  'configmap_status',     // useConfigMaps
+  'secret_status',        // useSecrets
+  'ingress_status',       // useIngresses
+  'node_status',          // useNodes
+  'job_status',           // useJobs
+  'cronjob_status',       // useCronJobs
+  'statefulset_status',   // useStatefulSets
+  'daemonset_status',     // useDaemonSets
+  'hpa_status',           // useHPAs
+  'replicaset_status',    // useReplicaSets
+  'pv_status',            // usePVs
+  'namespace_status',     // useNamespaces
+
+  // =====================================================================
+  // Phase 6 Batch 2 - Additional list/table cards
+  // =====================================================================
+
+  // RBAC cards
+  'role_status',          // useK8sRoles
+  'role_binding_status',  // useK8sRoleBindings
+
+  // Quota cards
+  'resource_quota_status', // useResourceQuotas
+  'limit_range_status',   // useLimitRanges
+
+  // Network cards
+  'network_policy_status', // useNetworkPolicies
+  'service_exports',      // useServiceExports
+  'service_imports',      // useServiceImports
+
+  // Operator cards
+  'operator_subscription_status', // useOperatorSubscriptions
+
+  // Service account
+  'service_account_status', // useServiceAccounts
+
+  // =====================================================================
+  // Phase 6 Batch 3 - Chart and overview cards
+  // =====================================================================
+
+  // Chart cards (demo data)
+  'cluster_metrics',        // useCachedClusterMetrics
+  'events_timeline',        // useCachedEventsTimeline
+  'pod_health_trend',       // usePodHealthTrend
+  'resource_trend',         // useResourceTrend
+
+  // Table/list cards with demo data
+  'resource_usage',         // useCachedResourceUsage
+  'top_pods',               // useTopPods
+  'security_issues',        // useSecurityIssues
+  'active_alerts',          // useActiveAlerts
+  'gitops_drift',           // useGitOpsDrift
+
+  // Status grid/overview cards (demo data)
+  'storage_overview',       // useStorageOverview
+  'network_overview',       // useNetworkOverview
+  'compute_overview',       // useComputeOverview
+
+  // =====================================================================
+  // Phase 6 Batch 4 - ArgoCD, Prow, GPU, ML, Policy cards
+  // =====================================================================
+
+  // Deployment cards
+  'deployment_status',      // useCachedDeployments (already registered)
+  'deployment_progress',    // useDeploymentProgress
+
+  // ArgoCD cards
+  'argocd_applications',    // useArgoCDApplications
+
+  // Prow/CI cards
+  'prow_jobs',              // useProwJobs
+
+  // GPU cards
+  'gpu_inventory',          // useGPUInventory
+  'gpu_overview',           // useGPUOverview
+  'gpu_workloads',          // useGPUWorkloads
+
+  // ML cards
+  'ml_jobs',                // useMLJobs
+  'ml_notebooks',           // useMLNotebooks
+
+  // Policy cards
+  'opa_policies',           // useOPAPolicies
+  'kyverno_policies',       // useKyvernoPolicies
+
+  // Alert cards
+  'alert_rules',            // useAlertRules
+
+  // Chart/upgrade cards
+  'chart_versions',         // useChartVersions
+
+  // CRD cards
+  'crd_health',             // useCRDHealth
+
+  // Compliance cards
+  'compliance_score',       // useComplianceScore
+
+  // Namespace cards
+  'namespace_events',       // useNamespaceEvents
+
+  // =====================================================================
+  // Phase 6 Batch 5 - GitOps, Security, Status cards
+  // =====================================================================
+
+  // ArgoCD cards
+  'argocd_health',          // useArgoCDHealth (stats-grid)
+  'argocd_sync_status',     // useArgoCDSyncStatus (stats-grid)
+
+  // GitOps cards
+  'gateway_status',         // useGatewayStatus
+  'kustomization_status',   // useKustomizationStatus
+
+  // Cluster status cards
+  'provider_health',        // useProviderHealth
+  'upgrade_status',         // useUpgradeStatus
+
+  // Prow/CI cards
+  'prow_status',            // useProwStatus (stats-grid)
+  'prow_history',           // useProwHistory
+
+  // Helm cards
+  'helm_history',           // useHelmHistory
+
+  // Security cards
+  'external_secrets',       // useExternalSecrets (stats-grid)
+  'cert_manager',           // useCertManager (stats-grid)
+  'vault_secrets',          // useVaultSecrets
+  'falco_alerts',           // useFalcoAlerts
+  'kubescape_scan',         // useKubescapeScan (stats-grid)
+  'trivy_scan',             // useTrivyScan (stats-grid)
+  'policy_violations',      // usePolicyViolations
+
+  // Event cards
+  'event_summary',          // useEventSummary (stats-grid)
+
+  // App cards
+  'app_status',             // useAppStatus
+
+  // GPU cards
+  'gpu_status',             // useGPUStatus (stats-grid)
+  'gpu_utilization',        // useGPUUtilization (chart)
+  'gpu_usage_trend',        // useGPUUsageTrend (chart)
+
+  // Namespace cards
+  'namespace_overview',     // useNamespaceOverview (stats-grid)
+  'namespace_quotas',       // useNamespaceQuotas
+  'namespace_rbac',         // useNamespaceRBAC
+
+  // Resource cards
+  'resource_capacity',      // useResourceCapacity (stats-grid)
+
+  // =====================================================================
+  // Phase 6 Batch 6 - Final compatible cards
+  // =====================================================================
+
+  // Cluster cards
+  'cluster_health',         // useClusters (already registered)
+  'cluster_costs',          // useClusterCosts
+
+  // CI/CD cards
+  'github_activity',        // useGithubActivity
+
+  // Utility cards
+  'rss_feed',               // useRSSFeed
+
+  // Cost cards
+  'kubecost_overview',      // useKubecostOverview (chart/donut)
+  'opencost_overview',      // useOpencostOverview (chart/donut)
+])
+
+/**
+ * Cards that should NEVER use UnifiedCard (games, embeds, custom viz)
+ */
+export const UNIFIED_EXCLUDED_CARDS = new Set<string>([
+  // Arcade games - require custom rendering
+  'kube_man', 'kube_kong', 'node_invaders', 'pod_pitfall', 'container_tetris',
+  'flappy_pod', 'pod_sweeper', 'game_2048', 'checkers', 'kube_chess',
+  'solitaire', 'match_game', 'kubedle', 'sudoku_game', 'pod_brothers',
+  'kube_kart', 'kube_pong', 'kube_snake', 'kube_galaga', 'kube_craft',
+  'kube_craft_3d', 'kube_doom', 'pod_crosser',
+
+  // Embedded content
+  'iframe_embed', 'mobile_browser', 'kubectl',
+
+  // Weather has animated backgrounds
+  'weather',
+
+  // Complex tree/topology visualizations
+  'cluster_resource_tree', 'service_topology', 'cluster_locations',
+  'cluster_comparison', 'cluster_network',
+
+  // AI-ML flow visualizations
+  'llmd_flow', 'epp_routing', 'kv_cache_monitor', 'pd_disaggregation',
+
+  // LLM/ML stack cards - require StackContext
+  'llm_inference', 'llm_models', 'llmd_stack_monitor',
+
+  // Monitor cards - complex custom visualizations
+  'cluster_health_monitor', 'namespace_monitor', 'workload_monitor',
+  'prow_ci_monitor', 'github_ci_monitor',
+
+  // Complex interactive cards
+  'cluster_focus', 'cluster_groups', 'resource_marshall',
+  'user_management', 'workload_deployment',
+
+  // Diff/comparison cards
+  'helm_values_diff', 'overlay_comparison',
+
+  // Console AI cards - special agent integration
+  'console_ai_health_check', 'console_ai_issues',
+  'console_ai_kubeconfig_audit', 'console_ai_offline_detection',
+
+  // Special cards
+  'deployment_missions', 'dynamic_card', 'hardware_health',
+  'stock_market_ticker',
+])
+
+interface UnifiedCardAdapterProps extends CardComponentProps {
+  /** The card type to render */
+  cardType: string
+  /** Unique card instance ID */
+  cardId: string
+  /** Instance-specific config overrides */
+  instanceConfig?: Record<string, unknown>
+  /** Force legacy rendering even if card is unified-ready */
+  forceLegacy?: boolean
+  /** Callback when legacy component should be rendered */
+  renderLegacy?: () => React.ReactNode
+}
+
+/**
+ * Check if a card should use UnifiedCard rendering
+ */
+export function shouldUseUnifiedCard(cardType: string): boolean {
+  // Explicitly excluded cards never use unified
+  if (UNIFIED_EXCLUDED_CARDS.has(cardType)) {
+    return false
+  }
+
+  // Only cards in the ready set use unified
+  return UNIFIED_READY_CARDS.has(cardType)
+}
+
+/**
+ * Check if a card has a valid config for UnifiedCard
+ */
+export function hasValidUnifiedConfig(cardType: string): boolean {
+  const config = getCardConfig(cardType)
+  if (!config) return false
+
+  // Check required fields
+  if (!config.type || !config.dataSource || !config.content) {
+    return false
+  }
+
+  // Check data source is configured
+  if (config.dataSource.type === 'hook' && !config.dataSource.hook) {
+    return false
+  }
+
+  // Check content type is supported
+  const supportedTypes = ['list', 'table', 'chart', 'status-grid']
+  if (!supportedTypes.includes(config.content.type)) {
+    return false
+  }
+
+  return true
+}
+
+/**
+ * UnifiedCardAdapter - Renders cards via UnifiedCard or legacy component
+ */
+export function UnifiedCardAdapter({
+  cardType,
+  cardId: _cardId,
+  instanceConfig,
+  forceLegacy = false,
+  renderLegacy,
+}: UnifiedCardAdapterProps) {
+  // Get config for this card type
+  const config = useMemo(() => getCardConfig(cardType), [cardType])
+
+  // Determine if we should use UnifiedCard
+  const useUnified = useMemo(() => {
+    if (forceLegacy) return false
+    if (!shouldUseUnifiedCard(cardType)) return false
+    if (!hasValidUnifiedConfig(cardType)) return false
+    return true
+  }, [cardType, forceLegacy])
+
+  // Render via UnifiedCard
+  if (useUnified && config) {
+    return (
+      <UnifiedCard
+        config={config}
+        instanceConfig={instanceConfig}
+        className="h-full"
+      />
+    )
+  }
+
+  // Fall back to legacy rendering
+  if (renderLegacy) {
+    return <>{renderLegacy()}</>
+  }
+
+  // If no legacy renderer provided, show placeholder
+  return (
+    <div className="flex items-center justify-center h-full text-gray-500 text-sm">
+      Card not available
+    </div>
+  )
+}
+
+/**
+ * Get migration status for a card type
+ */
+export function getCardMigrationStatus(cardType: string): {
+  status: 'unified' | 'ready' | 'pending' | 'excluded'
+  reason?: string
+} {
+  if (UNIFIED_EXCLUDED_CARDS.has(cardType)) {
+    return {
+      status: 'excluded',
+      reason: 'Card type not suitable for unified framework',
+    }
+  }
+
+  if (UNIFIED_READY_CARDS.has(cardType)) {
+    return {
+      status: 'unified',
+      reason: 'Card is rendering via UnifiedCard',
+    }
+  }
+
+  if (hasValidUnifiedConfig(cardType)) {
+    return {
+      status: 'ready',
+      reason: 'Config complete, ready for validation',
+    }
+  }
+
+  return {
+    status: 'pending',
+    reason: 'Config incomplete or missing',
+  }
+}
+
+/**
+ * Get all cards by migration status
+ */
+export function getCardsByMigrationStatus(): {
+  unified: string[]
+  ready: string[]
+  pending: string[]
+  excluded: string[]
+} {
+  const result = {
+    unified: Array.from(UNIFIED_READY_CARDS),
+    ready: [] as string[],
+    pending: [] as string[],
+    excluded: Array.from(UNIFIED_EXCLUDED_CARDS),
+  }
+
+  // Import all card types from config registry
+  // This would need to be done dynamically in practice
+  // For now, we check known card types
+
+  return result
+}
+
+export default UnifiedCardAdapter

--- a/web/src/lib/unified/card/hooks/index.ts
+++ b/web/src/lib/unified/card/hooks/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Unified Card Hooks
+ */
+
+export { useDataSource, registerDataHook, getDataHook, getRegisteredDataHooks } from './useDataSource'
+export type { UseDataSourceResult } from './useDataSource'
+
+export { useCardFiltering } from './useCardFiltering'
+export type { UseCardFilteringResult } from './useCardFiltering'

--- a/web/src/lib/unified/card/hooks/useCardFiltering.ts
+++ b/web/src/lib/unified/card/hooks/useCardFiltering.ts
@@ -1,0 +1,209 @@
+/**
+ * useCardFiltering - Unified filtering hook for cards
+ *
+ * Applies filters based on card configuration and provides
+ * filter control components for the UI.
+ */
+
+import { useState, useMemo, useCallback, ReactNode, createElement } from 'react'
+import type { CardFilterConfig } from '../../types'
+
+export interface UseCardFilteringResult {
+  /** Filtered data */
+  filteredData: unknown[] | undefined
+  /** Filter control components to render */
+  filterControls: ReactNode
+  /** Current filter state */
+  filterState: Record<string, unknown>
+  /** Update a filter value */
+  setFilter: (field: string, value: unknown) => void
+  /** Clear all filters */
+  clearFilters: () => void
+}
+
+/**
+ * useCardFiltering - Apply configured filters to data
+ */
+export function useCardFiltering(
+  data: unknown[] | undefined,
+  filters?: CardFilterConfig[]
+): UseCardFilteringResult {
+  // Filter state - keyed by field name
+  const [filterState, setFilterState] = useState<Record<string, unknown>>({})
+
+  // Update a single filter
+  const setFilter = useCallback((field: string, value: unknown) => {
+    setFilterState((prev) => ({
+      ...prev,
+      [field]: value,
+    }))
+  }, [])
+
+  // Clear all filters
+  const clearFilters = useCallback(() => {
+    setFilterState({})
+  }, [])
+
+  // Apply filters to data
+  const filteredData = useMemo(() => {
+    if (!data) return undefined
+    if (!filters || filters.length === 0) return data
+
+    let result = [...data]
+
+    for (const filter of filters) {
+      const filterValue = filterState[filter.field]
+
+      // Skip if no value set
+      if (filterValue === undefined || filterValue === null || filterValue === '') {
+        continue
+      }
+
+      switch (filter.type) {
+        case 'text': {
+          const query = String(filterValue).toLowerCase()
+          const searchFields = filter.searchFields ?? [filter.field]
+          result = result.filter((item) => {
+            const record = item as Record<string, unknown>
+            return searchFields.some((field) => {
+              const value = record[field]
+              return value && String(value).toLowerCase().includes(query)
+            })
+          })
+          break
+        }
+
+        case 'select':
+        case 'cluster-select': {
+          const selected = filterValue as string
+          result = result.filter((item) => {
+            const record = item as Record<string, unknown>
+            return record[filter.field] === selected
+          })
+          break
+        }
+
+        case 'multi-select':
+        case 'chips': {
+          const selected = filterValue as string[]
+          if (selected.length > 0) {
+            result = result.filter((item) => {
+              const record = item as Record<string, unknown>
+              return selected.includes(String(record[filter.field]))
+            })
+          }
+          break
+        }
+
+        case 'toggle': {
+          const enabled = filterValue as boolean
+          if (enabled) {
+            result = result.filter((item) => {
+              const record = item as Record<string, unknown>
+              return Boolean(record[filter.field])
+            })
+          }
+          break
+        }
+      }
+    }
+
+    return result
+  }, [data, filters, filterState])
+
+  // Generate filter control components
+  const filterControls = useMemo(() => {
+    if (!filters || filters.length === 0) return null
+
+    return createElement(
+      'div',
+      { className: 'flex items-center gap-2 p-2 border-b border-gray-800' },
+      filters.map((filter) =>
+        createElement(FilterControl, {
+          key: filter.field,
+          config: filter,
+          value: filterState[filter.field],
+          onChange: (value: unknown) => setFilter(filter.field, value),
+        })
+      )
+    )
+  }, [filters, filterState, setFilter])
+
+  return {
+    filteredData,
+    filterControls,
+    filterState,
+    setFilter,
+    clearFilters,
+  }
+}
+
+/**
+ * Individual filter control component
+ */
+function FilterControl({
+  config,
+  value,
+  onChange,
+}: {
+  config: CardFilterConfig
+  value: unknown
+  onChange: (value: unknown) => void
+}) {
+  switch (config.type) {
+    case 'text':
+      return createElement('input', {
+        type: 'text',
+        placeholder: config.placeholder ?? `Search ${config.label ?? config.field}...`,
+        value: (value as string) ?? '',
+        onChange: (e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.value),
+        className:
+          'flex-1 px-3 py-1.5 text-sm bg-gray-800 border border-gray-700 rounded focus:outline-none focus:border-blue-500 text-gray-200 placeholder-gray-500',
+      })
+
+    case 'select':
+    case 'cluster-select':
+      return createElement(
+        'select',
+        {
+          value: (value as string) ?? '',
+          onChange: (e: React.ChangeEvent<HTMLSelectElement>) =>
+            onChange(e.target.value || undefined),
+          className:
+            'px-3 py-1.5 text-sm bg-gray-800 border border-gray-700 rounded focus:outline-none focus:border-blue-500 text-gray-200',
+        },
+        createElement('option', { value: '' }, config.placeholder ?? 'All'),
+        config.options?.map((opt) =>
+          createElement('option', { key: opt.value, value: opt.value }, opt.label)
+        )
+      )
+
+    case 'toggle':
+      return createElement(
+        'label',
+        { className: 'flex items-center gap-2 text-sm text-gray-400 cursor-pointer' },
+        createElement('input', {
+          type: 'checkbox',
+          checked: (value as boolean) ?? false,
+          onChange: (e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.checked),
+          className: 'rounded border-gray-700 bg-gray-800',
+        }),
+        config.label ?? config.field
+      )
+
+    case 'chips':
+    case 'multi-select':
+      // Simplified chip display - full implementation in PR 2
+      return createElement(
+        'div',
+        { className: 'flex items-center gap-1 text-xs' },
+        createElement('span', { className: 'text-gray-400' }, config.label ?? config.field),
+        createElement('span', { className: 'text-gray-500' }, '(multi-select)')
+      )
+
+    default:
+      return null
+  }
+}
+
+export default useCardFiltering

--- a/web/src/lib/unified/card/hooks/useDataSource.ts
+++ b/web/src/lib/unified/card/hooks/useDataSource.ts
@@ -1,0 +1,304 @@
+/**
+ * useDataSource - Unified data fetching hook for cards
+ *
+ * Supports multiple data source types:
+ * - hook: Use a registered data hook (e.g., useClusters, usePods)
+ * - api: Direct API fetch with optional polling
+ * - static: Static data array
+ * - context: Read from React context
+ */
+
+import { useState, useEffect, useMemo, useCallback } from 'react'
+import type { CardDataSource } from '../../types'
+
+// Hook registry - populated by registerDataHook
+const dataHookRegistry: Record<
+  string,
+  (params?: Record<string, unknown>) => {
+    data: unknown[] | undefined
+    isLoading: boolean
+    error: Error | null
+    refetch?: () => void
+  }
+> = {}
+
+/**
+ * Register a data hook for use in card configs
+ *
+ * @example
+ * registerDataHook('useCachedPodIssues', useCachedPodIssues)
+ */
+export function registerDataHook(
+  name: string,
+  hook: (params?: Record<string, unknown>) => {
+    data: unknown[] | undefined
+    isLoading: boolean
+    error: Error | null
+    refetch?: () => void
+  }
+) {
+  dataHookRegistry[name] = hook
+}
+
+/**
+ * Get a registered data hook
+ */
+export function getDataHook(name: string) {
+  return dataHookRegistry[name]
+}
+
+/**
+ * List all registered data hooks
+ */
+export function getRegisteredDataHooks(): string[] {
+  return Object.keys(dataHookRegistry)
+}
+
+export interface UseDataSourceResult {
+  data: unknown[] | undefined
+  isLoading: boolean
+  error: Error | null
+  refetch: () => void
+}
+
+export interface UseDataSourceOptions {
+  /** Skip fetching data (useful when overrideData is provided) */
+  skip?: boolean
+}
+
+const EMPTY_RESULT: UseDataSourceResult = {
+  data: undefined,
+  isLoading: false,
+  error: null,
+  refetch: () => {},
+}
+
+/**
+ * Unified data source hook
+ *
+ * IMPORTANT: This hook must be used with a stable config reference.
+ * Changing config.type between renders will cause issues due to React's
+ * rules of hooks. Each data source type has its own component wrapper
+ * that should be used instead if dynamic switching is needed.
+ */
+export function useDataSource(
+  config: CardDataSource,
+  options?: UseDataSourceOptions
+): UseDataSourceResult {
+  const skip = options?.skip ?? false
+
+  // Call ALL hooks unconditionally - they check internally if they should be active
+  // This satisfies React's rules of hooks
+  // When skip is true, pass null to all hooks to make them return empty results
+  const hookResult = useHookDataSourceInternal(
+    !skip && config.type === 'hook' ? config.hook : null,
+    !skip && config.type === 'hook' ? config.params : undefined
+  )
+
+  const apiResult = useApiDataSourceInternal(
+    !skip && config.type === 'api' ? config.endpoint : null,
+    !skip && config.type === 'api' ? config.method : 'GET',
+    !skip && config.type === 'api' ? config.params : undefined,
+    !skip && config.type === 'api' ? config.pollInterval : undefined
+  )
+
+  const staticResult = useStaticDataSourceInternal(
+    !skip && config.type === 'static' ? (config.data ?? null) : null
+  )
+
+  const contextResult = useContextDataSourceInternal(
+    !skip && config.type === 'context' ? config.contextKey : null
+  )
+
+  // If skip is true, return empty result
+  if (skip) {
+    return EMPTY_RESULT
+  }
+
+  // Return the appropriate result based on config type
+  switch (config.type) {
+    case 'hook':
+      return hookResult
+    case 'api':
+      return apiResult
+    case 'static':
+      return staticResult
+    case 'context':
+      return contextResult
+    default: {
+      // Exhaustive check
+      const _exhaustiveCheck: never = config
+      return {
+        data: undefined,
+        isLoading: false,
+        error: new Error(`Unknown data source type: ${(_exhaustiveCheck as CardDataSource).type}`),
+        refetch: () => {},
+      }
+    }
+  }
+}
+
+/**
+ * Hook-based data source (internal - always runs but skips if hookName is null)
+ */
+function useHookDataSourceInternal(
+  hookName: string | null,
+  params?: Record<string, unknown>
+): UseDataSourceResult {
+  // Memoize error result
+  const errorResult = useMemo<UseDataSourceResult>(
+    () => {
+      if (!hookName) return EMPTY_RESULT
+      return {
+        data: undefined,
+        isLoading: false,
+        error: new Error(
+          `Data hook not registered: ${hookName}. Register it with registerDataHook().`
+        ),
+        refetch: () => {},
+      }
+    },
+    [hookName]
+  )
+
+  // Get the hook from registry
+  const registeredHook = hookName ? dataHookRegistry[hookName] : null
+
+  // Call the hook if it exists, otherwise use a stable empty result
+  // Note: We can't conditionally call hooks, but we CAN conditionally
+  // pass null to a function that returns stable results
+  const hookResult = registeredHook ? registeredHook(params) : null
+
+  // Return appropriate result
+  if (!hookName) {
+    return EMPTY_RESULT
+  }
+
+  if (!hookResult) {
+    return errorResult
+  }
+
+  return {
+    data: hookResult.data,
+    isLoading: hookResult.isLoading,
+    error: hookResult.error,
+    refetch: hookResult.refetch ?? (() => {}),
+  }
+}
+
+/**
+ * API-based data source (internal - always runs but skips if endpoint is null)
+ */
+function useApiDataSourceInternal(
+  endpoint: string | null,
+  method: 'GET' | 'POST' = 'GET',
+  params?: Record<string, unknown>,
+  pollInterval?: number
+): UseDataSourceResult {
+  const [data, setData] = useState<unknown[] | undefined>(undefined)
+  const [isLoading, setIsLoading] = useState(!!endpoint)
+  const [error, setError] = useState<Error | null>(null)
+
+  // Stringify params for stable dependency comparison
+  const paramsKey = useMemo(() => (params ? JSON.stringify(params) : ''), [params])
+
+  const fetchData = useCallback(async () => {
+    if (!endpoint) return
+
+    try {
+      setIsLoading(true)
+      setError(null)
+
+      let url = endpoint
+      if (method === 'GET' && params) {
+        const searchParams = new URLSearchParams()
+        Object.entries(params).forEach(([key, value]) => {
+          if (value !== undefined && value !== null) {
+            searchParams.set(key, String(value))
+          }
+        })
+        url = `${endpoint}?${searchParams.toString()}`
+      }
+
+      const response = await fetch(url, {
+        method,
+        headers: method === 'POST' ? { 'Content-Type': 'application/json' } : undefined,
+        body: method === 'POST' && params ? JSON.stringify(params) : undefined,
+      })
+
+      if (!response.ok) {
+        throw new Error(`API error: ${response.status} ${response.statusText}`)
+      }
+
+      const json = await response.json()
+      // Assume response is array or has data array property
+      const resultData = Array.isArray(json) ? json : json.data ?? json.items ?? []
+      setData(resultData)
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)))
+    } finally {
+      setIsLoading(false)
+    }
+  }, [endpoint, method, paramsKey]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Initial fetch (only if endpoint is provided)
+  useEffect(() => {
+    if (endpoint) {
+      fetchData()
+    }
+  }, [endpoint, fetchData])
+
+  // Polling (only if endpoint and pollInterval are provided)
+  useEffect(() => {
+    if (!endpoint || !pollInterval || pollInterval <= 0) return
+
+    const interval = setInterval(fetchData, pollInterval)
+    return () => clearInterval(interval)
+  }, [endpoint, fetchData, pollInterval])
+
+  // Return empty result if no endpoint
+  if (!endpoint) {
+    return EMPTY_RESULT
+  }
+
+  return { data, isLoading, error, refetch: fetchData }
+}
+
+/**
+ * Static data source (internal - always runs but skips if data is null)
+ */
+function useStaticDataSourceInternal(staticData: unknown[] | null): UseDataSourceResult {
+  return useMemo(
+    () => {
+      if (!staticData) return EMPTY_RESULT
+      return {
+        data: staticData,
+        isLoading: false,
+        error: null,
+        refetch: () => {},
+      }
+    },
+    [staticData]
+  )
+}
+
+/**
+ * Context-based data source (internal - always runs but skips if contextKey is null)
+ */
+function useContextDataSourceInternal(contextKey: string | null): UseDataSourceResult {
+  return useMemo(
+    () => {
+      if (!contextKey) return EMPTY_RESULT
+      // TODO: Implement context registry similar to hook registry
+      return {
+        data: undefined,
+        isLoading: false,
+        error: new Error(`Context data source not yet implemented: ${contextKey}`),
+        refetch: () => {},
+      }
+    },
+    [contextKey]
+  )
+}
+
+export default useDataSource

--- a/web/src/lib/unified/card/index.ts
+++ b/web/src/lib/unified/card/index.ts
@@ -1,0 +1,38 @@
+/**
+ * Unified Card Module
+ *
+ * Exports the UnifiedCard component and supporting utilities.
+ */
+
+export { UnifiedCard, default as UnifiedCardDefault } from './UnifiedCard'
+
+export {
+  useDataSource,
+  registerDataHook,
+  getDataHook,
+  getRegisteredDataHooks,
+  useCardFiltering,
+} from './hooks'
+
+export type { UseDataSourceResult, UseCardFilteringResult } from './hooks'
+
+export {
+  registerRenderer,
+  getRenderer,
+  getRegisteredRenderers,
+  renderCell,
+} from './renderers'
+
+export { ListVisualization, TableVisualization, ChartVisualization } from './visualizations'
+export type { ListVisualizationProps, TableVisualizationProps, ChartVisualizationProps } from './visualizations'
+
+// Unified Card Adapter for gradual migration
+export {
+  UnifiedCardAdapter,
+  UNIFIED_READY_CARDS,
+  UNIFIED_EXCLUDED_CARDS,
+  shouldUseUnifiedCard,
+  hasValidUnifiedConfig,
+  getCardMigrationStatus,
+  getCardsByMigrationStatus,
+} from './UnifiedCardAdapter'

--- a/web/src/lib/unified/card/renderers/index.ts
+++ b/web/src/lib/unified/card/renderers/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Unified Card Renderers
+ */
+
+export {
+  registerRenderer,
+  getRenderer,
+  getRegisteredRenderers,
+  renderCell,
+} from './registry'
+
+export type { RendererFunction } from '../../types'

--- a/web/src/lib/unified/card/renderers/registry.ts
+++ b/web/src/lib/unified/card/renderers/registry.ts
@@ -1,0 +1,553 @@
+/**
+ * Renderer Registry - Centralized cell rendering for unified cards
+ *
+ * Provides built-in renderers for common data types and allows
+ * registering custom renderers for specialized display.
+ */
+
+import { ReactNode, createElement } from 'react'
+import type { CardColumnConfig, RendererFunction } from '../../types'
+import { getStatusColors } from '../../../cards/statusColors'
+import {
+  formatStatNumber,
+  formatBytes,
+  formatPercent,
+  formatDuration,
+} from '../../../stats/types'
+
+// ============================================================================
+// Renderer Registry
+// ============================================================================
+
+const rendererRegistry: Record<string, RendererFunction> = {}
+
+/**
+ * Register a custom renderer
+ *
+ * @example
+ * registerRenderer('custom-badge', (value, item) => (
+ *   <CustomBadge value={value} item={item} />
+ * ))
+ */
+export function registerRenderer(name: string, renderer: RendererFunction): void {
+  rendererRegistry[name] = renderer
+}
+
+/**
+ * Get a renderer by name
+ */
+export function getRenderer(name: string): RendererFunction | undefined {
+  // Check custom registry first
+  if (rendererRegistry[name]) {
+    return rendererRegistry[name]
+  }
+  // Fall back to built-in renderers
+  return BUILT_IN_RENDERERS[name]
+}
+
+/**
+ * List all registered renderers
+ */
+export function getRegisteredRenderers(): string[] {
+  return [...Object.keys(BUILT_IN_RENDERERS), ...Object.keys(rendererRegistry)]
+}
+
+/**
+ * Render a cell value using the appropriate renderer
+ */
+export function renderCell(
+  value: unknown,
+  item: Record<string, unknown>,
+  column: CardColumnConfig
+): ReactNode {
+  // Get renderer name from column config, default to 'text'
+  const rendererName = column.render ?? 'text'
+
+  // Get the renderer function
+  const renderer = getRenderer(rendererName)
+  if (!renderer) {
+    // Fallback to text if renderer not found
+    console.warn(`Renderer not found: ${rendererName}, falling back to text`)
+    return renderText(value, item, column)
+  }
+
+  return renderer(value, item, column)
+}
+
+// ============================================================================
+// Built-in Renderers
+// ============================================================================
+
+/**
+ * Text renderer - displays value as-is with optional prefix/suffix
+ */
+function renderText(
+  value: unknown,
+  _item: Record<string, unknown>,
+  column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const text = String(value)
+  const prefix = column.prefix ?? ''
+  const suffix = column.suffix ?? ''
+
+  return `${prefix}${text}${suffix}`
+}
+
+/**
+ * Number renderer - formats with K/M suffix
+ */
+function renderNumber(
+  value: unknown,
+  _item: Record<string, unknown>,
+  column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const num = typeof value === 'number' ? value : parseFloat(String(value))
+  if (isNaN(num)) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const prefix = column.prefix ?? ''
+  const suffix = column.suffix ?? ''
+
+  return createElement(
+    'span',
+    { className: 'font-mono tabular-nums' },
+    `${prefix}${formatStatNumber(num)}${suffix}`
+  )
+}
+
+/**
+ * Percentage renderer - formats as X%
+ */
+function renderPercentage(
+  value: unknown,
+  _item: Record<string, unknown>,
+  column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const num = typeof value === 'number' ? value : parseFloat(String(value))
+  if (isNaN(num)) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const prefix = column.prefix ?? ''
+  const suffix = column.suffix ?? ''
+
+  return createElement(
+    'span',
+    { className: 'font-mono tabular-nums' },
+    `${prefix}${formatPercent(num)}${suffix}`
+  )
+}
+
+/**
+ * Bytes renderer - formats as KB/MB/GB/TB
+ */
+function renderBytes(
+  value: unknown,
+  _item: Record<string, unknown>,
+  column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const num = typeof value === 'number' ? value : parseFloat(String(value))
+  if (isNaN(num)) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const prefix = column.prefix ?? ''
+  const suffix = column.suffix ?? ''
+
+  return createElement(
+    'span',
+    { className: 'font-mono tabular-nums' },
+    `${prefix}${formatBytes(num)}${suffix}`
+  )
+}
+
+/**
+ * Duration renderer - formats seconds as Xd Xh Xm Xs
+ */
+function renderDuration(
+  value: unknown,
+  _item: Record<string, unknown>,
+  column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const num = typeof value === 'number' ? value : parseFloat(String(value))
+  if (isNaN(num)) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const prefix = column.prefix ?? ''
+  const suffix = column.suffix ?? ''
+
+  return createElement(
+    'span',
+    { className: 'font-mono tabular-nums' },
+    `${prefix}${formatDuration(num)}${suffix}`
+  )
+}
+
+/**
+ * Date renderer - formats as date string
+ */
+function renderDate(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  try {
+    const date = value instanceof Date ? value : new Date(String(value))
+    return createElement(
+      'span',
+      { className: 'text-gray-300' },
+      date.toLocaleDateString()
+    )
+  } catch {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+}
+
+/**
+ * DateTime renderer - formats as date + time string
+ */
+function renderDateTime(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  try {
+    const date = value instanceof Date ? value : new Date(String(value))
+    return createElement(
+      'span',
+      { className: 'text-gray-300' },
+      date.toLocaleString()
+    )
+  } catch {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+}
+
+/**
+ * Relative time renderer - formats as "X minutes ago"
+ */
+function renderRelativeTime(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  try {
+    const date = value instanceof Date ? value : new Date(String(value))
+    const now = Date.now()
+    const diff = now - date.getTime()
+
+    // Format relative time
+    const seconds = Math.floor(diff / 1000)
+    if (seconds < 60) return 'just now'
+
+    const minutes = Math.floor(seconds / 60)
+    if (minutes < 60) return `${minutes}m ago`
+
+    const hours = Math.floor(minutes / 60)
+    if (hours < 24) return `${hours}h ago`
+
+    const days = Math.floor(hours / 24)
+    if (days < 30) return `${days}d ago`
+
+    const months = Math.floor(days / 30)
+    if (months < 12) return `${months}mo ago`
+
+    const years = Math.floor(days / 365)
+    return `${years}y ago`
+  } catch {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+}
+
+/**
+ * Status badge renderer - displays status with color coding
+ */
+function renderStatusBadge(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const status = String(value)
+  const colors = getStatusColors(status)
+
+  return createElement(
+    'span',
+    {
+      className: `inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${colors.bg} ${colors.text}`,
+    },
+    status
+  )
+}
+
+/**
+ * Cluster badge renderer - displays cluster name with icon
+ */
+function renderClusterBadge(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const cluster = String(value)
+
+  return createElement(
+    'span',
+    {
+      className: 'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-purple-500/20 text-purple-400',
+    },
+    cluster
+  )
+}
+
+/**
+ * Namespace badge renderer - displays namespace name
+ */
+function renderNamespaceBadge(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const namespace = String(value)
+
+  return createElement(
+    'span',
+    {
+      className: 'inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-500/20 text-blue-400',
+    },
+    namespace
+  )
+}
+
+/**
+ * Progress bar renderer - displays value as a progress bar
+ */
+function renderProgressBar(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const num = typeof value === 'number' ? value : parseFloat(String(value))
+  if (isNaN(num)) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  // Clamp to 0-100
+  const percent = Math.min(100, Math.max(0, num))
+
+  // Determine color based on value
+  const severity = percent >= 90 ? 'error' : percent >= 70 ? 'warning' : 'success'
+  const colors = getStatusColors(
+    severity === 'error' ? 'failed' : severity === 'warning' ? 'pending' : 'running'
+  )
+
+  return createElement(
+    'div',
+    { className: 'flex items-center gap-2 w-full' },
+    createElement(
+      'div',
+      { className: 'flex-1 h-1.5 bg-gray-700 rounded-full overflow-hidden' },
+      createElement('div', {
+        className: `h-full ${colors.barColor} transition-all duration-300`,
+        style: { width: `${percent}%` },
+      })
+    ),
+    createElement(
+      'span',
+      { className: 'text-xs font-mono tabular-nums text-gray-400 w-10 text-right' },
+      `${Math.round(percent)}%`
+    )
+  )
+}
+
+/**
+ * Boolean renderer - displays checkmark or X
+ */
+function renderBoolean(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  const bool = Boolean(value)
+
+  return createElement(
+    'span',
+    {
+      className: bool ? 'text-green-400' : 'text-gray-500',
+    },
+    bool ? '✓' : '✗'
+  )
+}
+
+/**
+ * Icon renderer - displays an icon based on value
+ */
+function renderIcon(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  // For now, just render the value - icon lookup can be added later
+  return createElement(
+    'span',
+    { className: 'text-gray-400' },
+    String(value)
+  )
+}
+
+/**
+ * JSON renderer - displays JSON as formatted code
+ */
+function renderJson(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, 'null')
+  }
+
+  try {
+    const json = typeof value === 'string' ? value : JSON.stringify(value, null, 2)
+    return createElement(
+      'pre',
+      { className: 'text-xs text-gray-300 font-mono overflow-x-auto max-w-xs' },
+      json
+    )
+  } catch {
+    return createElement('span', { className: 'text-gray-500' }, '[Object]')
+  }
+}
+
+/**
+ * Truncate renderer - truncates long text with ellipsis
+ */
+function renderTruncate(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const text = String(value)
+
+  return createElement(
+    'span',
+    {
+      className: 'truncate max-w-[200px] block',
+      title: text,
+    },
+    text
+  )
+}
+
+/**
+ * Link renderer - displays as a clickable link
+ */
+function renderLink(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const url = String(value)
+
+  return createElement(
+    'a',
+    {
+      href: url,
+      target: '_blank',
+      rel: 'noopener noreferrer',
+      className: 'text-blue-400 hover:text-blue-300 hover:underline truncate max-w-[200px] block',
+    },
+    url
+  )
+}
+
+// ============================================================================
+// Built-in Renderer Map
+// ============================================================================
+
+const BUILT_IN_RENDERERS: Record<string, RendererFunction> = {
+  text: renderText,
+  number: renderNumber,
+  percentage: renderPercentage,
+  bytes: renderBytes,
+  duration: renderDuration,
+  date: renderDate,
+  datetime: renderDateTime,
+  'relative-time': renderRelativeTime,
+  'status-badge': renderStatusBadge,
+  'cluster-badge': renderClusterBadge,
+  'namespace-badge': renderNamespaceBadge,
+  'progress-bar': renderProgressBar,
+  boolean: renderBoolean,
+  icon: renderIcon,
+  json: renderJson,
+  truncate: renderTruncate,
+  link: renderLink,
+}
+
+export default {
+  registerRenderer,
+  getRenderer,
+  getRegisteredRenderers,
+  renderCell,
+}

--- a/web/src/lib/unified/card/visualizations/ChartVisualization.tsx
+++ b/web/src/lib/unified/card/visualizations/ChartVisualization.tsx
@@ -1,0 +1,524 @@
+/**
+ * ChartVisualization - Renders data as various chart types
+ *
+ * Supports: line, bar, donut, gauge, sparkline, area
+ * Uses Recharts library for rendering.
+ */
+
+import { useMemo } from 'react'
+import {
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  AreaChart,
+  Area,
+  PieChart,
+  Pie,
+  Cell,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts'
+import type { CardContentChart, CardChartSeries, CardAxisConfig } from '../../types'
+
+export interface ChartVisualizationProps {
+  /** Content configuration */
+  content: CardContentChart
+  /** Data to display */
+  data: unknown[]
+}
+
+// Default color palette for series
+const DEFAULT_COLORS = [
+  '#3b82f6', // blue
+  '#22c55e', // green
+  '#f59e0b', // amber
+  '#ef4444', // red
+  '#8b5cf6', // violet
+  '#06b6d4', // cyan
+  '#f97316', // orange
+  '#ec4899', // pink
+]
+
+/**
+ * ChartVisualization - Renders charts from config
+ */
+export function ChartVisualization({ content, data }: ChartVisualizationProps) {
+  const {
+    chartType,
+    series: rawSeries,
+    xAxis,
+    yAxis,
+    showLegend = true,
+    height = 200,
+  } = content
+
+  // Derive series from yAxis if not explicitly provided
+  const series: CardChartSeries[] = rawSeries ?? (
+    Array.isArray(yAxis)
+      ? yAxis.map(field => ({ field }))
+      : yAxis && typeof yAxis === 'string'
+        ? [{ field: yAxis }]
+        : []
+  )
+
+  // Render the appropriate chart type
+  switch (chartType) {
+    case 'line':
+      return (
+        <LineChartRenderer
+          data={data}
+          series={series}
+          xAxis={xAxis}
+          yAxis={yAxis}
+          showLegend={showLegend}
+          height={height}
+        />
+      )
+
+    case 'area':
+      return (
+        <AreaChartRenderer
+          data={data}
+          series={series}
+          xAxis={xAxis}
+          yAxis={yAxis}
+          showLegend={showLegend}
+          height={height}
+        />
+      )
+
+    case 'bar':
+      return (
+        <BarChartRenderer
+          data={data}
+          series={series}
+          xAxis={xAxis}
+          yAxis={yAxis}
+          showLegend={showLegend}
+          height={height}
+        />
+      )
+
+    case 'donut':
+      return (
+        <DonutChartRenderer
+          data={data}
+          series={series}
+          showLegend={showLegend}
+          height={height}
+        />
+      )
+
+    case 'gauge':
+      return (
+        <GaugeChartRenderer
+          data={data}
+          series={series}
+          height={height}
+        />
+      )
+
+    case 'sparkline':
+      return (
+        <SparklineRenderer
+          data={data}
+          series={series}
+          height={height}
+        />
+      )
+
+    default:
+      return (
+        <div className="flex items-center justify-center h-full text-gray-500 text-sm">
+          Unknown chart type: {chartType}
+        </div>
+      )
+  }
+}
+
+interface ChartRendererProps {
+  data: unknown[]
+  series: CardChartSeries[]
+  xAxis?: CardAxisConfig | string
+  yAxis?: CardAxisConfig | string | string[]
+  showLegend?: boolean
+  height: number
+}
+
+/**
+ * Normalize axis config to full CardAxisConfig object
+ */
+function normalizeAxisConfig(axis?: CardAxisConfig | string | string[]): CardAxisConfig | undefined {
+  if (!axis) return undefined
+  if (typeof axis === 'string') {
+    return { field: axis }
+  }
+  if (Array.isArray(axis)) {
+    return { field: axis[0] }
+  }
+  return axis
+}
+
+/**
+ * Line Chart Renderer
+ */
+function LineChartRenderer({
+  data,
+  series,
+  xAxis: xAxisProp,
+  yAxis: yAxisProp,
+  showLegend,
+  height,
+}: ChartRendererProps) {
+  const xAxis = normalizeAxisConfig(xAxisProp)
+  const yAxis = normalizeAxisConfig(yAxisProp)
+  const xField = xAxis?.field ?? 'time'
+
+  return (
+    <div style={{ width: '100%', height }}>
+      <ResponsiveContainer>
+        <LineChart data={data as Record<string, unknown>[]}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+          <XAxis
+            dataKey={xField}
+            tick={{ fill: '#9ca3af', fontSize: 11 }}
+            axisLine={{ stroke: '#4b5563' }}
+            tickLine={{ stroke: '#4b5563' }}
+          />
+          <YAxis
+            tick={{ fill: '#9ca3af', fontSize: 11 }}
+            axisLine={{ stroke: '#4b5563' }}
+            tickLine={{ stroke: '#4b5563' }}
+            label={
+              yAxis?.label
+                ? { value: yAxis.label, angle: -90, position: 'insideLeft', fill: '#9ca3af' }
+                : undefined
+            }
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: '#1f2937',
+              border: '1px solid #374151',
+              borderRadius: '0.375rem',
+            }}
+            labelStyle={{ color: '#e5e7eb' }}
+            itemStyle={{ color: '#e5e7eb' }}
+          />
+          {showLegend && (
+            <Legend
+              wrapperStyle={{ paddingTop: 10 }}
+              formatter={(value) => <span className="text-gray-300 text-xs">{value}</span>}
+            />
+          )}
+          {series.map((s, i) => (
+            <Line
+              key={s.field}
+              type="monotone"
+              dataKey={s.field}
+              name={s.label ?? s.field}
+              stroke={s.color ?? DEFAULT_COLORS[i % DEFAULT_COLORS.length]}
+              strokeWidth={2}
+              strokeDasharray={s.style === 'dashed' ? '5 5' : s.style === 'dotted' ? '2 2' : undefined}
+              dot={false}
+              activeDot={{ r: 4 }}
+            />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+/**
+ * Area Chart Renderer
+ */
+function AreaChartRenderer({
+  data,
+  series,
+  xAxis: xAxisProp,
+  yAxis: yAxisProp,
+  showLegend,
+  height,
+}: ChartRendererProps) {
+  const xAxis = normalizeAxisConfig(xAxisProp)
+  const yAxis = normalizeAxisConfig(yAxisProp)
+  const xField = xAxis?.field ?? 'time'
+
+  return (
+    <div style={{ width: '100%', height }}>
+      <ResponsiveContainer>
+        <AreaChart data={data as Record<string, unknown>[]}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+          <XAxis
+            dataKey={xField}
+            tick={{ fill: '#9ca3af', fontSize: 11 }}
+            axisLine={{ stroke: '#4b5563' }}
+            tickLine={{ stroke: '#4b5563' }}
+          />
+          <YAxis
+            tick={{ fill: '#9ca3af', fontSize: 11 }}
+            axisLine={{ stroke: '#4b5563' }}
+            tickLine={{ stroke: '#4b5563' }}
+            label={
+              yAxis?.label
+                ? { value: yAxis.label, angle: -90, position: 'insideLeft', fill: '#9ca3af' }
+                : undefined
+            }
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: '#1f2937',
+              border: '1px solid #374151',
+              borderRadius: '0.375rem',
+            }}
+            labelStyle={{ color: '#e5e7eb' }}
+            itemStyle={{ color: '#e5e7eb' }}
+          />
+          {showLegend && (
+            <Legend
+              wrapperStyle={{ paddingTop: 10 }}
+              formatter={(value) => <span className="text-gray-300 text-xs">{value}</span>}
+            />
+          )}
+          {series.map((s, i) => {
+            const color = s.color ?? DEFAULT_COLORS[i % DEFAULT_COLORS.length]
+            return (
+              <Area
+                key={s.field}
+                type="monotone"
+                dataKey={s.field}
+                name={s.label ?? s.field}
+                stroke={color}
+                fill={color}
+                fillOpacity={0.3}
+                strokeWidth={2}
+              />
+            )
+          })}
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+/**
+ * Bar Chart Renderer
+ */
+function BarChartRenderer({
+  data,
+  series,
+  xAxis: xAxisProp,
+  yAxis: yAxisProp,
+  showLegend,
+  height,
+}: ChartRendererProps) {
+  const xAxis = normalizeAxisConfig(xAxisProp)
+  const yAxis = normalizeAxisConfig(yAxisProp)
+  const xField = xAxis?.field ?? 'name'
+
+  return (
+    <div style={{ width: '100%', height }}>
+      <ResponsiveContainer>
+        <BarChart data={data as Record<string, unknown>[]}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+          <XAxis
+            dataKey={xField}
+            tick={{ fill: '#9ca3af', fontSize: 11 }}
+            axisLine={{ stroke: '#4b5563' }}
+            tickLine={{ stroke: '#4b5563' }}
+          />
+          <YAxis
+            tick={{ fill: '#9ca3af', fontSize: 11 }}
+            axisLine={{ stroke: '#4b5563' }}
+            tickLine={{ stroke: '#4b5563' }}
+            label={
+              yAxis?.label
+                ? { value: yAxis.label, angle: -90, position: 'insideLeft', fill: '#9ca3af' }
+                : undefined
+            }
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: '#1f2937',
+              border: '1px solid #374151',
+              borderRadius: '0.375rem',
+            }}
+            labelStyle={{ color: '#e5e7eb' }}
+            itemStyle={{ color: '#e5e7eb' }}
+          />
+          {showLegend && (
+            <Legend
+              wrapperStyle={{ paddingTop: 10 }}
+              formatter={(value) => <span className="text-gray-300 text-xs">{value}</span>}
+            />
+          )}
+          {series.map((s, i) => (
+            <Bar
+              key={s.field}
+              dataKey={s.field}
+              name={s.label ?? s.field}
+              fill={s.color ?? DEFAULT_COLORS[i % DEFAULT_COLORS.length]}
+              radius={[4, 4, 0, 0]}
+            />
+          ))}
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+/**
+ * Donut Chart Renderer
+ */
+function DonutChartRenderer({
+  data,
+  series,
+  showLegend,
+  height,
+}: Omit<ChartRendererProps, 'xAxis' | 'yAxis'>) {
+  // For donut charts, we expect data to be an array of { name, value } objects
+  // or we extract from the first series field
+  const chartData = useMemo(() => {
+    if (series.length === 0) return data
+
+    // If data has the series fields, transform to pie format
+    const primarySeries = series.find((s) => s.primary) ?? series[0]
+    if (!primarySeries) return data
+
+    return (data as Record<string, unknown>[]).map((item, i) => ({
+      name: String(item.name ?? item.label ?? `Item ${i + 1}`),
+      value: Number(item[primarySeries.field] ?? 0),
+      color: series[i]?.color ?? DEFAULT_COLORS[i % DEFAULT_COLORS.length],
+    }))
+  }, [data, series])
+
+  return (
+    <div style={{ width: '100%', height }}>
+      <ResponsiveContainer>
+        <PieChart>
+          <Pie
+            data={chartData as Array<{ name: string; value: number; color?: string }>}
+            cx="50%"
+            cy="50%"
+            innerRadius="60%"
+            outerRadius="80%"
+            paddingAngle={2}
+            dataKey="value"
+            nameKey="name"
+          >
+            {(chartData as Array<{ color?: string }>).map((entry, i) => (
+              <Cell
+                key={`cell-${i}`}
+                fill={entry.color ?? DEFAULT_COLORS[i % DEFAULT_COLORS.length]}
+              />
+            ))}
+          </Pie>
+          <Tooltip
+            contentStyle={{
+              backgroundColor: '#1f2937',
+              border: '1px solid #374151',
+              borderRadius: '0.375rem',
+            }}
+            labelStyle={{ color: '#e5e7eb' }}
+            itemStyle={{ color: '#e5e7eb' }}
+          />
+          {showLegend && (
+            <Legend
+              formatter={(value) => <span className="text-gray-300 text-xs">{value}</span>}
+            />
+          )}
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+/**
+ * Gauge Chart Renderer (simplified as a half-donut)
+ */
+function GaugeChartRenderer({
+  data,
+  series,
+  height,
+}: Omit<ChartRendererProps, 'xAxis' | 'yAxis' | 'showLegend'>) {
+  // Extract value from first data item and first series
+  const value = useMemo(() => {
+    if (data.length === 0 || series.length === 0) return 0
+    const firstItem = data[0] as Record<string, unknown>
+    return Number(firstItem[series[0].field] ?? 0)
+  }, [data, series])
+
+  // Create gauge data (value vs remaining to 100)
+  const gaugeData = [
+    { name: 'value', value: Math.min(100, Math.max(0, value)) },
+    { name: 'remaining', value: Math.max(0, 100 - value) },
+  ]
+
+  // Color based on value
+  const color = value >= 90 ? '#ef4444' : value >= 70 ? '#f59e0b' : '#22c55e'
+
+  return (
+    <div style={{ width: '100%', height }} className="relative">
+      <ResponsiveContainer>
+        <PieChart>
+          <Pie
+            data={gaugeData}
+            cx="50%"
+            cy="70%"
+            startAngle={180}
+            endAngle={0}
+            innerRadius="60%"
+            outerRadius="80%"
+            dataKey="value"
+            stroke="none"
+          >
+            <Cell fill={color} />
+            <Cell fill="#374151" />
+          </Pie>
+        </PieChart>
+      </ResponsiveContainer>
+      {/* Center label */}
+      <div className="absolute inset-0 flex items-center justify-center pt-4">
+        <span className="text-2xl font-bold text-gray-200">{Math.round(value)}%</span>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Sparkline Renderer (minimal line chart)
+ */
+function SparklineRenderer({
+  data,
+  series,
+  height,
+}: Omit<ChartRendererProps, 'xAxis' | 'yAxis' | 'showLegend'>) {
+  if (series.length === 0) {
+    return <div className="text-gray-500 text-sm">No series configured</div>
+  }
+
+  const primarySeries = series[0]
+
+  return (
+    <div style={{ width: '100%', height }}>
+      <ResponsiveContainer>
+        <LineChart data={data as Record<string, unknown>[]}>
+          <Line
+            type="monotone"
+            dataKey={primarySeries.field}
+            stroke={primarySeries.color ?? DEFAULT_COLORS[0]}
+            strokeWidth={2}
+            dot={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+export default ChartVisualization

--- a/web/src/lib/unified/card/visualizations/ListVisualization.tsx
+++ b/web/src/lib/unified/card/visualizations/ListVisualization.tsx
@@ -1,0 +1,363 @@
+/**
+ * ListVisualization - Renders data as a scrollable list
+ *
+ * Used for card content type 'list'. Displays data items in rows
+ * with configurable columns and cell renderers.
+ */
+
+import { useMemo, useState, useCallback } from 'react'
+import { ChevronLeft, ChevronRight, ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react'
+import type { CardContentList, CardColumnConfig, CardDrillDownConfig, CardAIActionsConfig } from '../../types'
+import { renderCell } from '../renderers'
+import { CardAIActions } from '../../../cards/CardComponents'
+
+type SortDirection = 'asc' | 'desc'
+
+export interface ListVisualizationProps {
+  /** Content configuration */
+  content: CardContentList
+  /** Data to display */
+  data: unknown[]
+  /** Drill-down configuration */
+  drillDown?: CardDrillDownConfig
+  /** Drill-down handler */
+  onDrillDown?: (item: Record<string, unknown>) => void
+}
+
+/**
+ * ListVisualization - Renders data as a list
+ */
+export function ListVisualization({
+  content,
+  data,
+  drillDown,
+  onDrillDown,
+}: ListVisualizationProps) {
+  const {
+    columns,
+    pageSize = 10,
+    itemClick = 'none',
+    showRowNumbers = false,
+    aiActions,
+    sortable = false,
+    defaultSort,
+    defaultDirection = 'asc',
+    sortOptions,
+  } = content
+
+  // Pagination state
+  const [currentPage, setCurrentPage] = useState(0)
+
+  // Sorting state
+  const [sortBy, setSortBy] = useState<string | undefined>(defaultSort)
+  const [sortDirection, setSortDirection] = useState<SortDirection>(defaultDirection)
+
+  // Build sort options from config or columns
+  const availableSortOptions = useMemo(() => {
+    if (sortOptions) return sortOptions
+    // Default: use all columns with headers as sortable options
+    return columns
+      .filter((col) => !col.hidden && col.header)
+      .map((col) => ({
+        field: col.field,
+        label: col.header || col.field,
+      }))
+  }, [sortOptions, columns])
+
+  // Sort data
+  const sortedData = useMemo(() => {
+    if (!sortable || !sortBy) return data
+
+    return [...data].sort((a, b) => {
+      const aRecord = a as Record<string, unknown>
+      const bRecord = b as Record<string, unknown>
+      const aVal = aRecord[sortBy]
+      const bVal = bRecord[sortBy]
+
+      // Handle null/undefined
+      if (aVal == null && bVal == null) return 0
+      if (aVal == null) return sortDirection === 'asc' ? 1 : -1
+      if (bVal == null) return sortDirection === 'asc' ? -1 : 1
+
+      // Handle numbers
+      if (typeof aVal === 'number' && typeof bVal === 'number') {
+        return sortDirection === 'asc' ? aVal - bVal : bVal - aVal
+      }
+
+      // Handle strings
+      const aStr = String(aVal).toLowerCase()
+      const bStr = String(bVal).toLowerCase()
+      const comparison = aStr.localeCompare(bStr)
+      return sortDirection === 'asc' ? comparison : -comparison
+    })
+  }, [data, sortable, sortBy, sortDirection])
+
+  // Calculate pagination (on sorted data)
+  const totalPages = Math.ceil(sortedData.length / pageSize)
+  const paginatedData = useMemo(() => {
+    if (!pageSize || pageSize <= 0) return sortedData
+    const start = currentPage * pageSize
+    return sortedData.slice(start, start + pageSize)
+  }, [sortedData, currentPage, pageSize])
+
+  // Handle item click
+  const handleItemClick = useCallback(
+    (item: Record<string, unknown>) => {
+      if (itemClick === 'none') return
+      if (itemClick === 'drill' && onDrillDown) {
+        onDrillDown(item)
+      }
+      // 'expand' and 'select' can be implemented later
+    },
+    [itemClick, onDrillDown]
+  )
+
+  // Get visible columns (filter out hidden)
+  const visibleColumns = useMemo(
+    () => columns.filter((col) => !col.hidden),
+    [columns]
+  )
+
+  // Find primary column for styling
+  const primaryColumn = useMemo(
+    () => columns.find((col) => col.primary),
+    [columns]
+  )
+
+  const isClickable = itemClick !== 'none' && !!(drillDown || onDrillDown)
+
+  // Toggle sort direction
+  const toggleSortDirection = useCallback(() => {
+    setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'))
+  }, [])
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Sort controls */}
+      {sortable && availableSortOptions.length > 0 && (
+        <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-800">
+          <ArrowUpDown className="w-3.5 h-3.5 text-gray-500" />
+          <select
+            value={sortBy || ''}
+            onChange={(e) => {
+              setSortBy(e.target.value || undefined)
+              setCurrentPage(0) // Reset to first page on sort change
+            }}
+            className="px-2 py-1 text-xs bg-gray-800 border border-gray-700 rounded text-gray-200 focus:outline-none focus:border-blue-500"
+          >
+            <option value="">Sort by...</option>
+            {availableSortOptions.map((opt) => (
+              <option key={opt.field} value={opt.field}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          {sortBy && (
+            <button
+              onClick={toggleSortDirection}
+              className="flex items-center gap-1 px-2 py-1 text-xs bg-gray-800 border border-gray-700 rounded text-gray-200 hover:bg-gray-700 transition-colors"
+              title={sortDirection === 'asc' ? 'Ascending (click to reverse)' : 'Descending (click to reverse)'}
+            >
+              {sortDirection === 'asc' ? (
+                <>
+                  <ArrowUp className="w-3 h-3" />
+                  <span>Asc</span>
+                </>
+              ) : (
+                <>
+                  <ArrowDown className="w-3 h-3" />
+                  <span>Desc</span>
+                </>
+              )}
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* List content */}
+      <div className="flex-1 overflow-y-auto">
+        {paginatedData.length === 0 ? (
+          <div className="flex items-center justify-center h-full text-gray-500 text-sm">
+            No items to display
+          </div>
+        ) : (
+          <div className="divide-y divide-gray-800">
+            {paginatedData.map((item, index) => (
+              <ListItem
+                key={index}
+                item={item as Record<string, unknown>}
+                columns={visibleColumns}
+                primaryColumn={primaryColumn}
+                rowNumber={showRowNumbers ? currentPage * pageSize + index + 1 : undefined}
+                isClickable={isClickable}
+                onClick={() => handleItemClick(item as Record<string, unknown>)}
+                aiActions={aiActions}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Pagination footer */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between px-3 py-2 border-t border-gray-800 text-xs text-gray-400">
+          <span>
+            {currentPage * pageSize + 1}–{Math.min((currentPage + 1) * pageSize, data.length)} of {data.length}
+          </span>
+          <div className="flex items-center gap-1">
+            <button
+              onClick={() => setCurrentPage((p) => Math.max(0, p - 1))}
+              disabled={currentPage === 0}
+              className="p-1 rounded hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+            <span className="px-2">
+              {currentPage + 1} / {totalPages}
+            </span>
+            <button
+              onClick={() => setCurrentPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={currentPage >= totalPages - 1}
+              className="p-1 rounded hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <ChevronRight className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Individual list item row
+ */
+function ListItem({
+  item,
+  columns,
+  primaryColumn,
+  rowNumber,
+  isClickable,
+  onClick,
+  aiActions,
+}: {
+  item: Record<string, unknown>
+  columns: CardColumnConfig[]
+  primaryColumn?: CardColumnConfig
+  rowNumber?: number
+  isClickable: boolean
+  onClick: () => void
+  aiActions?: CardAIActionsConfig
+}) {
+  // Build AI resource context from item using the mapping config
+  const aiResource = useMemo(() => {
+    if (!aiActions) return null
+
+    const { resourceMapping, issuesField, contextFields, showRepair } = aiActions
+    const { kind, nameField, namespaceField, clusterField, statusField } = resourceMapping
+
+    // Kind can be a static value or a field reference (starts with $)
+    const resolvedKind = kind.startsWith('$')
+      ? String(item[kind.slice(1)] ?? '')
+      : kind
+
+    const resource = {
+      kind: resolvedKind,
+      name: String(item[nameField] ?? ''),
+      namespace: namespaceField ? String(item[namespaceField] ?? '') : undefined,
+      cluster: clusterField ? String(item[clusterField] ?? '') : undefined,
+      status: statusField ? String(item[statusField] ?? '') : undefined,
+    }
+
+    // Extract issues if configured
+    let issues: Array<{ name: string; message: string }> = []
+    if (issuesField) {
+      const rawIssues = item[issuesField]
+      if (Array.isArray(rawIssues)) {
+        issues = rawIssues.map((issue) => {
+          if (typeof issue === 'string') {
+            return { name: resource.status || 'Issue', message: issue }
+          }
+          if (typeof issue === 'object' && issue !== null) {
+            return {
+              name: String((issue as Record<string, unknown>).name ?? 'Issue'),
+              message: String((issue as Record<string, unknown>).message ?? ''),
+            }
+          }
+          return { name: 'Issue', message: String(issue) }
+        })
+      }
+    }
+
+    // Extract additional context fields
+    const additionalContext: Record<string, unknown> = {}
+    if (contextFields) {
+      for (const field of contextFields) {
+        additionalContext[field] = item[field]
+      }
+    }
+
+    return { resource, issues, additionalContext, showRepair: showRepair !== false }
+  }, [item, aiActions])
+
+  return (
+    <div
+      className={`flex items-center gap-3 px-3 py-2 group ${
+        isClickable
+          ? 'cursor-pointer hover:bg-gray-800/50 transition-colors'
+          : ''
+      }`}
+      onClick={isClickable ? onClick : undefined}
+    >
+      {/* Row number */}
+      {rowNumber !== undefined && (
+        <span className="text-xs text-gray-600 w-6 text-right shrink-0">
+          {rowNumber}
+        </span>
+      )}
+
+      {/* Columns */}
+      {columns.map((column, colIndex) => {
+        const value = item[column.field]
+        const isPrimary = column === primaryColumn
+
+        return (
+          <div
+            key={column.field}
+            className={`
+              ${column.width ? '' : 'flex-1'}
+              ${column.align === 'center' ? 'text-center' : ''}
+              ${column.align === 'right' ? 'text-right' : ''}
+              ${isPrimary ? 'font-medium text-gray-200' : 'text-gray-400'}
+              ${colIndex === 0 && !rowNumber ? 'flex-1' : ''}
+              truncate
+            `}
+            style={
+              column.width
+                ? {
+                    width: typeof column.width === 'number' ? `${column.width}px` : column.width,
+                    flexShrink: 0,
+                  }
+                : undefined
+            }
+          >
+            {renderCell(value, item, column)}
+          </div>
+        )
+      })}
+
+      {/* AI Actions (Diagnose/Repair) */}
+      {aiResource && (
+        <CardAIActions
+          resource={aiResource.resource}
+          issues={aiResource.issues}
+          additionalContext={aiResource.additionalContext}
+          showRepair={aiResource.showRepair}
+          className="opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
+        />
+      )}
+    </div>
+  )
+}
+
+export default ListVisualization

--- a/web/src/lib/unified/card/visualizations/StatusGridVisualization.tsx
+++ b/web/src/lib/unified/card/visualizations/StatusGridVisualization.tsx
@@ -1,0 +1,197 @@
+/**
+ * StatusGridVisualization - Renders data as a grid of status items
+ *
+ * Used for card content type 'status-grid'. Displays status items in a grid
+ * with icons, labels, and dynamic values resolved from data.
+ */
+
+import { useMemo } from 'react'
+import {
+  Server, CheckCircle2, XCircle, WifiOff, Box, Cpu, MemoryStick, HardDrive, Zap, Layers,
+  FolderOpen, AlertCircle, AlertTriangle, AlertOctagon, Package, Ship, Settings, Clock,
+  MoreHorizontal, Database, Workflow, Globe, Network, ArrowRightLeft, CircleDot,
+  ShieldAlert, ShieldOff, User, Info, Percent, ClipboardList, Sparkles, Activity,
+  List, DollarSign, FlaskConical, FolderTree, Bell, RefreshCw, ArrowUpCircle,
+  Newspaper, FileCode, Lock, Unlock, UserCheck, FileText, Calendar, CreditCard,
+  Heart, Shield, ShieldCheck, GitBranch, Cloud, Link, Unlink,
+} from 'lucide-react'
+import type { CardContentStatusGrid, CardStatusItem } from '../../types'
+import { resolveFieldPath, formatValue } from '../../stats/valueResolvers'
+
+// Icon mapping for dynamic rendering
+const ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
+  Server, CheckCircle2, XCircle, WifiOff, Box, Cpu, MemoryStick, HardDrive, Zap, Layers,
+  FolderOpen, AlertCircle, AlertTriangle, AlertOctagon, Package, Ship, Settings, Clock,
+  MoreHorizontal, Database, Workflow, Globe, Network, ArrowRightLeft, CircleDot,
+  ShieldAlert, ShieldOff, User, Info, Percent, ClipboardList, Sparkles, Activity,
+  List, DollarSign, FlaskConical, FolderTree, Bell, RefreshCw, ArrowUpCircle,
+  Newspaper, FileCode, Lock, Unlock, UserCheck, FileText, Calendar, CreditCard,
+  Heart, Shield, ShieldCheck, GitBranch, Cloud, Link, Unlink,
+}
+
+// Color mapping for icons and backgrounds
+const ICON_COLORS: Record<string, string> = {
+  purple: 'text-purple-400',
+  green: 'text-green-400',
+  orange: 'text-orange-400',
+  yellow: 'text-yellow-400',
+  cyan: 'text-cyan-400',
+  blue: 'text-blue-400',
+  red: 'text-red-400',
+  gray: 'text-gray-400',
+  indigo: 'text-indigo-400',
+  pink: 'text-pink-400',
+  teal: 'text-teal-400',
+  emerald: 'text-emerald-400',
+}
+
+const BG_COLORS: Record<string, string> = {
+  purple: 'bg-purple-500/10',
+  green: 'bg-green-500/10',
+  orange: 'bg-orange-500/10',
+  yellow: 'bg-yellow-500/10',
+  cyan: 'bg-cyan-500/10',
+  blue: 'bg-blue-500/10',
+  red: 'bg-red-500/10',
+  gray: 'bg-gray-500/10',
+  indigo: 'bg-indigo-500/10',
+  pink: 'bg-pink-500/10',
+  teal: 'bg-teal-500/10',
+  emerald: 'bg-emerald-500/10',
+}
+
+export interface StatusGridVisualizationProps {
+  /** Content configuration */
+  content: CardContentStatusGrid
+  /** Data to resolve values from */
+  data: unknown[] | unknown
+}
+
+/**
+ * StatusGridVisualization - Renders a grid of status items
+ */
+export function StatusGridVisualization({
+  content,
+  data,
+}: StatusGridVisualizationProps) {
+  const { items, columns = 2, showCounts = true } = content
+
+  // Resolve values for all items
+  const resolvedItems = useMemo(() => {
+    return items.map((item) => ({
+      ...item,
+      resolvedValue: resolveItemValue(item, data),
+    }))
+  }, [items, data])
+
+  // Determine grid class based on column count
+  const gridClass = useMemo(() => {
+    switch (columns) {
+      case 1:
+        return 'grid-cols-1'
+      case 2:
+        return 'grid-cols-2'
+      case 3:
+        return 'grid-cols-3'
+      case 4:
+        return 'grid-cols-4'
+      default:
+        return 'grid-cols-2'
+    }
+  }, [columns])
+
+  return (
+    <div className={`grid ${gridClass} gap-3 p-3`}>
+      {resolvedItems.map((item) => (
+        <StatusGridItem
+          key={item.id}
+          item={item}
+          value={item.resolvedValue}
+          showValue={showCounts}
+        />
+      ))}
+    </div>
+  )
+}
+
+/**
+ * Resolve a status item's value from data
+ */
+function resolveItemValue(item: CardStatusItem, data: unknown): string | number {
+  const { valueSource } = item
+
+  switch (valueSource.type) {
+    case 'field': {
+      const value = resolveFieldPath(data, valueSource.path)
+      return formatValue(value) as string | number
+    }
+
+    case 'computed': {
+      // Simple computed expression support
+      const expression = valueSource.expression
+      if (expression === 'count' && Array.isArray(data)) {
+        return data.length
+      }
+      // For more complex expressions, return placeholder
+      return '-'
+    }
+
+    case 'count': {
+      if (!Array.isArray(data)) return 0
+      if (valueSource.filter) {
+        // Filter format: 'field=value'
+        const [field, expectedValue] = valueSource.filter.split('=')
+        const filtered = data.filter((item) => {
+          const val = resolveFieldPath(item, field.trim())
+          return String(val) === expectedValue?.trim()
+        })
+        return filtered.length
+      }
+      return data.length
+    }
+
+    default:
+      return '-'
+  }
+}
+
+/**
+ * Individual status grid item
+ */
+function StatusGridItem({
+  item,
+  value,
+  showValue,
+}: {
+  item: CardStatusItem & { resolvedValue: string | number }
+  value: string | number
+  showValue: boolean
+}) {
+  const IconComponent = ICONS[item.icon] || Box
+  const iconColor = ICON_COLORS[item.color] || ICON_COLORS.gray
+  const bgColor = item.bgColor || BG_COLORS[item.color] || BG_COLORS.gray
+
+  return (
+    <div
+      className={`
+        flex items-center gap-3 p-3 rounded-lg
+        ${bgColor}
+        transition-colors hover:bg-opacity-20
+      `}
+    >
+      <div className={`shrink-0 ${iconColor}`}>
+        <IconComponent className="w-5 h-5" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="text-xs text-gray-400 truncate">{item.label}</div>
+        {showValue && (
+          <div className="text-lg font-semibold text-gray-200 truncate">
+            {value}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default StatusGridVisualization

--- a/web/src/lib/unified/card/visualizations/TableVisualization.tsx
+++ b/web/src/lib/unified/card/visualizations/TableVisualization.tsx
@@ -1,0 +1,244 @@
+/**
+ * TableVisualization - Renders data as a table with headers
+ *
+ * Used for card content type 'table'. Displays data in a traditional
+ * table layout with sortable columns and pagination.
+ */
+
+import { useMemo, useState, useCallback } from 'react'
+import { ChevronLeft, ChevronRight, ChevronUp, ChevronDown } from 'lucide-react'
+import type { CardContentTable, CardDrillDownConfig } from '../../types'
+import { renderCell } from '../renderers'
+
+export interface TableVisualizationProps {
+  /** Content configuration */
+  content: CardContentTable
+  /** Data to display */
+  data: unknown[]
+  /** Drill-down configuration */
+  drillDown?: CardDrillDownConfig
+  /** Drill-down handler */
+  onDrillDown?: (item: Record<string, unknown>) => void
+}
+
+type SortDirection = 'asc' | 'desc'
+
+/**
+ * TableVisualization - Renders data as a table
+ */
+export function TableVisualization({
+  content,
+  data,
+  drillDown,
+  onDrillDown,
+}: TableVisualizationProps) {
+  const {
+    columns,
+    sortable = true,
+    defaultSort,
+    defaultDirection = 'asc',
+    pageSize = 10,
+  } = content
+
+  // Sort state
+  const [sortField, setSortField] = useState<string | undefined>(defaultSort)
+  const [sortDirection, setSortDirection] = useState<SortDirection>(defaultDirection)
+
+  // Pagination state
+  const [currentPage, setCurrentPage] = useState(0)
+
+  // Get visible columns
+  const visibleColumns = useMemo(
+    () => columns.filter((col) => !col.hidden),
+    [columns]
+  )
+
+  // Sort data
+  const sortedData = useMemo(() => {
+    if (!sortField) return data
+
+    return [...data].sort((a, b) => {
+      const aVal = (a as Record<string, unknown>)[sortField]
+      const bVal = (b as Record<string, unknown>)[sortField]
+
+      // Handle nullish values
+      if (aVal === null || aVal === undefined) return sortDirection === 'asc' ? 1 : -1
+      if (bVal === null || bVal === undefined) return sortDirection === 'asc' ? -1 : 1
+
+      // Compare values
+      let comparison = 0
+      if (typeof aVal === 'number' && typeof bVal === 'number') {
+        comparison = aVal - bVal
+      } else if (typeof aVal === 'string' && typeof bVal === 'string') {
+        comparison = aVal.localeCompare(bVal)
+      } else {
+        comparison = String(aVal).localeCompare(String(bVal))
+      }
+
+      return sortDirection === 'asc' ? comparison : -comparison
+    })
+  }, [data, sortField, sortDirection])
+
+  // Paginate data
+  const totalPages = Math.ceil(sortedData.length / pageSize)
+  const paginatedData = useMemo(() => {
+    if (!pageSize || pageSize <= 0) return sortedData
+    const start = currentPage * pageSize
+    return sortedData.slice(start, start + pageSize)
+  }, [sortedData, currentPage, pageSize])
+
+  // Handle sort click
+  const handleSort = useCallback(
+    (field: string) => {
+      if (!sortable) return
+      if (sortField === field) {
+        // Toggle direction
+        setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'))
+      } else {
+        // New field, default to ascending
+        setSortField(field)
+        setSortDirection('asc')
+      }
+      // Reset to first page on sort change
+      setCurrentPage(0)
+    },
+    [sortable, sortField]
+  )
+
+  // Handle row click
+  const handleRowClick = useCallback(
+    (item: Record<string, unknown>) => {
+      if (onDrillDown) {
+        onDrillDown(item)
+      }
+    },
+    [onDrillDown]
+  )
+
+  const isClickable = !!(drillDown || onDrillDown)
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Table */}
+      <div className="flex-1 overflow-auto">
+        <table className="w-full text-sm">
+          {/* Header */}
+          <thead className="sticky top-0 bg-gray-900/95 backdrop-blur-sm">
+            <tr className="border-b border-gray-800">
+              {visibleColumns.map((column) => (
+                <th
+                  key={column.field}
+                  className={`
+                    px-3 py-2 text-xs font-medium text-gray-400 uppercase tracking-wider
+                    ${column.align === 'center' ? 'text-center' : ''}
+                    ${column.align === 'right' ? 'text-right' : 'text-left'}
+                    ${sortable && column.sortable !== false ? 'cursor-pointer hover:text-gray-200 select-none' : ''}
+                  `}
+                  style={
+                    column.width
+                      ? {
+                          width: typeof column.width === 'number' ? `${column.width}px` : column.width,
+                        }
+                      : undefined
+                  }
+                  onClick={
+                    sortable && column.sortable !== false
+                      ? () => handleSort(column.field)
+                      : undefined
+                  }
+                >
+                  <div className="flex items-center gap-1">
+                    <span>{column.header ?? column.field}</span>
+                    {sortable && column.sortable !== false && sortField === column.field && (
+                      sortDirection === 'asc' ? (
+                        <ChevronUp className="w-3 h-3" />
+                      ) : (
+                        <ChevronDown className="w-3 h-3" />
+                      )
+                    )}
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+
+          {/* Body */}
+          <tbody className="divide-y divide-gray-800">
+            {paginatedData.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={visibleColumns.length}
+                  className="px-3 py-8 text-center text-gray-500"
+                >
+                  No data to display
+                </td>
+              </tr>
+            ) : (
+              paginatedData.map((item, rowIndex) => (
+                <tr
+                  key={rowIndex}
+                  className={`
+                    ${isClickable ? 'cursor-pointer hover:bg-gray-800/50' : ''}
+                    transition-colors
+                  `}
+                  onClick={
+                    isClickable
+                      ? () => handleRowClick(item as Record<string, unknown>)
+                      : undefined
+                  }
+                >
+                  {visibleColumns.map((column) => {
+                    const value = (item as Record<string, unknown>)[column.field]
+                    return (
+                      <td
+                        key={column.field}
+                        className={`
+                          px-3 py-2
+                          ${column.align === 'center' ? 'text-center' : ''}
+                          ${column.align === 'right' ? 'text-right' : ''}
+                          ${column.primary ? 'font-medium text-gray-200' : 'text-gray-400'}
+                        `}
+                      >
+                        {renderCell(value, item as Record<string, unknown>, column)}
+                      </td>
+                    )
+                  })}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination footer */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between px-3 py-2 border-t border-gray-800 text-xs text-gray-400">
+          <span>
+            {currentPage * pageSize + 1}–{Math.min((currentPage + 1) * pageSize, sortedData.length)} of {sortedData.length}
+          </span>
+          <div className="flex items-center gap-1">
+            <button
+              onClick={() => setCurrentPage((p) => Math.max(0, p - 1))}
+              disabled={currentPage === 0}
+              className="p-1 rounded hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+            <span className="px-2">
+              {currentPage + 1} / {totalPages}
+            </span>
+            <button
+              onClick={() => setCurrentPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={currentPage >= totalPages - 1}
+              className="p-1 rounded hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <ChevronRight className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default TableVisualization

--- a/web/src/lib/unified/card/visualizations/index.ts
+++ b/web/src/lib/unified/card/visualizations/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Unified Card Visualizations
+ */
+
+export { ListVisualization } from './ListVisualization'
+export type { ListVisualizationProps } from './ListVisualization'
+
+export { TableVisualization } from './TableVisualization'
+export type { TableVisualizationProps } from './TableVisualization'
+
+export { ChartVisualization } from './ChartVisualization'
+export type { ChartVisualizationProps } from './ChartVisualization'
+
+export { StatusGridVisualization } from './StatusGridVisualization'
+export type { StatusGridVisualizationProps } from './StatusGridVisualization'

--- a/web/src/lib/unified/dashboard/DashboardGrid.tsx
+++ b/web/src/lib/unified/dashboard/DashboardGrid.tsx
@@ -1,0 +1,295 @@
+/**
+ * DashboardGrid - Grid layout for dashboard cards
+ *
+ * Renders a responsive grid of cards with optional drag-and-drop support.
+ */
+
+import { useMemo, useState, useCallback } from 'react'
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+  DragStartEvent,
+  DragOverlay,
+} from '@dnd-kit/core'
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  rectSortingStrategy,
+  useSortable,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import type { DashboardCardPlacement, DashboardFeatures } from '../types'
+import { UnifiedCard } from '../card'
+import { getCardConfig } from '../../../config/cards'
+
+export interface DashboardGridProps {
+  /** Card placements */
+  cards: DashboardCardPlacement[]
+  /** Features configuration */
+  features?: DashboardFeatures
+  /** Called when cards are reordered */
+  onReorder?: (cards: DashboardCardPlacement[]) => void
+  /** Called when a card is removed */
+  onRemoveCard?: (cardId: string) => void
+  /** Called when a card is configured */
+  onConfigureCard?: (cardId: string) => void
+  /** Whether data is loading */
+  isLoading?: boolean
+  /** Additional className */
+  className?: string
+}
+
+/**
+ * DashboardGrid - Renders a grid of cards
+ */
+export function DashboardGrid({
+  cards,
+  features,
+  onReorder,
+  onRemoveCard,
+  onConfigureCard,
+  isLoading = false,
+  className = '',
+}: DashboardGridProps) {
+  const [activeId, setActiveId] = useState<string | null>(null)
+
+  // Configure drag sensors
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  )
+
+  // Get the active card for drag overlay
+  const activeCard = useMemo(() => {
+    if (!activeId) return null
+    return cards.find((c) => c.id === activeId) || null
+  }, [activeId, cards])
+
+  // Handle drag start
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveId(event.active.id as string)
+  }, [])
+
+  // Handle drag end
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      setActiveId(null)
+
+      const { active, over } = event
+      if (!over || active.id === over.id) return
+
+      const oldIndex = cards.findIndex((c) => c.id === active.id)
+      const newIndex = cards.findIndex((c) => c.id === over.id)
+
+      if (oldIndex !== -1 && newIndex !== -1 && onReorder) {
+        const newCards = arrayMove(cards, oldIndex, newIndex)
+        onReorder(newCards)
+      }
+    },
+    [cards, onReorder]
+  )
+
+  // Enable drag-drop if configured and we have a reorder handler
+  const enableDragDrop = features?.dragDrop !== false && !!onReorder
+
+  // Render grid content
+  const gridContent = (
+    <div className={`grid grid-cols-12 gap-4 ${className}`}>
+      {cards.map((placement) => (
+        <DashboardCardWrapper
+          key={placement.id}
+          placement={placement}
+          isDraggable={enableDragDrop}
+          isLoading={isLoading}
+          onRemove={onRemoveCard ? () => onRemoveCard(placement.id) : undefined}
+          onConfigure={
+            onConfigureCard ? () => onConfigureCard(placement.id) : undefined
+          }
+        />
+      ))}
+    </div>
+  )
+
+  // Wrap with DnD context if drag-drop is enabled
+  if (enableDragDrop) {
+    return (
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={cards.map((c) => c.id)}
+          strategy={rectSortingStrategy}
+        >
+          {gridContent}
+        </SortableContext>
+
+        {/* Drag overlay */}
+        <DragOverlay>
+          {activeCard && (
+            <DashboardCardWrapper
+              placement={activeCard}
+              isDraggable={false}
+              isOverlay={true}
+            />
+          )}
+        </DragOverlay>
+      </DndContext>
+    )
+  }
+
+  return gridContent
+}
+
+/**
+ * Wrapper for individual cards with sortable support
+ */
+interface DashboardCardWrapperProps {
+  placement: DashboardCardPlacement
+  isDraggable?: boolean
+  isOverlay?: boolean
+  isLoading?: boolean
+  onRemove?: () => void
+  onConfigure?: () => void
+}
+
+function DashboardCardWrapper({
+  placement,
+  isDraggable = false,
+  isOverlay = false,
+  isLoading = false,
+  onRemove,
+  onConfigure,
+}: DashboardCardWrapperProps) {
+  // Get sortable props if draggable
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: placement.id,
+    disabled: !isDraggable,
+  })
+
+  // Calculate grid column span
+  const colSpan = `col-span-${Math.min(12, Math.max(3, placement.position.w))}`
+
+  // Calculate height (each row unit = 100px approximately)
+  const minHeight = `min-h-[${placement.position.h * 100}px]`
+
+  // Get card config - support both cardType (new) and card_type (legacy localStorage)
+  const cardTypeKey = placement.cardType || (placement as { card_type?: string }).card_type
+  const cardConfig = cardTypeKey ? getCardConfig(cardTypeKey) : undefined
+
+  // Style for drag transform
+  const style = isDraggable
+    ? {
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.5 : 1,
+      }
+    : undefined
+
+  if (!cardConfig) {
+    return (
+      <div
+        ref={setNodeRef}
+        style={style}
+        className={`${colSpan} ${minHeight} glass rounded-lg p-4 flex items-center justify-center text-gray-500`}
+      >
+        Unknown card type: {cardTypeKey || 'undefined'}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`${colSpan} ${minHeight} ${isOverlay ? 'shadow-2xl' : ''}`}
+      {...(isDraggable ? attributes : {})}
+    >
+      <div className="relative h-full group">
+        {/* Drag handle */}
+        {isDraggable && (
+          <div
+            {...listeners}
+            className="absolute top-2 left-2 z-10 cursor-grab active:cursor-grabbing p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity bg-gray-800/50"
+            title="Drag to reorder"
+          >
+            <svg
+              className="w-4 h-4 text-gray-400"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path d="M8 6a2 2 0 11-4 0 2 2 0 014 0zM8 12a2 2 0 11-4 0 2 2 0 014 0zM8 18a2 2 0 11-4 0 2 2 0 014 0zM14 6a2 2 0 11-4 0 2 2 0 014 0zM14 12a2 2 0 11-4 0 2 2 0 014 0zM14 18a2 2 0 11-4 0 2 2 0 014 0z" />
+            </svg>
+          </div>
+        )}
+
+        {/* Card actions */}
+        {(onRemove || onConfigure) && !isOverlay && (
+          <div className="absolute top-2 right-2 z-10 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+            {onConfigure && (
+              <button
+                onClick={onConfigure}
+                className="p-1 rounded bg-gray-800/50 hover:bg-gray-700 text-gray-400 hover:text-white transition-colors"
+                title="Configure card"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+              </button>
+            )}
+            {onRemove && (
+              <button
+                onClick={onRemove}
+                className="p-1 rounded bg-gray-800/50 hover:bg-red-900/50 text-gray-400 hover:text-red-400 transition-colors"
+                title="Remove card"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* The actual card */}
+        <UnifiedCard
+          config={cardConfig}
+          instanceConfig={placement.config as Record<string, unknown> | undefined}
+          title={placement.title}
+          className="h-full glass rounded-lg"
+        />
+
+        {/* Loading overlay */}
+        {isLoading && !isOverlay && (
+          <div className="absolute inset-0 bg-gray-900/50 rounded-lg flex items-center justify-center">
+            <div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default DashboardGrid

--- a/web/src/lib/unified/dashboard/UnifiedDashboard.tsx
+++ b/web/src/lib/unified/dashboard/UnifiedDashboard.tsx
@@ -1,0 +1,317 @@
+/**
+ * UnifiedDashboard - Single component that renders any dashboard from config
+ *
+ * This component accepts a UnifiedDashboardConfig and renders a complete
+ * dashboard with stats, cards, and optional features like drag-drop and
+ * card management.
+ *
+ * Usage:
+ *   <UnifiedDashboard config={mainDashboardConfig} />
+ */
+
+import { useState, useCallback, useMemo, useEffect } from 'react'
+import { Activity, RefreshCw, Plus } from 'lucide-react'
+import type {
+  UnifiedDashboardProps,
+  DashboardCardPlacement,
+} from '../types'
+import { UnifiedStatsSection } from '../stats'
+import { DashboardGrid } from './DashboardGrid'
+import { DashboardHealthIndicator } from '../../../components/dashboard/DashboardHealthIndicator'
+import { AddCardModal } from '../../../components/dashboard/AddCardModal'
+import { ConfigureCardModal } from '../../../components/dashboard/ConfigureCardModal'
+
+/** Card suggestion type from AddCardModal */
+interface CardSuggestion {
+  type: string
+  title: string
+  description: string
+  visualization: string
+  config: Record<string, unknown>
+}
+
+/** Card type for ConfigureCardModal */
+interface ConfigurableCard {
+  id: string
+  card_type: string
+  config: Record<string, unknown>
+  title?: string
+}
+
+/**
+ * UnifiedDashboard - Renders a complete dashboard from config
+ */
+export function UnifiedDashboard({
+  config,
+  statsData,
+  className = '',
+}: UnifiedDashboardProps) {
+  // Card state - load from localStorage or use config defaults
+  const [cards, setCards] = useState<DashboardCardPlacement[]>(() => {
+    if (config.storageKey) {
+      try {
+        const stored = localStorage.getItem(config.storageKey)
+        if (stored) {
+          const parsed = JSON.parse(stored)
+          if (Array.isArray(parsed) && parsed.length > 0) {
+            return parsed
+          }
+        }
+      } catch {
+        // Ignore parse errors
+      }
+    }
+    return config.cards
+  })
+
+  // Loading state
+  const [isLoading, setIsLoading] = useState(false)
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
+
+  // Modal state
+  const [showAddCardModal, setShowAddCardModal] = useState(false)
+  const [showConfigureCardModal, setShowConfigureCardModal] = useState(false)
+  const [cardToEdit, setCardToEdit] = useState<ConfigurableCard | null>(null)
+
+  // Persist cards to localStorage when they change
+  useEffect(() => {
+    if (config.storageKey && cards.length > 0) {
+      try {
+        localStorage.setItem(config.storageKey, JSON.stringify(cards))
+      } catch {
+        // Ignore storage errors
+      }
+    }
+  }, [cards, config.storageKey])
+
+  // Handle card reorder
+  const handleReorder = useCallback((newCards: DashboardCardPlacement[]) => {
+    setCards(newCards)
+  }, [])
+
+  // Handle card removal
+  const handleRemoveCard = useCallback((cardId: string) => {
+    setCards((prev) => prev.filter((c) => c.id !== cardId))
+  }, [])
+
+  // Handle card configuration
+  const handleConfigureCard = useCallback((cardId: string) => {
+    const card = cards.find((c) => c.id === cardId)
+    if (card) {
+      setCardToEdit({
+        id: card.id,
+        card_type: card.cardType,
+        config: card.config || {},
+        title: card.title,
+      })
+      setShowConfigureCardModal(true)
+    }
+  }, [cards])
+
+  // Handle refresh
+  const handleRefresh = useCallback(async () => {
+    setIsLoading(true)
+    // Simulate refresh - in real implementation this would trigger data refetch
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    setLastUpdated(new Date())
+    setIsLoading(false)
+  }, [])
+
+  // Handle add card
+  const handleAddCard = useCallback(() => {
+    setShowAddCardModal(true)
+  }, [])
+
+  // Handle adding cards from AddCardModal
+  const handleAddCards = useCallback((newCards: CardSuggestion[]) => {
+    setCards((prev) => {
+      const additions: DashboardCardPlacement[] = newCards.map((card, index) => ({
+        id: `${card.type}-${Date.now()}-${index}`,
+        cardType: card.type,
+        title: card.title,
+        config: card.config,
+        position: {
+          x: (prev.length + index) % 12, // Simple grid placement
+          y: Math.floor((prev.length + index) / 2) * 3, // Stack rows
+          w: 6, // Default width
+          h: 3, // Default height
+        },
+      }))
+      return [...prev, ...additions]
+    })
+    setShowAddCardModal(false)
+  }, [])
+
+  // Handle saving card configuration
+  const handleSaveCardConfig = useCallback((cardId: string, newConfig: Record<string, unknown>, title?: string) => {
+    setCards((prev) =>
+      prev.map((card) =>
+        card.id === cardId
+          ? {
+              ...card,
+              config: { ...card.config, ...newConfig },
+              title: title || card.title,
+            }
+          : card
+      )
+    )
+    setShowConfigureCardModal(false)
+    setCardToEdit(null)
+  }, [])
+
+  // Handle reset to defaults
+  const handleReset = useCallback(() => {
+    setCards(config.cards)
+    if (config.storageKey) {
+      try {
+        localStorage.removeItem(config.storageKey)
+      } catch {
+        // Ignore storage errors
+      }
+    }
+  }, [config.cards, config.storageKey])
+
+  // Check if customized (different from defaults)
+  const isCustomized = useMemo(() => {
+    if (cards.length !== config.cards.length) return true
+    return cards.some((card, i) => {
+      const defaultCard = config.cards[i]
+      return (
+        card.id !== defaultCard?.id ||
+        card.cardType !== defaultCard?.cardType ||
+        card.position.w !== defaultCard?.position.w ||
+        card.position.h !== defaultCard?.position.h
+      )
+    })
+  }, [cards, config.cards])
+
+  // Features with defaults
+  const features = config.features || {}
+
+  return (
+    <div className={`p-4 md:p-6 ${className}`}>
+      {/* Dashboard header */}
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <div>
+            <h1 className="text-2xl font-bold text-white">{config.name}</h1>
+            {config.subtitle && (
+              <p className="text-sm text-gray-400 mt-1">{config.subtitle}</p>
+            )}
+          </div>
+          {/* Health indicator */}
+          <DashboardHealthIndicator />
+        </div>
+
+        <div className="flex items-center gap-2">
+          {/* Last updated indicator */}
+          {lastUpdated && (
+            <span className="text-xs text-gray-500">
+              Updated {lastUpdated.toLocaleTimeString()}
+            </span>
+          )}
+
+          {/* Refresh button */}
+          {features.autoRefresh !== false && (
+            <button
+              onClick={handleRefresh}
+              disabled={isLoading}
+              className="p-2 rounded-lg bg-gray-800 hover:bg-gray-700 disabled:opacity-50 transition-colors"
+              title="Refresh"
+            >
+              <RefreshCw
+                className={`w-4 h-4 text-gray-400 ${isLoading ? 'animate-spin' : ''}`}
+              />
+            </button>
+          )}
+
+          {/* Add card button */}
+          {features.addCard !== false && (
+            <button
+              onClick={handleAddCard}
+              className="p-2 rounded-lg bg-gray-800 hover:bg-gray-700 transition-colors"
+              title="Add card"
+            >
+              <Plus className="w-4 h-4 text-gray-400" />
+            </button>
+          )}
+
+          {/* Reset button (if customized) */}
+          {isCustomized && (
+            <button
+              onClick={handleReset}
+              className="px-3 py-1.5 text-xs rounded-lg bg-gray-800 hover:bg-gray-700 text-gray-400 transition-colors"
+              title="Reset to default layout"
+            >
+              Reset
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Stats section */}
+      {config.stats && (
+        <UnifiedStatsSection
+          config={config.stats}
+          data={statsData}
+          hasData={!!statsData}
+          isLoading={isLoading}
+          lastUpdated={lastUpdated}
+          className="mb-6"
+        />
+      )}
+
+      {/* Cards grid */}
+      <DashboardGrid
+        cards={cards}
+        features={features}
+        onReorder={features.dragDrop !== false ? handleReorder : undefined}
+        onRemoveCard={handleRemoveCard}
+        onConfigureCard={handleConfigureCard}
+        isLoading={isLoading}
+      />
+
+      {/* Empty state */}
+      {cards.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <Activity className="w-12 h-12 text-gray-600 mb-4" />
+          <h3 className="text-lg font-medium text-gray-300 mb-2">
+            No cards configured
+          </h3>
+          <p className="text-sm text-gray-500 mb-4">
+            Add cards to start building your dashboard
+          </p>
+          {features.addCard !== false && (
+            <button
+              onClick={handleAddCard}
+              className="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg text-sm font-medium transition-colors"
+            >
+              Add your first card
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Add Card Modal */}
+      <AddCardModal
+        isOpen={showAddCardModal}
+        onClose={() => setShowAddCardModal(false)}
+        onAddCards={handleAddCards}
+        existingCardTypes={cards.map((c) => c.cardType)}
+      />
+
+      {/* Configure Card Modal */}
+      <ConfigureCardModal
+        isOpen={showConfigureCardModal}
+        card={cardToEdit}
+        onClose={() => {
+          setShowConfigureCardModal(false)
+          setCardToEdit(null)
+        }}
+        onSave={handleSaveCardConfig}
+      />
+    </div>
+  )
+}
+
+export default UnifiedDashboard

--- a/web/src/lib/unified/dashboard/index.ts
+++ b/web/src/lib/unified/dashboard/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Unified Dashboard Components
+ */
+
+export { UnifiedDashboard } from './UnifiedDashboard'
+export { DashboardGrid } from './DashboardGrid'
+
+export type { DashboardGridProps } from './DashboardGrid'

--- a/web/src/lib/unified/index.ts
+++ b/web/src/lib/unified/index.ts
@@ -1,0 +1,150 @@
+/**
+ * Unified Component Architecture
+ *
+ * This module provides the unified component system:
+ * - UnifiedCard: Single component that renders any card type from config
+ * - UnifiedStatBlock: Single component that renders any stat block from config (PR 5)
+ * - UnifiedDashboard: Single component that renders any dashboard from config (PR 6)
+ *
+ * All variations come from configuration, not code branches.
+ *
+ * @example
+ * ```tsx
+ * import { UnifiedCard, registerDataHook } from '@/lib/unified'
+ *
+ * // Register data hooks at app startup
+ * registerDataHook('useCachedPodIssues', useCachedPodIssues)
+ *
+ * // Use in component
+ * <UnifiedCard config={podIssuesConfig} />
+ * ```
+ */
+
+// Types
+export type {
+  // Card types
+  UnifiedCardConfig,
+  UnifiedCardProps,
+  CardDataSource,
+  CardDataSourceHook,
+  CardDataSourceApi,
+  CardDataSourceStatic,
+  CardDataSourceContext,
+  CardDataTransform,
+  CardContent,
+  CardContentList,
+  CardContentTable,
+  CardContentChart,
+  CardContentStatusGrid,
+  CardContentCustom,
+  CardColumnConfig,
+  CardRenderer,
+  CardChartSeries,
+  CardAxisConfig,
+  CardStatusItem,
+  CardValueSource,
+  CardFilterConfig,
+  CardFilterOption,
+  CardStatConfig,
+  CardStatAction,
+  CardFooterConfig,
+  CardDrillDownConfig,
+  CardEmptyStateConfig,
+  CardLoadingStateConfig,
+  CardWidth,
+
+  // Stat block types
+  UnifiedStatBlockConfig,
+  UnifiedStatBlockProps,
+  StatValueSource,
+  StatValueSourceField,
+  StatValueSourceComputed,
+  StatValueSourceHook,
+  StatValueSourceAggregate,
+  StatValueFormat,
+  StatBlockAction,
+
+  // Stats section types
+  UnifiedStatsSectionConfig,
+  UnifiedStatsSectionProps,
+
+  // Dashboard types
+  UnifiedDashboardConfig,
+  UnifiedDashboardProps,
+  DashboardCardPlacement,
+  DashboardFeatures,
+
+  // Registry types
+  CardConfigRegistry,
+  StatsConfigRegistry,
+  DashboardConfigRegistry,
+  RendererFunction,
+  RendererRegistry,
+  DataHookFunction,
+  DataHookRegistry,
+} from './types'
+
+// Re-export from existing modules
+export type {
+  CardCategory,
+  CardVisualization,
+  CardPlacement,
+  CardStatus,
+} from '../cards/types'
+
+export type {
+  StatBlockColor,
+  StatBlockValue,
+  StatBlockConfig,
+} from '../stats/types'
+
+// Components
+export {
+  UnifiedCard,
+  useDataSource,
+  registerDataHook,
+  getDataHook,
+  getRegisteredDataHooks,
+  useCardFiltering,
+  registerRenderer,
+  getRenderer,
+  getRegisteredRenderers,
+  renderCell,
+  ListVisualization,
+  TableVisualization,
+  ChartVisualization,
+} from './card'
+
+export type {
+  ListVisualizationProps,
+  TableVisualizationProps,
+  ChartVisualizationProps,
+} from './card'
+
+// Stats components (PR 5)
+export {
+  UnifiedStatBlock,
+  UnifiedStatsSection,
+  resolveStatValue,
+  resolveFieldPath,
+  resolveComputedExpression,
+  resolveAggregate,
+  formatValue,
+  formatNumber,
+  formatBytes,
+  formatCurrency,
+  formatDuration,
+} from './stats'
+
+export type { ResolvedStatValue } from './stats'
+
+// Dashboard components (PR 6)
+export {
+  UnifiedDashboard,
+  DashboardGrid,
+} from './dashboard'
+
+export type { DashboardGridProps } from './dashboard'
+
+// Hook registration
+export { registerUnifiedHooks } from './registerHooks'

--- a/web/src/lib/unified/migration/analyzer.ts
+++ b/web/src/lib/unified/migration/analyzer.ts
@@ -1,0 +1,369 @@
+/**
+ * Card Component Analyzer
+ *
+ * Analyzes legacy card components to determine migration complexity
+ * and generate migration recommendations.
+ */
+
+import type {
+  CardAnalysis,
+  VisualizationType,
+  CardPattern,
+  DataSourceInfo,
+} from './types'
+
+/**
+ * Cards that should NOT be migrated (games, specialized visualizations)
+ */
+const NON_MIGRATION_CARDS = new Set([
+  // Arcade games
+  'kube_man', 'kube_kong', 'node_invaders', 'pod_pitfall', 'container_tetris',
+  'flappy_pod', 'pod_sweeper', 'game_2048', 'checkers', 'kube_chess',
+  'solitaire', 'match_game', 'kubedle', 'sudoku_game', 'pod_brothers',
+  'kube_kart', 'kube_pong', 'kube_snake', 'kube_galaga', 'kube_craft',
+  'kube_craft_3d', 'kube_doom', 'pod_crosser',
+  // Embedded/utility
+  'iframe_embed', 'mobile_browser', 'kubectl',
+  // Weather has animated backgrounds
+  'weather',
+])
+
+/**
+ * Cards that use the unified CardWrapper pattern - prime migration candidates
+ */
+const UNIFIED_PATTERN_CARDS = new Set([
+  'pod_issues', 'deployment_issues', 'security_issues', 'cluster_health',
+  'service_status', 'operator_status', 'active_alerts', 'hardware_health',
+  'event_stream', 'event_summary', 'warning_events', 'recent_events',
+  'namespace_events', 'app_status', 'deployment_status', 'pvc_status',
+  'service_exports', 'service_imports', 'gateway_status', 'crd_health',
+  'helm_release_status', 'argocd_applications', 'argocd_sync_status',
+  'kustomization_status', 'opa_policies', 'kyverno_policies', 'top_pods',
+  'chart_versions', 'llm_inference', 'llm_models', 'ml_jobs', 'prow_jobs',
+  'prow_status', 'gpu_inventory', 'gpu_workloads', 'namespace_rbac',
+  'role_status', 'role_binding_status', 'argocd_health', 'gitops_drift',
+])
+
+/**
+ * Chart/visualization cards that need moderate effort
+ */
+const CHART_CARDS = new Set([
+  'events_timeline', 'resource_usage', 'resource_trend', 'pod_health_trend',
+  'gpu_utilization', 'gpu_usage_trend', 'cluster_metrics', 'resource_capacity',
+  'compliance_score', 'deployment_progress', 'storage_overview', 'network_overview',
+  'compute_overview', 'gpu_overview', 'gpu_status',
+])
+
+/**
+ * Complex visualization cards requiring custom handling
+ */
+const COMPLEX_CARDS = new Set([
+  'cluster_locations', 'cluster_comparison', 'cluster_network', 'service_topology',
+  'cluster_resource_tree', 'workload_monitor', 'cluster_health_monitor',
+  'llmd_stack_monitor', 'prow_ci_monitor', 'github_ci_monitor', 'resource_marshall',
+  'cluster_groups', 'namespace_monitor', 'cluster_focus', 'user_management',
+  // AI-ML flow cards
+  'llmd_flow', 'epp_routing', 'kv_cache_monitor', 'pd_disaggregation',
+  // Kagenti cards
+  'kagenti_status', 'kagenti_agent_fleet', 'kagenti_build_pipeline',
+  'kagenti_tool_registry', 'kagenti_agent_discovery', 'kagenti_security',
+  'kagenti_topology',
+])
+
+/**
+ * Known data hooks and their registration status
+ */
+const REGISTERED_HOOKS: Record<string, boolean> = {
+  useCachedPodIssues: true,
+  useCachedDeploymentIssues: true,
+  useCachedSecurityIssues: true,
+  useCachedEvents: true,
+  useCachedPods: true,
+  useCachedServices: true,
+  useCachedDeployments: true,
+  useClusters: true,
+  useGPUNodes: true,
+  useAlerts: true,
+  useOperators: true,
+  useHelmReleases: true,
+  useNamespaces: true,
+  // Add more as they get registered
+}
+
+/**
+ * Analyze a card type and return migration information
+ */
+export function analyzeCard(cardType: string): CardAnalysis {
+  const normalizedType = cardType.toLowerCase().replace(/-/g, '_')
+
+  // Check if non-migratable
+  if (NON_MIGRATION_CARDS.has(normalizedType)) {
+    return createNonCandidateAnalysis(cardType, 'game_or_embed')
+  }
+
+  // Check if uses unified pattern (simple migration)
+  if (UNIFIED_PATTERN_CARDS.has(normalizedType)) {
+    return createSimpleAnalysis(cardType)
+  }
+
+  // Check if chart card (moderate effort)
+  if (CHART_CARDS.has(normalizedType)) {
+    return createChartAnalysis(cardType)
+  }
+
+  // Check if complex card
+  if (COMPLEX_CARDS.has(normalizedType)) {
+    return createComplexAnalysis(cardType)
+  }
+
+  // Unknown card - assume moderate complexity
+  return createUnknownAnalysis(cardType)
+}
+
+/**
+ * Analyze multiple cards and return all analyses
+ */
+export function analyzeCards(cardTypes: string[]): CardAnalysis[] {
+  return cardTypes.map(analyzeCard)
+}
+
+/**
+ * Get list of all known card types
+ */
+export function getAllKnownCardTypes(): string[] {
+  const allCards = new Set<string>()
+
+  NON_MIGRATION_CARDS.forEach(c => allCards.add(c))
+  UNIFIED_PATTERN_CARDS.forEach(c => allCards.add(c))
+  CHART_CARDS.forEach(c => allCards.add(c))
+  COMPLEX_CARDS.forEach(c => allCards.add(c))
+
+  return Array.from(allCards).sort()
+}
+
+/**
+ * Get migration candidates (cards worth migrating)
+ */
+export function getMigrationCandidates(): string[] {
+  const candidates: string[] = []
+
+  UNIFIED_PATTERN_CARDS.forEach(c => candidates.push(c))
+  CHART_CARDS.forEach(c => candidates.push(c))
+
+  return candidates.sort()
+}
+
+/**
+ * Check if a hook is registered in the unified data source system
+ */
+export function isHookRegistered(hookName: string): boolean {
+  return REGISTERED_HOOKS[hookName] === true
+}
+
+/**
+ * Detect patterns in card based on type
+ */
+function detectPatterns(cardType: string): CardPattern {
+  const isUnified = UNIFIED_PATTERN_CARDS.has(cardType)
+
+  return {
+    usesCardData: isUnified,
+    usesCardListItem: isUnified,
+    usesPagination: isUnified,
+    usesSearch: isUnified,
+    usesControlsRow: isUnified,
+    usesAIActions: isUnified,
+    usesLoadingState: isUnified || CHART_CARDS.has(cardType),
+    usesDrillDown: isUnified || CHART_CARDS.has(cardType),
+    hasClusterFilter: isUnified,
+    hasNamespaceFilter: isUnified,
+  }
+}
+
+/**
+ * Get visualization type for card
+ */
+function getVisualizationType(cardType: string): VisualizationType {
+  if (NON_MIGRATION_CARDS.has(cardType)) {
+    if (cardType.includes('game') || cardType.includes('chess') ||
+        cardType.includes('checkers') || cardType.includes('tetris') ||
+        cardType.includes('kong') || cardType.includes('doom')) {
+      return 'game'
+    }
+    if (cardType.includes('embed') || cardType.includes('browser')) {
+      return 'embed'
+    }
+  }
+
+  if (CHART_CARDS.has(cardType)) {
+    if (cardType.includes('gauge') || cardType.includes('score')) return 'gauge'
+    return 'chart'
+  }
+
+  if (cardType.includes('topology') || cardType.includes('tree')) return 'topology'
+  if (cardType.includes('location') || cardType.includes('map')) return 'map'
+  if (cardType.includes('grid') || cardType.includes('health')) return 'status-grid'
+
+  if (UNIFIED_PATTERN_CARDS.has(cardType)) return 'list'
+
+  return 'custom'
+}
+
+/**
+ * Get data source info for card type
+ */
+function getDataSourceInfo(cardType: string): DataSourceInfo | null {
+  const hookMappings: Record<string, string> = {
+    pod_issues: 'useCachedPodIssues',
+    deployment_issues: 'useCachedDeploymentIssues',
+    security_issues: 'useCachedSecurityIssues',
+    event_stream: 'useCachedEvents',
+    cluster_health: 'useClusters',
+    gpu_inventory: 'useGPUNodes',
+    active_alerts: 'useAlerts',
+    operator_status: 'useOperators',
+    helm_release_status: 'useHelmReleases',
+  }
+
+  const hookName = hookMappings[cardType]
+  if (!hookName) return null
+
+  return {
+    hookName,
+    isCached: hookName.startsWith('useCached'),
+    type: 'hook',
+    isRegistered: isHookRegistered(hookName),
+  }
+}
+
+// Note: Effort estimates are hardcoded in create*Analysis functions
+// Simple: 0.5h, Moderate: 2h, Complex: 4h, Custom: 8h
+
+// Helper functions to create analyses
+
+function createSimpleAnalysis(cardType: string): CardAnalysis {
+  return {
+    cardType,
+    componentFile: `${pascalCase(cardType)}.tsx`,
+    configFile: `config/cards/${cardType.replace(/_/g, '-')}.ts`,
+    complexity: 'simple',
+    visualizationType: 'list',
+    patterns: detectPatterns(cardType),
+    dataSource: getDataSourceInfo(cardType),
+    linesOfCode: 250, // Average for simple cards
+    isMigrationCandidate: true,
+    estimatedEffort: 0.5,
+    manualHandlingNeeded: [],
+  }
+}
+
+function createChartAnalysis(cardType: string): CardAnalysis {
+  return {
+    cardType,
+    componentFile: `${pascalCase(cardType)}.tsx`,
+    configFile: `config/cards/${cardType.replace(/_/g, '-')}.ts`,
+    complexity: 'moderate',
+    visualizationType: 'chart',
+    patterns: {
+      ...detectPatterns(cardType),
+      usesCardData: false,
+      usesCardListItem: false,
+      usesPagination: false,
+    },
+    dataSource: getDataSourceInfo(cardType),
+    linesOfCode: 350, // Average for chart cards
+    isMigrationCandidate: true,
+    estimatedEffort: 2,
+    manualHandlingNeeded: ['chart-configuration', 'time-range-selector'],
+  }
+}
+
+function createComplexAnalysis(cardType: string): CardAnalysis {
+  return {
+    cardType,
+    componentFile: `${pascalCase(cardType)}.tsx`,
+    configFile: null,
+    complexity: 'complex',
+    visualizationType: getVisualizationType(cardType),
+    patterns: {
+      ...detectPatterns(cardType),
+      usesCardData: false,
+      usesCardListItem: false,
+    },
+    dataSource: getDataSourceInfo(cardType),
+    linesOfCode: 500, // Average for complex cards
+    isMigrationCandidate: true,
+    estimatedEffort: 4,
+    manualHandlingNeeded: ['custom-visualization', 'state-management', 'fullscreen-support'],
+  }
+}
+
+function createNonCandidateAnalysis(
+  cardType: string,
+  reason: 'game_or_embed' | 'specialized'
+): CardAnalysis {
+  return {
+    cardType,
+    componentFile: `${pascalCase(cardType)}.tsx`,
+    configFile: null,
+    complexity: 'custom',
+    visualizationType: getVisualizationType(cardType),
+    patterns: {
+      usesCardData: false,
+      usesCardListItem: false,
+      usesPagination: false,
+      usesSearch: false,
+      usesControlsRow: false,
+      usesAIActions: false,
+      usesLoadingState: false,
+      usesDrillDown: false,
+      hasClusterFilter: false,
+      hasNamespaceFilter: false,
+    },
+    dataSource: null,
+    linesOfCode: 600,
+    isMigrationCandidate: false,
+    nonCandidateReason: reason === 'game_or_embed'
+      ? 'Game or embedded content - not suitable for unified framework'
+      : 'Highly specialized visualization - requires custom component',
+    estimatedEffort: 0,
+    manualHandlingNeeded: [],
+  }
+}
+
+function createUnknownAnalysis(cardType: string): CardAnalysis {
+  return {
+    cardType,
+    componentFile: `${pascalCase(cardType)}.tsx`,
+    configFile: null,
+    complexity: 'moderate',
+    visualizationType: 'custom',
+    patterns: {
+      usesCardData: false,
+      usesCardListItem: false,
+      usesPagination: false,
+      usesSearch: false,
+      usesControlsRow: false,
+      usesAIActions: false,
+      usesLoadingState: true,
+      usesDrillDown: false,
+      hasClusterFilter: false,
+      hasNamespaceFilter: false,
+    },
+    dataSource: null,
+    linesOfCode: 300,
+    isMigrationCandidate: true,
+    estimatedEffort: 2,
+    manualHandlingNeeded: ['needs-analysis'],
+  }
+}
+
+/**
+ * Convert snake_case to PascalCase
+ */
+function pascalCase(str: string): string {
+  return str
+    .split('_')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join('')
+}

--- a/web/src/lib/unified/migration/index.ts
+++ b/web/src/lib/unified/migration/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Unified Card Migration Utilities
+ *
+ * Tools to help migrate legacy card components to the UnifiedCard framework.
+ *
+ * Phase 5 of the Unified Component Framework activation.
+ */
+
+export * from './types'
+export * from './analyzer'
+export * from './validator'
+export * from './report'

--- a/web/src/lib/unified/migration/report.ts
+++ b/web/src/lib/unified/migration/report.ts
@@ -1,0 +1,264 @@
+/**
+ * Migration Report Generator
+ *
+ * Generates comprehensive migration reports and batch recommendations.
+ */
+
+import type {
+  CardAnalysis,
+  CardComplexity,
+  MigrationBatch,
+  MigrationReport,
+  VisualizationType,
+} from './types'
+import { analyzeCard, getMigrationCandidates, getAllKnownCardTypes } from './analyzer'
+
+/**
+ * Generate a full migration report for all known cards
+ */
+export function generateMigrationReport(): MigrationReport {
+  const allCardTypes = getAllKnownCardTypes()
+  const cards = allCardTypes.map(analyzeCard)
+
+  const byComplexity = countByComplexity(cards)
+  const byVisualization = countByVisualization(cards)
+
+  const migrationCandidates = cards.filter(c => c.isMigrationCandidate)
+  const nonCandidates = cards.filter(c => !c.isMigrationCandidate)
+
+  const totalEstimatedEffort = migrationCandidates.reduce(
+    (sum, c) => sum + c.estimatedEffort,
+    0
+  )
+
+  const batches = generateBatches(migrationCandidates)
+
+  return {
+    totalCards: cards.length,
+    byComplexity,
+    byVisualization,
+    migrationCandidates: migrationCandidates.length,
+    nonCandidates: nonCandidates.length,
+    totalEstimatedEffort,
+    batches,
+    cards,
+    generatedAt: new Date(),
+  }
+}
+
+/**
+ * Generate recommended migration batches
+ */
+export function generateBatches(candidates: CardAnalysis[]): MigrationBatch[] {
+  const batches: MigrationBatch[] = []
+
+  // Batch 1: Simple list cards (highest priority, lowest effort)
+  const simpleListCards = candidates.filter(
+    c => c.complexity === 'simple' && c.visualizationType === 'list'
+  )
+  if (simpleListCards.length > 0) {
+    batches.push({
+      id: 'batch-1-simple-lists',
+      name: 'Batch 1: Simple List Cards',
+      cards: simpleListCards.map(c => c.cardType),
+      estimatedEffort: simpleListCards.reduce((sum, c) => sum + c.estimatedEffort, 0),
+      priority: 1,
+    })
+  }
+
+  // Batch 2: Status grid cards
+  const statusGridCards = candidates.filter(
+    c => c.visualizationType === 'status-grid'
+  )
+  if (statusGridCards.length > 0) {
+    batches.push({
+      id: 'batch-2-status-grids',
+      name: 'Batch 2: Status Grid Cards',
+      cards: statusGridCards.map(c => c.cardType),
+      estimatedEffort: statusGridCards.reduce((sum, c) => sum + c.estimatedEffort, 0),
+      priority: 2,
+    })
+  }
+
+  // Batch 3: Chart cards (moderate effort)
+  const chartCards = candidates.filter(
+    c => c.visualizationType === 'chart' || c.visualizationType === 'gauge'
+  )
+  if (chartCards.length > 0) {
+    batches.push({
+      id: 'batch-3-charts',
+      name: 'Batch 3: Chart & Gauge Cards',
+      cards: chartCards.map(c => c.cardType),
+      estimatedEffort: chartCards.reduce((sum, c) => sum + c.estimatedEffort, 0),
+      priority: 3,
+    })
+  }
+
+  // Batch 4: Table cards
+  const tableCards = candidates.filter(c => c.visualizationType === 'table')
+  if (tableCards.length > 0) {
+    batches.push({
+      id: 'batch-4-tables',
+      name: 'Batch 4: Table Cards',
+      cards: tableCards.map(c => c.cardType),
+      estimatedEffort: tableCards.reduce((sum, c) => sum + c.estimatedEffort, 0),
+      priority: 4,
+    })
+  }
+
+  // Batch 5: Complex cards (maps, topologies, custom)
+  const complexCards = candidates.filter(
+    c => c.complexity === 'complex' || c.visualizationType === 'custom'
+  )
+  if (complexCards.length > 0) {
+    batches.push({
+      id: 'batch-5-complex',
+      name: 'Batch 5: Complex Visualizations',
+      cards: complexCards.map(c => c.cardType),
+      estimatedEffort: complexCards.reduce((sum, c) => sum + c.estimatedEffort, 0),
+      priority: 5,
+    })
+  }
+
+  return batches
+}
+
+/**
+ * Count cards by complexity
+ */
+function countByComplexity(cards: CardAnalysis[]): Record<CardComplexity, number> {
+  return {
+    simple: cards.filter(c => c.complexity === 'simple').length,
+    moderate: cards.filter(c => c.complexity === 'moderate').length,
+    complex: cards.filter(c => c.complexity === 'complex').length,
+    custom: cards.filter(c => c.complexity === 'custom').length,
+  }
+}
+
+/**
+ * Count cards by visualization type
+ */
+function countByVisualization(cards: CardAnalysis[]): Record<VisualizationType, number> {
+  const counts: Record<VisualizationType, number> = {
+    list: 0,
+    table: 0,
+    chart: 0,
+    'status-grid': 0,
+    gauge: 0,
+    map: 0,
+    topology: 0,
+    game: 0,
+    embed: 0,
+    custom: 0,
+  }
+
+  for (const card of cards) {
+    counts[card.visualizationType]++
+  }
+
+  return counts
+}
+
+/**
+ * Format report as markdown
+ */
+export function formatReportAsMarkdown(report: MigrationReport): string {
+  const lines: string[] = []
+
+  lines.push('# Card Migration Report')
+  lines.push('')
+  lines.push(`Generated: ${report.generatedAt.toISOString()}`)
+  lines.push('')
+
+  // Summary
+  lines.push('## Summary')
+  lines.push('')
+  lines.push(`| Metric | Count |`)
+  lines.push(`|--------|-------|`)
+  lines.push(`| Total Cards | ${report.totalCards} |`)
+  lines.push(`| Migration Candidates | ${report.migrationCandidates} |`)
+  lines.push(`| Non-Candidates | ${report.nonCandidates} |`)
+  lines.push(`| Estimated Total Effort | ${report.totalEstimatedEffort} hours |`)
+  lines.push('')
+
+  // By Complexity
+  lines.push('## Cards by Complexity')
+  lines.push('')
+  lines.push(`| Complexity | Count |`)
+  lines.push(`|------------|-------|`)
+  for (const [complexity, count] of Object.entries(report.byComplexity)) {
+    lines.push(`| ${complexity} | ${count} |`)
+  }
+  lines.push('')
+
+  // By Visualization
+  lines.push('## Cards by Visualization Type')
+  lines.push('')
+  lines.push(`| Type | Count |`)
+  lines.push(`|------|-------|`)
+  for (const [type, count] of Object.entries(report.byVisualization)) {
+    if (count > 0) {
+      lines.push(`| ${type} | ${count} |`)
+    }
+  }
+  lines.push('')
+
+  // Batches
+  lines.push('## Recommended Migration Batches')
+  lines.push('')
+  for (const batch of report.batches) {
+    lines.push(`### ${batch.name}`)
+    lines.push('')
+    lines.push(`**Priority**: ${batch.priority}`)
+    lines.push(`**Estimated Effort**: ${batch.estimatedEffort} hours`)
+    lines.push(`**Cards**: ${batch.cards.length}`)
+    lines.push('')
+    lines.push('Cards in this batch:')
+    for (const card of batch.cards) {
+      lines.push(`- \`${card}\``)
+    }
+    lines.push('')
+  }
+
+  // Non-candidates
+  const nonCandidates = report.cards.filter(c => !c.isMigrationCandidate)
+  if (nonCandidates.length > 0) {
+    lines.push('## Non-Migration Candidates')
+    lines.push('')
+    lines.push('These cards should remain as custom implementations:')
+    lines.push('')
+    for (const card of nonCandidates) {
+      lines.push(`- \`${card.cardType}\`: ${card.nonCandidateReason}`)
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * Format report as JSON
+ */
+export function formatReportAsJSON(report: MigrationReport): string {
+  return JSON.stringify(report, null, 2)
+}
+
+/**
+ * Get quick stats for display
+ */
+export function getQuickStats(): {
+  totalCards: number
+  migrationCandidates: number
+  simpleCards: number
+  estimatedHours: number
+} {
+  const candidates = getMigrationCandidates()
+  const analyses = candidates.map(analyzeCard)
+
+  return {
+    totalCards: getAllKnownCardTypes().length,
+    migrationCandidates: candidates.length,
+    simpleCards: analyses.filter(a => a.complexity === 'simple').length,
+    estimatedHours: analyses.reduce((sum, a) => sum + a.estimatedEffort, 0),
+  }
+}

--- a/web/src/lib/unified/migration/types.ts
+++ b/web/src/lib/unified/migration/types.ts
@@ -1,0 +1,164 @@
+/**
+ * Migration Types
+ *
+ * Type definitions for card migration analysis and validation.
+ */
+
+/** Card complexity level for migration effort estimation */
+export type CardComplexity = 'simple' | 'moderate' | 'complex' | 'custom'
+
+/** Card visualization type detected from component */
+export type VisualizationType =
+  | 'list'
+  | 'table'
+  | 'chart'
+  | 'status-grid'
+  | 'gauge'
+  | 'map'
+  | 'topology'
+  | 'game'
+  | 'embed'
+  | 'custom'
+
+/** Card pattern detected from component structure */
+export interface CardPattern {
+  /** Uses useCardData hook for filtering/sorting/pagination */
+  usesCardData: boolean
+  /** Uses CardListItem for row rendering */
+  usesCardListItem: boolean
+  /** Uses CardPaginationFooter */
+  usesPagination: boolean
+  /** Uses CardSearchInput */
+  usesSearch: boolean
+  /** Uses CardControlsRow */
+  usesControlsRow: boolean
+  /** Uses CardAIActions */
+  usesAIActions: boolean
+  /** Uses useCardLoadingState */
+  usesLoadingState: boolean
+  /** Uses useDrillDown */
+  usesDrillDown: boolean
+  /** Has cluster filter support */
+  hasClusterFilter: boolean
+  /** Has namespace filter support */
+  hasNamespaceFilter: boolean
+}
+
+/** Data source information extracted from component */
+export interface DataSourceInfo {
+  /** Hook name used for data fetching (e.g., 'useCachedPodIssues') */
+  hookName: string
+  /** Whether it's a cached hook */
+  isCached: boolean
+  /** Source type */
+  type: 'hook' | 'prop' | 'context' | 'static'
+  /** Whether hook is already registered in unified system */
+  isRegistered: boolean
+}
+
+/** Card analysis result */
+export interface CardAnalysis {
+  /** Card type identifier (e.g., 'pod_issues') */
+  cardType: string
+  /** Component file name */
+  componentFile: string
+  /** Config file name (if exists) */
+  configFile: string | null
+  /** Detected complexity level */
+  complexity: CardComplexity
+  /** Detected visualization type */
+  visualizationType: VisualizationType
+  /** Pattern detection results */
+  patterns: CardPattern
+  /** Data source information */
+  dataSource: DataSourceInfo | null
+  /** Lines of code */
+  linesOfCode: number
+  /** Whether card is a good migration candidate */
+  isMigrationCandidate: boolean
+  /** Reason if not a candidate */
+  nonCandidateReason?: string
+  /** Estimated migration effort (hours) */
+  estimatedEffort: number
+  /** Features that need manual handling */
+  manualHandlingNeeded: string[]
+}
+
+/** Migration validation result */
+export interface MigrationValidation {
+  /** Whether migration is valid */
+  isValid: boolean
+  /** Data parity check passed */
+  dataParityPassed: boolean
+  /** UI parity check passed */
+  uiParityPassed: boolean
+  /** Feature parity check passed */
+  featureParityPassed: boolean
+  /** List of issues found */
+  issues: ValidationIssue[]
+  /** List of warnings */
+  warnings: string[]
+}
+
+/** Individual validation issue */
+export interface ValidationIssue {
+  /** Issue severity */
+  severity: 'error' | 'warning' | 'info'
+  /** Issue category */
+  category: 'data' | 'ui' | 'feature' | 'behavior'
+  /** Issue message */
+  message: string
+  /** Legacy value (if applicable) */
+  legacyValue?: unknown
+  /** Unified value (if applicable) */
+  unifiedValue?: unknown
+}
+
+/** Migration batch definition */
+export interface MigrationBatch {
+  /** Batch identifier */
+  id: string
+  /** Batch name */
+  name: string
+  /** Cards in this batch */
+  cards: string[]
+  /** Estimated total effort */
+  estimatedEffort: number
+  /** Batch priority (lower = higher priority) */
+  priority: number
+}
+
+/** Migration report summary */
+export interface MigrationReport {
+  /** Total cards analyzed */
+  totalCards: number
+  /** Cards by complexity */
+  byComplexity: Record<CardComplexity, number>
+  /** Cards by visualization type */
+  byVisualization: Record<VisualizationType, number>
+  /** Migration candidates count */
+  migrationCandidates: number
+  /** Non-candidates count */
+  nonCandidates: number
+  /** Total estimated effort (hours) */
+  totalEstimatedEffort: number
+  /** Suggested migration batches */
+  batches: MigrationBatch[]
+  /** Individual card analyses */
+  cards: CardAnalysis[]
+  /** Generated timestamp */
+  generatedAt: Date
+}
+
+/** Card category for grouping */
+export type CardCategory =
+  | 'health'
+  | 'events'
+  | 'resources'
+  | 'ai-ml'
+  | 'charts'
+  | 'security'
+  | 'gitops'
+  | 'games'
+  | 'utilities'
+  | 'specialized'

--- a/web/src/lib/unified/migration/validator.ts
+++ b/web/src/lib/unified/migration/validator.ts
@@ -1,0 +1,253 @@
+/**
+ * Migration Validator
+ *
+ * Validates that a migrated card behaves equivalently to the legacy version.
+ */
+
+import type { MigrationValidation, ValidationIssue } from './types'
+
+/**
+ * Validate that a migrated card works correctly
+ *
+ * This performs runtime validation by comparing:
+ * - Data output between legacy and unified
+ * - Feature availability (filtering, pagination, drill-down)
+ * - UI behavior (loading states, empty states, error handling)
+ */
+export function validateMigration(
+  _cardType: string,
+  legacyData: unknown[],
+  unifiedData: unknown[]
+): MigrationValidation {
+  const issues: ValidationIssue[] = []
+  const warnings: string[] = []
+
+  // 1. Check data parity
+  const dataParityPassed = validateDataParity(legacyData, unifiedData, issues)
+
+  // 2. Check data count
+  if (legacyData.length !== unifiedData.length) {
+    issues.push({
+      severity: 'error',
+      category: 'data',
+      message: `Data count mismatch: legacy=${legacyData.length}, unified=${unifiedData.length}`,
+      legacyValue: legacyData.length,
+      unifiedValue: unifiedData.length,
+    })
+  }
+
+  // 3. Check for missing fields
+  if (legacyData.length > 0 && unifiedData.length > 0) {
+    const legacyFields = getObjectFields(legacyData[0])
+    const unifiedFields = getObjectFields(unifiedData[0])
+
+    const missingInUnified = legacyFields.filter(f => !unifiedFields.includes(f))
+    const extraInUnified = unifiedFields.filter(f => !legacyFields.includes(f))
+
+    if (missingInUnified.length > 0) {
+      issues.push({
+        severity: 'warning',
+        category: 'data',
+        message: `Fields missing in unified data: ${missingInUnified.join(', ')}`,
+      })
+    }
+
+    if (extraInUnified.length > 0) {
+      warnings.push(`Extra fields in unified data: ${extraInUnified.join(', ')}`)
+    }
+  }
+
+  const isValid = issues.filter(i => i.severity === 'error').length === 0
+
+  return {
+    isValid,
+    dataParityPassed,
+    uiParityPassed: true, // Would need runtime testing
+    featureParityPassed: true, // Would need feature detection
+    issues,
+    warnings,
+  }
+}
+
+/**
+ * Validate data parity between legacy and unified
+ */
+function validateDataParity(
+  legacyData: unknown[],
+  unifiedData: unknown[],
+  issues: ValidationIssue[]
+): boolean {
+  if (legacyData.length === 0 && unifiedData.length === 0) {
+    return true
+  }
+
+  if (legacyData.length !== unifiedData.length) {
+    return false
+  }
+
+  // Sample check - compare first few items
+  const sampleSize = Math.min(5, legacyData.length)
+  let allMatch = true
+
+  for (let i = 0; i < sampleSize; i++) {
+    const legacyItem = legacyData[i] as Record<string, unknown>
+    const unifiedItem = unifiedData[i] as Record<string, unknown>
+
+    if (!legacyItem || !unifiedItem) continue
+
+    // Compare key fields
+    const keyFields = ['id', 'name', 'namespace', 'cluster', 'status']
+
+    for (const field of keyFields) {
+      if (legacyItem[field] !== undefined && unifiedItem[field] !== undefined) {
+        if (String(legacyItem[field]) !== String(unifiedItem[field])) {
+          issues.push({
+            severity: 'error',
+            category: 'data',
+            message: `Field "${field}" mismatch at index ${i}`,
+            legacyValue: legacyItem[field],
+            unifiedValue: unifiedItem[field],
+          })
+          allMatch = false
+        }
+      }
+    }
+  }
+
+  return allMatch
+}
+
+/**
+ * Get all field names from an object
+ */
+function getObjectFields(obj: unknown): string[] {
+  if (typeof obj !== 'object' || obj === null) return []
+  return Object.keys(obj)
+}
+
+/**
+ * Create a validation summary for multiple cards
+ */
+export function createValidationSummary(
+  validations: Record<string, MigrationValidation>
+): {
+  totalCards: number
+  validCards: number
+  invalidCards: number
+  warnings: number
+  issues: ValidationIssue[]
+} {
+  const cards = Object.values(validations)
+  const allIssues = cards.flatMap(v => v.issues)
+
+  return {
+    totalCards: cards.length,
+    validCards: cards.filter(v => v.isValid).length,
+    invalidCards: cards.filter(v => !v.isValid).length,
+    warnings: cards.reduce((sum, v) => sum + v.warnings.length, 0),
+    issues: allIssues,
+  }
+}
+
+/**
+ * Check if a config matches expected patterns for a card type
+ */
+export function validateConfig(
+  _cardType: string,
+  config: Record<string, unknown>
+): ValidationIssue[] {
+  const issues: ValidationIssue[] = []
+
+  // Required fields for all configs
+  const requiredFields = ['type', 'title', 'dataSource', 'content']
+
+  for (const field of requiredFields) {
+    if (!(field in config)) {
+      issues.push({
+        severity: 'error',
+        category: 'feature',
+        message: `Missing required config field: ${field}`,
+      })
+    }
+  }
+
+  // Validate dataSource
+  const dataSource = config.dataSource as Record<string, unknown> | undefined
+  if (dataSource) {
+    if (!dataSource.type) {
+      issues.push({
+        severity: 'error',
+        category: 'feature',
+        message: 'dataSource missing type field',
+      })
+    }
+    if (dataSource.type === 'hook' && !dataSource.hook) {
+      issues.push({
+        severity: 'error',
+        category: 'feature',
+        message: 'dataSource type is "hook" but hook name is missing',
+      })
+    }
+  }
+
+  // Validate content
+  const content = config.content as Record<string, unknown> | undefined
+  if (content) {
+    if (!content.type) {
+      issues.push({
+        severity: 'error',
+        category: 'feature',
+        message: 'content missing type field',
+      })
+    }
+    if (content.type === 'list' && !content.columns) {
+      issues.push({
+        severity: 'warning',
+        category: 'feature',
+        message: 'list content should have columns defined',
+      })
+    }
+  }
+
+  return issues
+}
+
+/**
+ * Feature compatibility checker
+ */
+export function checkFeatureCompatibility(
+  _cardType: string,
+  requiredFeatures: string[]
+): {
+  compatible: boolean
+  missingFeatures: string[]
+  availableFeatures: string[]
+} {
+  // Features supported by UnifiedCard framework
+  const supportedFeatures = new Set([
+    'list-visualization',
+    'table-visualization',
+    'chart-visualization',
+    'status-grid-visualization',
+    'custom-visualization',
+    'text-search',
+    'cluster-filter',
+    'namespace-filter',
+    'pagination',
+    'sorting',
+    'drill-down',
+    'ai-actions',
+    'loading-state',
+    'empty-state',
+    'error-state',
+  ])
+
+  const missingFeatures = requiredFeatures.filter(f => !supportedFeatures.has(f))
+  const availableFeatures = requiredFeatures.filter(f => supportedFeatures.has(f))
+
+  return {
+    compatible: missingFeatures.length === 0,
+    missingFeatures,
+    availableFeatures,
+  }
+}

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -1,0 +1,1280 @@
+/**
+ * Unified Card System - Hook Registration
+ *
+ * This file registers data hooks with the unified card system.
+ * Import this file early in the application (e.g., in main.tsx) to make
+ * hooks available for unified cards.
+ *
+ * IMPORTANT: These hooks are called inside the useDataSource hook,
+ * which is a React hook. The registered functions must follow React's
+ * rules of hooks - they are called consistently on every render.
+ */
+
+import { useState, useEffect, useMemo } from 'react'
+import { registerDataHook } from './card/hooks/useDataSource'
+import {
+  useCachedPodIssues,
+  useCachedEvents,
+  useCachedDeployments,
+  useCachedDeploymentIssues,
+} from '../../hooks/useCachedData'
+import {
+  useClusters,
+  usePVCs,
+  useServices,
+  useOperators,
+  useHelmReleases,
+  useConfigMaps,
+  useSecrets,
+  useIngresses,
+  useNodes,
+  useJobs,
+  useCronJobs,
+  useStatefulSets,
+  useDaemonSets,
+  useHPAs,
+  useReplicaSets,
+  usePVs,
+  useResourceQuotas,
+  useLimitRanges,
+  useNetworkPolicies,
+  useNamespaces,
+  useOperatorSubscriptions,
+  useServiceAccounts,
+  useK8sRoles,
+  useK8sRoleBindings,
+} from '../../hooks/mcp'
+import {
+  useServiceExports,
+  useServiceImports,
+} from '../../hooks/useMCS'
+
+// ============================================================================
+// Wrapper hooks that convert params object to positional args
+// These are React hooks that can be safely registered
+// ============================================================================
+
+function useUnifiedPodIssues(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useCachedPodIssues(cluster, namespace)
+  return {
+    data: result.data,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: () => { result.refetch() },
+  }
+}
+
+function useUnifiedEvents(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useCachedEvents(cluster, namespace)
+  return {
+    data: result.data,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: () => { result.refetch() },
+  }
+}
+
+function useUnifiedDeployments(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useCachedDeployments(cluster, namespace)
+  return {
+    data: result.data,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: () => { result.refetch() },
+  }
+}
+
+function useUnifiedClusters() {
+  const result = useClusters()
+  return {
+    data: result.clusters,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedPVCs(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = usePVCs(cluster, namespace)
+  return {
+    data: result.pvcs,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedServices(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useServices(cluster, namespace)
+  return {
+    data: result.services,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedDeploymentIssues(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useCachedDeploymentIssues(cluster, namespace)
+  return {
+    data: result.issues,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedOperators(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const result = useOperators(cluster)
+  return {
+    data: result.operators,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedHelmReleases(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const result = useHelmReleases(cluster)
+  return {
+    data: result.releases,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedConfigMaps(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useConfigMaps(cluster, namespace)
+  return {
+    data: result.configmaps,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedSecrets(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useSecrets(cluster, namespace)
+  return {
+    data: result.secrets,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedIngresses(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useIngresses(cluster, namespace)
+  return {
+    data: result.ingresses,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedNodes(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const result = useNodes(cluster)
+  return {
+    data: result.nodes,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedJobs(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useJobs(cluster, namespace)
+  return {
+    data: result.jobs,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedCronJobs(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useCronJobs(cluster, namespace)
+  return {
+    data: result.cronjobs,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedStatefulSets(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useStatefulSets(cluster, namespace)
+  return {
+    data: result.statefulsets,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedDaemonSets(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useDaemonSets(cluster, namespace)
+  return {
+    data: result.daemonsets,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedHPAs(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useHPAs(cluster, namespace)
+  return {
+    data: result.hpas,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedReplicaSets(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useReplicaSets(cluster, namespace)
+  return {
+    data: result.replicasets,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedPVs(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const result = usePVs(cluster)
+  return {
+    data: result.pvs,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedResourceQuotas(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useResourceQuotas(cluster, namespace)
+  return {
+    data: result.resourceQuotas,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedLimitRanges(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useLimitRanges(cluster, namespace)
+  return {
+    data: result.limitRanges,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedNetworkPolicies(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useNetworkPolicies(cluster, namespace)
+  return {
+    data: result.networkpolicies,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedNamespaces(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const result = useNamespaces(cluster)
+  return {
+    data: result.namespaces,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedOperatorSubscriptions(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const result = useOperatorSubscriptions(cluster)
+  return {
+    data: result.subscriptions,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedServiceAccounts(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useServiceAccounts(cluster, namespace)
+  return {
+    data: result.serviceAccounts,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedK8sRoles(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useK8sRoles(cluster, namespace)
+  return {
+    data: result.roles,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedK8sRoleBindings(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useK8sRoleBindings(cluster, namespace)
+  return {
+    data: result.bindings,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedServiceExports(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useServiceExports(cluster, namespace)
+  return {
+    data: result.exports,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedServiceImports(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useServiceImports(cluster, namespace)
+  return {
+    data: result.imports,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+// ============================================================================
+// Demo data hooks for cards that don't have real data hooks yet
+// These return static demo data for visualization purposes
+// ============================================================================
+
+function useDemoDataHook<T>(demoData: T[]) {
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setIsLoading(false), 500)
+    return () => clearTimeout(timer)
+  }, [])
+
+  return {
+    data: isLoading ? [] : demoData,
+    isLoading,
+    error: null,
+    refetch: () => {},
+  }
+}
+
+// Cluster metrics demo data
+const DEMO_CLUSTER_METRICS = [
+  { timestamp: Date.now() - 300000, cpu: 45, memory: 62, pods: 156 },
+  { timestamp: Date.now() - 240000, cpu: 48, memory: 64, pods: 158 },
+  { timestamp: Date.now() - 180000, cpu: 42, memory: 61, pods: 155 },
+  { timestamp: Date.now() - 120000, cpu: 51, memory: 67, pods: 162 },
+  { timestamp: Date.now() - 60000, cpu: 47, memory: 65, pods: 159 },
+  { timestamp: Date.now(), cpu: 49, memory: 66, pods: 161 },
+]
+
+// Resource usage demo data
+const DEMO_RESOURCE_USAGE = [
+  { cluster: 'prod-east', cpu: 72, memory: 68, storage: 45 },
+  { cluster: 'staging', cpu: 35, memory: 42, storage: 28 },
+  { cluster: 'dev', cpu: 15, memory: 22, storage: 12 },
+]
+
+// Events timeline demo data
+const DEMO_EVENTS_TIMELINE = [
+  { timestamp: Date.now() - 300000, count: 12, type: 'Normal' },
+  { timestamp: Date.now() - 240000, count: 8, type: 'Warning' },
+  { timestamp: Date.now() - 180000, count: 15, type: 'Normal' },
+  { timestamp: Date.now() - 120000, count: 5, type: 'Warning' },
+  { timestamp: Date.now() - 60000, count: 10, type: 'Normal' },
+  { timestamp: Date.now(), count: 7, type: 'Warning' },
+]
+
+// Security issues demo data
+const DEMO_SECURITY_ISSUES = [
+  { id: '1', severity: 'high', title: 'Pod running as root', cluster: 'prod-east', namespace: 'default' },
+  { id: '2', severity: 'medium', title: 'Missing network policy', cluster: 'staging', namespace: 'apps' },
+  { id: '3', severity: 'low', title: 'Deprecated API version', cluster: 'dev', namespace: 'test' },
+]
+
+// Active alerts demo data
+const DEMO_ACTIVE_ALERTS = [
+  { id: '1', severity: 'critical', name: 'HighCPUUsage', cluster: 'prod-east', message: 'CPU > 90% for 5m' },
+  { id: '2', severity: 'warning', name: 'PodCrashLooping', cluster: 'staging', message: 'Pod restarting frequently' },
+]
+
+// Storage overview demo data
+const DEMO_STORAGE_OVERVIEW = {
+  totalCapacity: 2048,
+  used: 1234,
+  pvcs: 45,
+  unbound: 3,
+}
+
+// Network overview demo data
+const DEMO_NETWORK_OVERVIEW = {
+  services: 67,
+  ingresses: 12,
+  networkPolicies: 23,
+  loadBalancers: 5,
+}
+
+// Top pods demo data
+const DEMO_TOP_PODS = [
+  { name: 'api-server-7d8f9c', namespace: 'production', cpu: 850, memory: 1024, cluster: 'prod-east' },
+  { name: 'ml-worker-5c6d7e', namespace: 'ml-workloads', cpu: 3200, memory: 8192, cluster: 'vllm-d' },
+  { name: 'cache-redis-0', namespace: 'data', cpu: 120, memory: 512, cluster: 'staging' },
+]
+
+// GitOps drift demo data
+const DEMO_GITOPS_DRIFT = [
+  { app: 'frontend', status: 'synced', cluster: 'prod-east', lastSync: Date.now() - 60000 },
+  { app: 'backend', status: 'drifted', cluster: 'staging', lastSync: Date.now() - 300000 },
+  { app: 'monitoring', status: 'synced', cluster: 'dev', lastSync: Date.now() - 120000 },
+]
+
+// Pod health trend demo data
+const DEMO_POD_HEALTH_TREND = [
+  { timestamp: Date.now() - 300000, healthy: 145, unhealthy: 3 },
+  { timestamp: Date.now() - 240000, healthy: 148, unhealthy: 2 },
+  { timestamp: Date.now() - 180000, healthy: 142, unhealthy: 5 },
+  { timestamp: Date.now() - 120000, healthy: 150, unhealthy: 1 },
+  { timestamp: Date.now() - 60000, healthy: 147, unhealthy: 4 },
+  { timestamp: Date.now(), healthy: 149, unhealthy: 2 },
+]
+
+// Resource trend demo data
+const DEMO_RESOURCE_TREND = [
+  { timestamp: Date.now() - 300000, cpu: 45, memory: 62 },
+  { timestamp: Date.now() - 240000, cpu: 52, memory: 65 },
+  { timestamp: Date.now() - 180000, cpu: 48, memory: 58 },
+  { timestamp: Date.now() - 120000, cpu: 55, memory: 70 },
+  { timestamp: Date.now() - 60000, cpu: 50, memory: 67 },
+  { timestamp: Date.now(), cpu: 53, memory: 64 },
+]
+
+// Compute overview demo data
+const DEMO_COMPUTE_OVERVIEW = {
+  nodes: 12,
+  cpuUsage: 48,
+  memoryUsage: 62,
+  podCount: 156,
+}
+
+// ============================================================================
+// Batch 4 demo data - ArgoCD, Prow, GPU, ML, Policy cards
+// ============================================================================
+
+// ArgoCD applications demo data
+const DEMO_ARGOCD_APPLICATIONS = [
+  { name: 'frontend-app', project: 'production', syncStatus: 'Synced', healthStatus: 'Healthy', namespace: 'apps' },
+  { name: 'backend-api', project: 'production', syncStatus: 'OutOfSync', healthStatus: 'Progressing', namespace: 'apps' },
+  { name: 'monitoring', project: 'infra', syncStatus: 'Synced', healthStatus: 'Healthy', namespace: 'monitoring' },
+]
+
+// GPU inventory demo data
+const DEMO_GPU_INVENTORY = [
+  { cluster: 'vllm-d', node: 'gpu-node-1', model: 'NVIDIA A100 80GB', memory: 85899345920, utilization: 72 },
+  { cluster: 'vllm-d', node: 'gpu-node-2', model: 'NVIDIA A100 80GB', memory: 85899345920, utilization: 85 },
+  { cluster: 'ml-train', node: 'ml-worker-1', model: 'NVIDIA H100', memory: 85899345920, utilization: 45 },
+]
+
+// Prow jobs demo data
+const DEMO_PROW_JOBS = [
+  { name: 'pull-kubestellar-verify', type: 'presubmit', state: 'success', startTime: Date.now() - 120000 },
+  { name: 'periodic-e2e-tests', type: 'periodic', state: 'pending', startTime: Date.now() - 60000 },
+  { name: 'post-kubestellar-deploy', type: 'postsubmit', state: 'failure', startTime: Date.now() - 300000 },
+]
+
+// ML jobs demo data
+const DEMO_ML_JOBS = [
+  { name: 'train-llm-v2', namespace: 'ml-workloads', status: 'Running', progress: 75, cluster: 'ml-train' },
+  { name: 'fine-tune-bert', namespace: 'ml-workloads', status: 'Completed', progress: 100, cluster: 'ml-train' },
+  { name: 'eval-model-v3', namespace: 'ml-eval', status: 'Pending', progress: 0, cluster: 'vllm-d' },
+]
+
+// ML notebooks demo data
+const DEMO_ML_NOTEBOOKS = [
+  { name: 'data-exploration', namespace: 'ml-notebooks', status: 'Running', user: 'data-scientist', cluster: 'ml-train' },
+  { name: 'model-analysis', namespace: 'ml-notebooks', status: 'Stopped', user: 'ml-engineer', cluster: 'ml-train' },
+]
+
+// OPA policies demo data
+const DEMO_OPA_POLICIES = [
+  { name: 'require-labels', namespace: 'gatekeeper-system', status: 'active', violations: 3, cluster: 'prod-east' },
+  { name: 'deny-privileged', namespace: 'gatekeeper-system', status: 'active', violations: 0, cluster: 'prod-east' },
+  { name: 'require-requests', namespace: 'gatekeeper-system', status: 'warn', violations: 12, cluster: 'staging' },
+]
+
+// Kyverno policies demo data
+const DEMO_KYVERNO_POLICIES = [
+  { name: 'require-image-tag', namespace: 'kyverno', status: 'enforce', violations: 2, cluster: 'prod-east' },
+  { name: 'disallow-latest', namespace: 'kyverno', status: 'audit', violations: 5, cluster: 'staging' },
+]
+
+// Alert rules demo data
+const DEMO_ALERT_RULES = [
+  { name: 'HighCPUUsage', severity: 'warning', state: 'firing', group: 'kubernetes', cluster: 'prod-east' },
+  { name: 'PodCrashLooping', severity: 'critical', state: 'pending', group: 'kubernetes', cluster: 'staging' },
+  { name: 'NodeNotReady', severity: 'critical', state: 'inactive', group: 'nodes', cluster: 'dev' },
+]
+
+// Chart versions demo data
+const DEMO_CHART_VERSIONS = [
+  { chart: 'nginx-ingress', current: '4.6.0', latest: '4.8.0', updateAvailable: true, cluster: 'prod-east' },
+  { chart: 'cert-manager', current: '1.12.0', latest: '1.12.0', updateAvailable: false, cluster: 'prod-east' },
+  { chart: 'prometheus', current: '45.0.0', latest: '47.0.0', updateAvailable: true, cluster: 'monitoring' },
+]
+
+// CRD health demo data
+const DEMO_CRD_HEALTH = [
+  { name: 'applications.argoproj.io', version: 'v1alpha1', status: 'healthy', instances: 15, cluster: 'prod-east' },
+  { name: 'certificates.cert-manager.io', version: 'v1', status: 'healthy', instances: 8, cluster: 'prod-east' },
+  { name: 'inferencepools.llm.kubestellar.io', version: 'v1', status: 'degraded', instances: 2, cluster: 'vllm-d' },
+]
+
+// Compliance score demo data
+const DEMO_COMPLIANCE_SCORE = {
+  overall: 85,
+  categories: [
+    { name: 'Security', score: 92, passed: 46, failed: 4 },
+    { name: 'Reliability', score: 78, passed: 39, failed: 11 },
+    { name: 'Best Practices', score: 85, passed: 68, failed: 12 },
+  ],
+}
+
+// Namespace events demo data
+const DEMO_NAMESPACE_EVENTS = [
+  { type: 'Normal', reason: 'Scheduled', message: 'Pod scheduled', object: 'pod/api-7d8f', namespace: 'production', count: 1, lastSeen: Date.now() - 30000 },
+  { type: 'Warning', reason: 'BackOff', message: 'Container restarting', object: 'pod/worker-5c6d', namespace: 'production', count: 5, lastSeen: Date.now() - 60000 },
+]
+
+// GPU overview demo data
+const DEMO_GPU_OVERVIEW = {
+  totalGPUs: 24,
+  allocatedGPUs: 18,
+  utilizationAvg: 72,
+  memoryUsageAvg: 68,
+}
+
+// GPU workloads demo data
+const DEMO_GPU_WORKLOADS = [
+  { name: 'llm-inference-7d8f', namespace: 'ml-serving', gpus: 4, model: 'A100', utilization: 85, cluster: 'vllm-d' },
+  { name: 'training-job-5c6d', namespace: 'ml-training', gpus: 8, model: 'H100', utilization: 92, cluster: 'ml-train' },
+]
+
+// Deployment progress demo data
+const DEMO_DEPLOYMENT_PROGRESS = [
+  { name: 'api-server', namespace: 'production', replicas: 5, ready: 5, progress: 100, status: 'complete' },
+  { name: 'worker', namespace: 'production', replicas: 10, ready: 7, progress: 70, status: 'progressing' },
+]
+
+// ============================================================================
+// Batch 5 demo data - GitOps, Security, Status cards
+// ============================================================================
+
+// ArgoCD health demo data (stats-grid)
+const DEMO_ARGOCD_HEALTH = {
+  healthy: 12,
+  degraded: 2,
+  progressing: 1,
+  missing: 0,
+}
+
+// ArgoCD sync status demo data (stats-grid)
+const DEMO_ARGOCD_SYNC_STATUS = {
+  synced: 11,
+  outOfSync: 3,
+  unknown: 1,
+}
+
+// Gateway status demo data
+const DEMO_GATEWAY_STATUS = [
+  { name: 'api-gateway', class: 'istio', addresses: 2, status: 'Programmed', cluster: 'prod-east' },
+  { name: 'internal-gw', class: 'nginx', addresses: 1, status: 'Programmed', cluster: 'staging' },
+]
+
+// Kustomization status demo data
+const DEMO_KUSTOMIZATION_STATUS = [
+  { name: 'apps', namespace: 'flux-system', ready: true, lastApplied: Date.now() - 120000 },
+  { name: 'infra', namespace: 'flux-system', ready: true, lastApplied: Date.now() - 300000 },
+  { name: 'monitoring', namespace: 'flux-system', ready: false, lastApplied: Date.now() - 600000 },
+]
+
+// Provider health demo data
+const DEMO_PROVIDER_HEALTH = [
+  { provider: 'AWS', type: 'cloud', status: 'healthy', latency: 45 },
+  { provider: 'OpenAI', type: 'ai', status: 'healthy', latency: 120 },
+  { provider: 'Azure', type: 'cloud', status: 'degraded', latency: 250 },
+]
+
+// Upgrade status demo data
+const DEMO_UPGRADE_STATUS = [
+  { cluster: 'prod-east', currentVersion: '1.28.5', availableVersion: '1.29.2', status: 'available' },
+  { cluster: 'staging', currentVersion: '1.29.1', availableVersion: '1.29.2', status: 'available' },
+  { cluster: 'dev', currentVersion: '1.29.2', availableVersion: '1.29.2', status: 'current' },
+]
+
+// Prow status demo data (stats-grid)
+const DEMO_PROW_STATUS = {
+  running: 5,
+  passed: 42,
+  failed: 3,
+  pending: 2,
+}
+
+// Prow history demo data
+const DEMO_PROW_HISTORY = [
+  { job: 'e2e-tests', result: 'success', duration: 1200, finishedAt: Date.now() - 3600000 },
+  { job: 'unit-tests', result: 'success', duration: 300, finishedAt: Date.now() - 7200000 },
+  { job: 'lint', result: 'failure', duration: 60, finishedAt: Date.now() - 10800000 },
+]
+
+// Helm history demo data
+const DEMO_HELM_HISTORY = [
+  { revision: 5, chart: 'nginx-ingress-4.6.0', appVersion: '1.9.0', status: 'deployed', updated: Date.now() - 86400000 },
+  { revision: 4, chart: 'nginx-ingress-4.5.2', appVersion: '1.8.0', status: 'superseded', updated: Date.now() - 172800000 },
+]
+
+// External secrets demo data (stats-grid)
+const DEMO_EXTERNAL_SECRETS = {
+  total: 25,
+  ready: 23,
+  failed: 2,
+}
+
+// Cert manager demo data (stats-grid)
+const DEMO_CERT_MANAGER = {
+  certificates: 15,
+  ready: 14,
+  expiringSoon: 1,
+  expired: 0,
+}
+
+// Vault secrets demo data
+const DEMO_VAULT_SECRETS = [
+  { path: 'secret/data/api-keys', status: 'synced', lastSync: Date.now() - 60000 },
+  { path: 'secret/data/db-creds', status: 'synced', lastSync: Date.now() - 120000 },
+]
+
+// Falco alerts demo data
+const DEMO_FALCO_ALERTS = [
+  { rule: 'Terminal shell in container', severity: 'Warning', count: 3, lastSeen: Date.now() - 300000 },
+  { rule: 'Sensitive file read', severity: 'Notice', count: 12, lastSeen: Date.now() - 600000 },
+]
+
+// Kubescape scan demo data (stats-grid)
+const DEMO_KUBESCAPE_SCAN = {
+  passed: 85,
+  failed: 12,
+  skipped: 3,
+  riskScore: 22,
+}
+
+// Trivy scan demo data (stats-grid)
+const DEMO_TRIVY_SCAN = {
+  critical: 2,
+  high: 8,
+  medium: 25,
+  low: 45,
+}
+
+// Event summary demo data (stats-grid)
+const DEMO_EVENT_SUMMARY = {
+  normal: 156,
+  warning: 23,
+  error: 5,
+}
+
+// App status demo data
+const DEMO_APP_STATUS = [
+  { name: 'frontend', namespace: 'production', status: 'healthy', pods: 3, cluster: 'prod-east' },
+  { name: 'backend', namespace: 'production', status: 'degraded', pods: 5, cluster: 'prod-east' },
+]
+
+// GPU status demo data (stats-grid)
+const DEMO_GPU_STATUS = {
+  total: 24,
+  available: 6,
+  allocated: 18,
+  errored: 0,
+}
+
+// GPU utilization demo data (chart)
+const DEMO_GPU_UTILIZATION = [
+  { timestamp: Date.now() - 300000, utilization: 72, memory: 68 },
+  { timestamp: Date.now() - 240000, utilization: 78, memory: 72 },
+  { timestamp: Date.now() - 180000, utilization: 65, memory: 60 },
+  { timestamp: Date.now() - 120000, utilization: 82, memory: 78 },
+  { timestamp: Date.now() - 60000, utilization: 75, memory: 70 },
+  { timestamp: Date.now(), utilization: 80, memory: 74 },
+]
+
+// GPU usage trend demo data (chart)
+const DEMO_GPU_USAGE_TREND = [
+  { timestamp: Date.now() - 3600000, avgUtilization: 68 },
+  { timestamp: Date.now() - 2700000, avgUtilization: 72 },
+  { timestamp: Date.now() - 1800000, avgUtilization: 78 },
+  { timestamp: Date.now() - 900000, avgUtilization: 74 },
+  { timestamp: Date.now(), avgUtilization: 76 },
+]
+
+// Policy violations demo data
+const DEMO_POLICY_VIOLATIONS = [
+  { policy: 'require-labels', resource: 'deployment/api', namespace: 'default', severity: 'warning', cluster: 'prod-east' },
+  { policy: 'deny-privileged', resource: 'pod/debug', namespace: 'kube-system', severity: 'critical', cluster: 'staging' },
+]
+
+// Namespace overview demo data (stats-grid)
+const DEMO_NAMESPACE_OVERVIEW = {
+  pods: 45,
+  deployments: 12,
+  services: 8,
+  configmaps: 15,
+}
+
+// Namespace quotas demo data
+const DEMO_NAMESPACE_QUOTAS = [
+  { namespace: 'production', cpuUsed: '4', cpuLimit: '8', memUsed: '8Gi', memLimit: '16Gi' },
+  { namespace: 'staging', cpuUsed: '2', cpuLimit: '4', memUsed: '4Gi', memLimit: '8Gi' },
+]
+
+// Namespace RBAC demo data
+const DEMO_NAMESPACE_RBAC = [
+  { subject: 'developers', type: 'Group', role: 'edit', namespace: 'production' },
+  { subject: 'ci-bot', type: 'ServiceAccount', role: 'admin', namespace: 'production' },
+]
+
+// Resource capacity demo data (stats-grid)
+const DEMO_RESOURCE_CAPACITY = {
+  cpuTotal: 96,
+  cpuUsed: 48,
+  memoryTotal: 384,
+  memoryUsed: 256,
+}
+
+// ============================================================================
+// Batch 6 demo data - Remaining compatible cards
+// ============================================================================
+
+// GitHub activity demo data
+const DEMO_GITHUB_ACTIVITY = [
+  { type: 'PushEvent', repo: 'kubestellar/console', actor: 'developer1', timestamp: Date.now() - 3600000 },
+  { type: 'PullRequestEvent', repo: 'kubestellar/console', actor: 'developer2', timestamp: Date.now() - 7200000 },
+  { type: 'IssuesEvent', repo: 'kubestellar/kubestellar', actor: 'contributor', timestamp: Date.now() - 10800000 },
+]
+
+// RSS feed demo data
+const DEMO_RSS_FEED = [
+  { title: 'Kubernetes 1.30 Released', source: 'k8s.io', pubDate: Date.now() - 86400000 },
+  { title: 'New CNCF Project Announcement', source: 'cncf.io', pubDate: Date.now() - 172800000 },
+  { title: 'Cloud Native Best Practices', source: 'blog.k8s.io', pubDate: Date.now() - 259200000 },
+]
+
+// Kubecost overview demo data (chart/donut)
+const DEMO_KUBECOST_OVERVIEW = {
+  totalCost: 12500,
+  breakdown: [
+    { category: 'Compute', cost: 7500 },
+    { category: 'Storage', cost: 2500 },
+    { category: 'Network', cost: 1500 },
+    { category: 'Other', cost: 1000 },
+  ],
+}
+
+// OpenCost overview demo data
+const DEMO_OPENCOST_OVERVIEW = {
+  totalCost: 8500,
+  breakdown: [
+    { category: 'CPU', cost: 4500 },
+    { category: 'Memory', cost: 2500 },
+    { category: 'Storage', cost: 1000 },
+    { category: 'GPU', cost: 500 },
+  ],
+}
+
+// Cluster costs demo data
+const DEMO_CLUSTER_COSTS = [
+  { cluster: 'prod-east', dailyCost: 450, monthlyCost: 13500, trend: 'up' },
+  { cluster: 'staging', dailyCost: 120, monthlyCost: 3600, trend: 'stable' },
+  { cluster: 'dev', dailyCost: 80, monthlyCost: 2400, trend: 'down' },
+]
+
+// ============================================================================
+// Filtered event hooks
+// These provide pre-filtered event data for specific card types
+// ============================================================================
+
+function useWarningEvents(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useCachedEvents(cluster, namespace)
+
+  // Filter to only warning events
+  const warningEvents = useMemo(() => {
+    if (!result.data) return []
+    return result.data.filter(e => e.type === 'Warning')
+  }, [result.data])
+
+  return {
+    data: warningEvents,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: () => { result.refetch() },
+  }
+}
+
+function useRecentEvents(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useCachedEvents(cluster, namespace)
+
+  // Filter to events within the last hour
+  const recentEvents = useMemo(() => {
+    if (!result.data) return []
+    const oneHourAgo = Date.now() - 60 * 60 * 1000
+    return result.data.filter(e => {
+      if (!e.lastSeen) return false
+      return new Date(e.lastSeen).getTime() >= oneHourAgo
+    })
+  }, [result.data])
+
+  return {
+    data: recentEvents,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: () => { result.refetch() },
+  }
+}
+
+// Demo hook factories
+function useClusterMetrics() {
+  return useDemoDataHook(DEMO_CLUSTER_METRICS)
+}
+
+function useResourceUsage() {
+  return useDemoDataHook(DEMO_RESOURCE_USAGE)
+}
+
+function useEventsTimeline() {
+  return useDemoDataHook(DEMO_EVENTS_TIMELINE)
+}
+
+function useSecurityIssues() {
+  return useDemoDataHook(DEMO_SECURITY_ISSUES)
+}
+
+function useActiveAlerts() {
+  return useDemoDataHook(DEMO_ACTIVE_ALERTS)
+}
+
+function useStorageOverview() {
+  return useDemoDataHook([DEMO_STORAGE_OVERVIEW])
+}
+
+function useNetworkOverview() {
+  return useDemoDataHook([DEMO_NETWORK_OVERVIEW])
+}
+
+function useTopPods() {
+  return useDemoDataHook(DEMO_TOP_PODS)
+}
+
+function useGitOpsDrift() {
+  return useDemoDataHook(DEMO_GITOPS_DRIFT)
+}
+
+function usePodHealthTrend() {
+  return useDemoDataHook(DEMO_POD_HEALTH_TREND)
+}
+
+function useResourceTrend() {
+  return useDemoDataHook(DEMO_RESOURCE_TREND)
+}
+
+function useComputeOverview() {
+  return useDemoDataHook([DEMO_COMPUTE_OVERVIEW])
+}
+
+// ============================================================================
+// Batch 4 demo hooks - ArgoCD, Prow, GPU, ML, Policy cards
+// ============================================================================
+
+function useArgoCDApplications() {
+  return useDemoDataHook(DEMO_ARGOCD_APPLICATIONS)
+}
+
+function useGPUInventory() {
+  return useDemoDataHook(DEMO_GPU_INVENTORY)
+}
+
+function useProwJobs() {
+  return useDemoDataHook(DEMO_PROW_JOBS)
+}
+
+function useMLJobs() {
+  return useDemoDataHook(DEMO_ML_JOBS)
+}
+
+function useMLNotebooks() {
+  return useDemoDataHook(DEMO_ML_NOTEBOOKS)
+}
+
+function useOPAPolicies() {
+  return useDemoDataHook(DEMO_OPA_POLICIES)
+}
+
+function useKyvernoPolicies() {
+  return useDemoDataHook(DEMO_KYVERNO_POLICIES)
+}
+
+function useAlertRules() {
+  return useDemoDataHook(DEMO_ALERT_RULES)
+}
+
+function useChartVersions() {
+  return useDemoDataHook(DEMO_CHART_VERSIONS)
+}
+
+function useCRDHealth() {
+  return useDemoDataHook(DEMO_CRD_HEALTH)
+}
+
+function useComplianceScore() {
+  return useDemoDataHook([DEMO_COMPLIANCE_SCORE])
+}
+
+function useNamespaceEvents(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useCachedEvents(cluster, namespace)
+
+  // Filter to specific namespace if provided
+  const namespaceEvents = useMemo(() => {
+    if (!result.data) return []
+    if (!namespace) return result.data.slice(0, 20)
+    return result.data.filter(e => e.namespace === namespace)
+  }, [result.data, namespace])
+
+  return {
+    data: namespaceEvents.length > 0 ? namespaceEvents : DEMO_NAMESPACE_EVENTS,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: () => { result.refetch() },
+  }
+}
+
+function useGPUOverview() {
+  return useDemoDataHook([DEMO_GPU_OVERVIEW])
+}
+
+function useGPUWorkloads() {
+  return useDemoDataHook(DEMO_GPU_WORKLOADS)
+}
+
+function useDeploymentProgress() {
+  return useDemoDataHook(DEMO_DEPLOYMENT_PROGRESS)
+}
+
+// ============================================================================
+// Batch 5 demo hooks - GitOps, Security, Status cards
+// ============================================================================
+
+function useArgoCDHealth() {
+  return useDemoDataHook([DEMO_ARGOCD_HEALTH])
+}
+
+function useArgoCDSyncStatus() {
+  return useDemoDataHook([DEMO_ARGOCD_SYNC_STATUS])
+}
+
+function useGatewayStatus() {
+  return useDemoDataHook(DEMO_GATEWAY_STATUS)
+}
+
+function useKustomizationStatus() {
+  return useDemoDataHook(DEMO_KUSTOMIZATION_STATUS)
+}
+
+function useProviderHealth() {
+  return useDemoDataHook(DEMO_PROVIDER_HEALTH)
+}
+
+function useUpgradeStatus() {
+  return useDemoDataHook(DEMO_UPGRADE_STATUS)
+}
+
+function useProwStatus() {
+  return useDemoDataHook([DEMO_PROW_STATUS])
+}
+
+function useProwHistory() {
+  return useDemoDataHook(DEMO_PROW_HISTORY)
+}
+
+function useHelmHistory() {
+  return useDemoDataHook(DEMO_HELM_HISTORY)
+}
+
+function useExternalSecrets() {
+  return useDemoDataHook([DEMO_EXTERNAL_SECRETS])
+}
+
+function useCertManager() {
+  return useDemoDataHook([DEMO_CERT_MANAGER])
+}
+
+function useVaultSecrets() {
+  return useDemoDataHook(DEMO_VAULT_SECRETS)
+}
+
+function useFalcoAlerts() {
+  return useDemoDataHook(DEMO_FALCO_ALERTS)
+}
+
+function useKubescapeScan() {
+  return useDemoDataHook([DEMO_KUBESCAPE_SCAN])
+}
+
+function useTrivyScan() {
+  return useDemoDataHook([DEMO_TRIVY_SCAN])
+}
+
+function useEventSummary() {
+  return useDemoDataHook([DEMO_EVENT_SUMMARY])
+}
+
+function useAppStatus() {
+  return useDemoDataHook(DEMO_APP_STATUS)
+}
+
+function useGPUStatus() {
+  return useDemoDataHook([DEMO_GPU_STATUS])
+}
+
+function useGPUUtilization() {
+  return useDemoDataHook(DEMO_GPU_UTILIZATION)
+}
+
+function useGPUUsageTrend() {
+  return useDemoDataHook(DEMO_GPU_USAGE_TREND)
+}
+
+function usePolicyViolations() {
+  return useDemoDataHook(DEMO_POLICY_VIOLATIONS)
+}
+
+function useNamespaceOverview() {
+  return useDemoDataHook([DEMO_NAMESPACE_OVERVIEW])
+}
+
+function useNamespaceQuotas() {
+  return useDemoDataHook(DEMO_NAMESPACE_QUOTAS)
+}
+
+function useNamespaceRBAC() {
+  return useDemoDataHook(DEMO_NAMESPACE_RBAC)
+}
+
+function useResourceCapacity() {
+  return useDemoDataHook([DEMO_RESOURCE_CAPACITY])
+}
+
+// ============================================================================
+// Batch 6 demo hooks - Remaining compatible cards
+// ============================================================================
+
+function useGithubActivity() {
+  return useDemoDataHook(DEMO_GITHUB_ACTIVITY)
+}
+
+function useRSSFeed() {
+  return useDemoDataHook(DEMO_RSS_FEED)
+}
+
+function useKubecostOverview() {
+  return useDemoDataHook([DEMO_KUBECOST_OVERVIEW])
+}
+
+function useOpencostOverview() {
+  return useDemoDataHook([DEMO_OPENCOST_OVERVIEW])
+}
+
+function useClusterCosts() {
+  return useDemoDataHook(DEMO_CLUSTER_COSTS)
+}
+
+// ============================================================================
+// Register all data hooks for use in unified cards
+// Call this once at application startup
+// ============================================================================
+
+export function registerUnifiedHooks(): void {
+  // Real data hooks (wrapped to match unified interface)
+  registerDataHook('useCachedPodIssues', useUnifiedPodIssues)
+  registerDataHook('useCachedEvents', useUnifiedEvents)
+  registerDataHook('useCachedDeployments', useUnifiedDeployments)
+  registerDataHook('useClusters', useUnifiedClusters)
+  registerDataHook('usePVCs', useUnifiedPVCs)
+  registerDataHook('useServices', useUnifiedServices)
+  registerDataHook('useCachedDeploymentIssues', useUnifiedDeploymentIssues)
+  registerDataHook('useOperators', useUnifiedOperators)
+  registerDataHook('useHelmReleases', useUnifiedHelmReleases)
+  registerDataHook('useConfigMaps', useUnifiedConfigMaps)
+  registerDataHook('useSecrets', useUnifiedSecrets)
+  registerDataHook('useIngresses', useUnifiedIngresses)
+  registerDataHook('useNodes', useUnifiedNodes)
+  registerDataHook('useJobs', useUnifiedJobs)
+  registerDataHook('useCronJobs', useUnifiedCronJobs)
+  registerDataHook('useStatefulSets', useUnifiedStatefulSets)
+  registerDataHook('useDaemonSets', useUnifiedDaemonSets)
+  registerDataHook('useHPAs', useUnifiedHPAs)
+  registerDataHook('useReplicaSets', useUnifiedReplicaSets)
+  registerDataHook('usePVs', useUnifiedPVs)
+  registerDataHook('useResourceQuotas', useUnifiedResourceQuotas)
+  registerDataHook('useLimitRanges', useUnifiedLimitRanges)
+  registerDataHook('useNetworkPolicies', useUnifiedNetworkPolicies)
+  registerDataHook('useNamespaces', useUnifiedNamespaces)
+  registerDataHook('useOperatorSubscriptions', useUnifiedOperatorSubscriptions)
+  registerDataHook('useServiceAccounts', useUnifiedServiceAccounts)
+  registerDataHook('useK8sRoles', useUnifiedK8sRoles)
+  registerDataHook('useK8sRoleBindings', useUnifiedK8sRoleBindings)
+  registerDataHook('useServiceExports', useUnifiedServiceExports)
+  registerDataHook('useServiceImports', useUnifiedServiceImports)
+
+  // Filtered event hooks
+  registerDataHook('useWarningEvents', useWarningEvents)
+  registerDataHook('useRecentEvents', useRecentEvents)
+
+  // Demo data hooks for cards without real data sources yet
+  registerDataHook('useCachedClusterMetrics', useClusterMetrics)
+  registerDataHook('useCachedResourceUsage', useResourceUsage)
+  registerDataHook('useCachedEventsTimeline', useEventsTimeline)
+  registerDataHook('useSecurityIssues', useSecurityIssues)
+  registerDataHook('useActiveAlerts', useActiveAlerts)
+  registerDataHook('useStorageOverview', useStorageOverview)
+  registerDataHook('useNetworkOverview', useNetworkOverview)
+  registerDataHook('useTopPods', useTopPods)
+  registerDataHook('useGitOpsDrift', useGitOpsDrift)
+  registerDataHook('usePodHealthTrend', usePodHealthTrend)
+  registerDataHook('useResourceTrend', useResourceTrend)
+  registerDataHook('useComputeOverview', useComputeOverview)
+
+  // Batch 4 - ArgoCD, Prow, GPU, ML, Policy cards
+  registerDataHook('useArgoCDApplications', useArgoCDApplications)
+  registerDataHook('useGPUInventory', useGPUInventory)
+  registerDataHook('useProwJobs', useProwJobs)
+  registerDataHook('useMLJobs', useMLJobs)
+  registerDataHook('useMLNotebooks', useMLNotebooks)
+  registerDataHook('useOPAPolicies', useOPAPolicies)
+  registerDataHook('useKyvernoPolicies', useKyvernoPolicies)
+  registerDataHook('useAlertRules', useAlertRules)
+  registerDataHook('useChartVersions', useChartVersions)
+  registerDataHook('useCRDHealth', useCRDHealth)
+  registerDataHook('useComplianceScore', useComplianceScore)
+  registerDataHook('useNamespaceEvents', useNamespaceEvents)
+  registerDataHook('useGPUOverview', useGPUOverview)
+  registerDataHook('useGPUWorkloads', useGPUWorkloads)
+  registerDataHook('useDeploymentProgress', useDeploymentProgress)
+
+  // Batch 5 - GitOps, Security, Status cards
+  registerDataHook('useArgoCDHealth', useArgoCDHealth)
+  registerDataHook('useArgoCDSyncStatus', useArgoCDSyncStatus)
+  registerDataHook('useGatewayStatus', useGatewayStatus)
+  registerDataHook('useKustomizationStatus', useKustomizationStatus)
+  registerDataHook('useProviderHealth', useProviderHealth)
+  registerDataHook('useUpgradeStatus', useUpgradeStatus)
+  registerDataHook('useProwStatus', useProwStatus)
+  registerDataHook('useProwHistory', useProwHistory)
+  registerDataHook('useHelmHistory', useHelmHistory)
+  registerDataHook('useExternalSecrets', useExternalSecrets)
+  registerDataHook('useCertManager', useCertManager)
+  registerDataHook('useVaultSecrets', useVaultSecrets)
+  registerDataHook('useFalcoAlerts', useFalcoAlerts)
+  registerDataHook('useKubescapeScan', useKubescapeScan)
+  registerDataHook('useTrivyScan', useTrivyScan)
+  registerDataHook('useEventSummary', useEventSummary)
+  registerDataHook('useAppStatus', useAppStatus)
+  registerDataHook('useGPUStatus', useGPUStatus)
+  registerDataHook('useGPUUtilization', useGPUUtilization)
+  registerDataHook('useGPUUsageTrend', useGPUUsageTrend)
+  registerDataHook('usePolicyViolations', usePolicyViolations)
+  registerDataHook('useNamespaceOverview', useNamespaceOverview)
+  registerDataHook('useNamespaceQuotas', useNamespaceQuotas)
+  registerDataHook('useNamespaceRBAC', useNamespaceRBAC)
+  registerDataHook('useResourceCapacity', useResourceCapacity)
+
+  // Batch 6 - Remaining compatible cards
+  registerDataHook('useGithubActivity', useGithubActivity)
+  registerDataHook('useRSSFeed', useRSSFeed)
+  registerDataHook('useKubecostOverview', useKubecostOverview)
+  registerDataHook('useOpencostOverview', useOpencostOverview)
+  registerDataHook('useClusterCosts', useClusterCosts)
+}
+
+// Auto-register when this module is imported
+registerUnifiedHooks()

--- a/web/src/lib/unified/stats/UnifiedStatBlock.tsx
+++ b/web/src/lib/unified/stats/UnifiedStatBlock.tsx
@@ -1,0 +1,202 @@
+/**
+ * UnifiedStatBlock - Single stat block component
+ *
+ * Renders a stat from configuration, automatically resolving values
+ * from the provided data source.
+ */
+
+import { useMemo } from 'react'
+import {
+  Server, CheckCircle2, XCircle, WifiOff, Box, Cpu, MemoryStick, HardDrive, Zap, Layers,
+  FolderOpen, AlertCircle, AlertTriangle, AlertOctagon, Package, Ship, Settings, Clock,
+  MoreHorizontal, Database, Workflow, Globe, Network, ArrowRightLeft, CircleDot,
+  ShieldAlert, ShieldOff, User, Info, Percent, ClipboardList, Sparkles, Activity,
+  List, DollarSign, FlaskConical, FolderTree, Bell, RefreshCw, ArrowUpCircle,
+  Newspaper, FileCode, Lock, Unlock, UserCheck, FileText, Calendar, CreditCard,
+  Heart, Shield, ShieldCheck,
+} from 'lucide-react'
+import type { UnifiedStatBlockProps, StatBlockValue } from '../types'
+import { resolveStatValue } from './valueResolvers'
+
+// Icon mapping for dynamic rendering
+const ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
+  Server, CheckCircle2, XCircle, WifiOff, Box, Cpu, MemoryStick, HardDrive, Zap, Layers,
+  FolderOpen, AlertCircle, AlertTriangle, AlertOctagon, Package, Ship, Settings, Clock,
+  MoreHorizontal, Database, Workflow, Globe, Network, ArrowRightLeft, CircleDot,
+  ShieldAlert, ShieldOff, User, Info, Percent, ClipboardList, Sparkles, Activity,
+  List, DollarSign, FlaskConical, FolderTree, Bell, RefreshCw, ArrowUpCircle,
+  Newspaper, FileCode, Lock, Unlock, UserCheck, FileText, Calendar, CreditCard,
+  Heart, Shield, ShieldCheck,
+}
+
+// Color mapping for icons
+const ICON_COLORS: Record<string, string> = {
+  purple: 'text-purple-400',
+  green: 'text-green-400',
+  orange: 'text-orange-400',
+  yellow: 'text-yellow-400',
+  cyan: 'text-cyan-400',
+  blue: 'text-blue-400',
+  red: 'text-red-400',
+  gray: 'text-gray-400',
+  indigo: 'text-indigo-400',
+}
+
+// Value color mapping based on stat ID
+const VALUE_COLORS: Record<string, string> = {
+  healthy: 'text-green-400',
+  passing: 'text-green-400',
+  deployed: 'text-green-400',
+  bound: 'text-green-400',
+  normal: 'text-blue-400',
+  unhealthy: 'text-orange-400',
+  warning: 'text-yellow-400',
+  warnings: 'text-yellow-400',
+  pending: 'text-yellow-400',
+  unreachable: 'text-yellow-400',
+  critical: 'text-red-400',
+  failed: 'text-red-400',
+  failing: 'text-red-400',
+  errors: 'text-red-400',
+  issues: 'text-red-400',
+  high: 'text-orange-400',
+  medium: 'text-yellow-400',
+  low: 'text-blue-400',
+  privileged: 'text-red-400',
+  root: 'text-orange-400',
+}
+
+/**
+ * UnifiedStatBlock - Renders a single stat from config
+ */
+export function UnifiedStatBlock({
+  config,
+  data,
+  getValue,
+  isLoading = false,
+}: UnifiedStatBlockProps) {
+  // Resolve the value
+  const resolvedValue = useMemo((): StatBlockValue => {
+    // If custom getValue is provided, use it
+    if (getValue) {
+      return getValue()
+    }
+
+    // Otherwise resolve from config
+    const resolved = resolveStatValue(config.valueSource, data, config.format)
+
+    return {
+      value: resolved.value,
+      sublabel: config.sublabelField
+        ? resolved.sublabel
+        : undefined,
+      isDemo: resolved.isDemo,
+      isClickable: !!config.onClick,
+    }
+  }, [config, data, getValue])
+
+  // Get components
+  const IconComponent = ICONS[config.icon] || Server
+  const iconColor = ICON_COLORS[config.color] || 'text-foreground'
+  const valueColor = VALUE_COLORS[config.id] || 'text-foreground'
+
+  // Determine clickable state
+  const isClickable = resolvedValue.isClickable !== false && !!config.onClick
+  const isDemo = resolvedValue.isDemo === true
+  const hasData = resolvedValue.value !== undefined && resolvedValue.value !== '-'
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="glass p-4 rounded-lg">
+        <div className="flex items-center gap-2 mb-2">
+          <div className="w-5 h-5 bg-gray-800 rounded-full animate-pulse" />
+          <div className="h-4 bg-gray-800 rounded w-20 animate-pulse" />
+        </div>
+        <div className="h-9 bg-gray-800 rounded w-16 animate-pulse mb-1" />
+        <div className="h-3 bg-gray-800 rounded w-24 animate-pulse" />
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className={`
+        relative glass p-4 rounded-lg transition-colors
+        ${isClickable ? 'cursor-pointer hover:bg-secondary/50' : ''}
+        ${isDemo ? 'border border-yellow-500/30 bg-yellow-500/5 shadow-[0_0_12px_rgba(234,179,8,0.15)]' : ''}
+      `}
+      onClick={() => {
+        if (isClickable && config.onClick) {
+          // Handle click action based on type
+          handleStatClick(config.onClick)
+        }
+      }}
+      title={config.tooltip}
+    >
+      {/* Demo indicator */}
+      {isDemo && (
+        <span className="absolute -top-1 -right-1" title="Demo data">
+          <FlaskConical className="w-3.5 h-3.5 text-yellow-400/50" />
+        </span>
+      )}
+
+      {/* Header with icon and name */}
+      <div className="flex items-center gap-2 mb-2">
+        <IconComponent className={`w-5 h-5 shrink-0 ${iconColor}`} />
+        <span className="text-sm text-muted-foreground truncate">{config.name}</span>
+      </div>
+
+      {/* Value */}
+      <div className={`text-3xl font-bold ${hasData ? valueColor : 'text-muted-foreground'}`}>
+        {hasData ? resolvedValue.value : '-'}
+      </div>
+
+      {/* Sublabel */}
+      {resolvedValue.sublabel && (
+        <div className="text-xs text-muted-foreground">{resolvedValue.sublabel}</div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Handle stat click action
+ */
+function handleStatClick(action: NonNullable<UnifiedStatBlockProps['config']['onClick']>) {
+  switch (action.type) {
+    case 'drill':
+      // Dispatch drill-down event
+      window.dispatchEvent(
+        new CustomEvent('stat-drill', {
+          detail: { target: action.target, params: action.params },
+        })
+      )
+      break
+
+    case 'filter':
+      // Dispatch filter event
+      window.dispatchEvent(
+        new CustomEvent('stat-filter', {
+          detail: { field: action.target, params: action.params },
+        })
+      )
+      break
+
+    case 'navigate':
+      // Navigate to route
+      window.location.hash = action.target
+      break
+
+    case 'callback':
+      // Dispatch callback event
+      window.dispatchEvent(
+        new CustomEvent('stat-callback', {
+          detail: { name: action.target, params: action.params },
+        })
+      )
+      break
+  }
+}
+
+export default UnifiedStatBlock

--- a/web/src/lib/unified/stats/UnifiedStatsSection.tsx
+++ b/web/src/lib/unified/stats/UnifiedStatsSection.tsx
@@ -1,0 +1,303 @@
+/**
+ * UnifiedStatsSection - Container for multiple stat blocks
+ *
+ * Renders a configurable grid of stat blocks with optional
+ * collapsing, configuration modal, and last updated timestamp.
+ */
+
+import { useState, useMemo, useCallback } from 'react'
+import { Activity, ChevronDown, ChevronRight, Settings, FlaskConical } from 'lucide-react'
+import type { UnifiedStatsSectionProps, UnifiedStatBlockConfig, StatBlockValue } from '../types'
+import { UnifiedStatBlock } from './UnifiedStatBlock'
+import { resolveStatValue } from './valueResolvers'
+
+/**
+ * UnifiedStatsSection - Renders a section of stat blocks from config
+ */
+export function UnifiedStatsSection({
+  config,
+  data,
+  getStatValue,
+  hasData = true,
+  isLoading = false,
+  lastUpdated,
+  className = '',
+}: UnifiedStatsSectionProps) {
+  // Collapsed state with localStorage persistence
+  const storageKey = config.storageKey || `kubestellar-${config.type}-stats-collapsed`
+  const [isExpanded, setIsExpanded] = useState(() => {
+    try {
+      const saved = localStorage.getItem(storageKey)
+      return saved !== null ? JSON.parse(saved) : !config.defaultCollapsed
+    } catch {
+      return !config.defaultCollapsed
+    }
+  })
+
+  // Configuration modal state
+  const [showConfig, setShowConfig] = useState(false)
+  const [customBlocks, setCustomBlocks] = useState<UnifiedStatBlockConfig[] | null>(null)
+
+  // Determine visible blocks
+  const visibleBlocks = useMemo(() => {
+    const blocks = customBlocks || config.blocks
+    return blocks.filter((block) => block.visible !== false)
+  }, [config.blocks, customBlocks])
+
+  // Check if any block uses demo data
+  const isDemoData = useMemo(() => {
+    if (!data) return false
+    return visibleBlocks.some((block) => {
+      const resolved = resolveStatValue(block.valueSource, data, block.format)
+      return resolved.isDemo
+    })
+  }, [visibleBlocks, data])
+
+  // Toggle collapsed state
+  const toggleExpanded = useCallback(() => {
+    const newValue = !isExpanded
+    setIsExpanded(newValue)
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(!newValue))
+    } catch {
+      // Ignore storage errors
+    }
+  }, [isExpanded, storageKey])
+
+  // Get value for a block
+  const getBlockValue = useCallback(
+    (block: UnifiedStatBlockConfig): (() => StatBlockValue) | undefined => {
+      if (getStatValue) {
+        return () => getStatValue(block.id)
+      }
+      return undefined
+    },
+    [getStatValue]
+  )
+
+  // Save custom block configuration
+  const saveBlocks = useCallback((blocks: UnifiedStatBlockConfig[]) => {
+    setCustomBlocks(blocks)
+    // Persist to localStorage
+    try {
+      localStorage.setItem(`${storageKey}-blocks`, JSON.stringify(blocks))
+    } catch {
+      // Ignore storage errors
+    }
+  }, [storageKey])
+
+  // Load custom blocks on mount
+  useMemo(() => {
+    try {
+      const saved = localStorage.getItem(`${storageKey}-blocks`)
+      if (saved) {
+        setCustomBlocks(JSON.parse(saved))
+      }
+    } catch {
+      // Ignore storage errors
+    }
+  }, [storageKey])
+
+  // Dynamic grid columns based on visible blocks
+  const gridCols = useMemo(() => {
+    const count = visibleBlocks.length
+
+    // Use custom grid config if provided
+    if (config.grid?.responsive) {
+      const { sm = 2, md = 4, lg = count } = config.grid.responsive
+      return `grid-cols-${sm} md:grid-cols-${md} lg:grid-cols-${lg}`
+    }
+
+    // Default responsive behavior
+    if (count <= 4) return 'grid-cols-2 md:grid-cols-4'
+    if (count <= 5) return 'grid-cols-2 md:grid-cols-5'
+    if (count <= 6) return 'grid-cols-2 md:grid-cols-3 lg:grid-cols-6'
+    if (count <= 8) return 'grid-cols-2 md:grid-cols-4 lg:grid-cols-8'
+    return 'grid-cols-2 md:grid-cols-5 lg:grid-cols-10'
+  }, [visibleBlocks.length, config.grid])
+
+  const collapsible = config.collapsible !== false
+
+  return (
+    <div className={`mb-6 ${className}`}>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-3">
+          {collapsible ? (
+            <button
+              onClick={toggleExpanded}
+              className="flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Activity className="w-4 h-4" />
+              <span>{config.title || 'Stats Overview'}</span>
+              {isExpanded ? (
+                <ChevronDown className="w-4 h-4" />
+              ) : (
+                <ChevronRight className="w-4 h-4" />
+              )}
+            </button>
+          ) : (
+            <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+              <Activity className="w-4 h-4" />
+              <span>{config.title || 'Stats Overview'}</span>
+            </div>
+          )}
+
+          {/* Demo indicator */}
+          {isDemoData && (
+            <span className="flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-yellow-500/20 text-yellow-400 border border-yellow-500/30">
+              <FlaskConical className="w-2.5 h-2.5" />
+              Demo
+            </span>
+          )}
+
+          {/* Last updated */}
+          {lastUpdated && (
+            <span className="text-xs text-muted-foreground/60">
+              Updated {lastUpdated.toLocaleTimeString()}
+            </span>
+          )}
+        </div>
+
+        {/* Configure button */}
+        {config.showConfigButton !== false && isExpanded && (
+          <button
+            onClick={() => setShowConfig(true)}
+            className="p-1 text-muted-foreground hover:text-foreground hover:bg-secondary rounded transition-colors"
+            title="Configure stats"
+          >
+            <Settings className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+
+      {/* Stats grid */}
+      {(!collapsible || isExpanded) && (
+        <div className={`grid ${gridCols} gap-4`}>
+          {visibleBlocks.map((block) => (
+            <UnifiedStatBlock
+              key={block.id}
+              config={block}
+              data={hasData ? data : undefined}
+              getValue={getBlockValue(block)}
+              isLoading={isLoading}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Configuration modal placeholder */}
+      {showConfig && (
+        <StatsConfigModal
+          isOpen={showConfig}
+          onClose={() => setShowConfig(false)}
+          blocks={customBlocks || config.blocks}
+          onSave={saveBlocks}
+          defaultBlocks={config.blocks}
+          title={`Configure ${config.title || 'Stats'}`}
+        />
+      )}
+    </div>
+  )
+}
+
+/**
+ * Simple configuration modal for stat blocks
+ */
+interface StatsConfigModalProps {
+  isOpen: boolean
+  onClose: () => void
+  blocks: UnifiedStatBlockConfig[]
+  onSave: (blocks: UnifiedStatBlockConfig[]) => void
+  defaultBlocks: UnifiedStatBlockConfig[]
+  title: string
+}
+
+function StatsConfigModal({
+  isOpen,
+  onClose,
+  blocks,
+  onSave,
+  defaultBlocks,
+  title,
+}: StatsConfigModalProps) {
+  const [localBlocks, setLocalBlocks] = useState(blocks)
+
+  if (!isOpen) return null
+
+  const toggleVisibility = (blockId: string) => {
+    setLocalBlocks((prev) =>
+      prev.map((block) =>
+        block.id === blockId ? { ...block, visible: !block.visible } : block
+      )
+    )
+  }
+
+  const handleSave = () => {
+    onSave(localBlocks)
+    onClose()
+  }
+
+  const handleReset = () => {
+    setLocalBlocks(defaultBlocks)
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Modal */}
+      <div className="relative glass rounded-lg p-6 max-w-md w-full mx-4 max-h-[80vh] overflow-y-auto">
+        <h2 className="text-lg font-semibold mb-4">{title}</h2>
+
+        {/* Block list */}
+        <div className="space-y-2 mb-6">
+          {localBlocks.map((block) => (
+            <label
+              key={block.id}
+              className="flex items-center gap-3 p-2 rounded hover:bg-secondary/50 cursor-pointer"
+            >
+              <input
+                type="checkbox"
+                checked={block.visible !== false}
+                onChange={() => toggleVisibility(block.id)}
+                className="w-4 h-4 rounded"
+              />
+              <span className="text-sm">{block.name}</span>
+            </label>
+          ))}
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center justify-between">
+          <button
+            onClick={handleReset}
+            className="text-sm text-muted-foreground hover:text-foreground"
+          >
+            Reset to default
+          </button>
+          <div className="flex gap-2">
+            <button
+              onClick={onClose}
+              className="px-3 py-1.5 text-sm rounded bg-secondary hover:bg-secondary/80"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSave}
+              className="px-3 py-1.5 text-sm rounded bg-primary text-primary-foreground hover:bg-primary/90"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default UnifiedStatsSection

--- a/web/src/lib/unified/stats/configs.ts
+++ b/web/src/lib/unified/stats/configs.ts
@@ -1,0 +1,211 @@
+/**
+ * Unified Stats Section Configs
+ *
+ * Converts legacy StatsBlockDefinitions to UnifiedStatsSectionConfig format.
+ * These configs work with UnifiedStatsSection using the getStatValue callback.
+ */
+
+import type { UnifiedStatsSectionConfig, UnifiedStatBlockConfig, StatBlockColor } from '../types'
+import {
+  CLUSTERS_STAT_BLOCKS,
+  WORKLOADS_STAT_BLOCKS,
+  PODS_STAT_BLOCKS,
+  GITOPS_STAT_BLOCKS,
+  STORAGE_STAT_BLOCKS,
+  NETWORK_STAT_BLOCKS,
+  SECURITY_STAT_BLOCKS,
+  COMPLIANCE_STAT_BLOCKS,
+  DATA_COMPLIANCE_STAT_BLOCKS,
+  COMPUTE_STAT_BLOCKS,
+  EVENTS_STAT_BLOCKS,
+  COST_STAT_BLOCKS,
+  ALERTS_STAT_BLOCKS,
+  DASHBOARD_STAT_BLOCKS,
+  OPERATORS_STAT_BLOCKS,
+  DEPLOY_STAT_BLOCKS,
+  StatBlockConfig,
+} from '../../../components/ui/StatsBlockDefinitions'
+
+/**
+ * Convert legacy StatBlockConfig to UnifiedStatBlockConfig
+ */
+function convertBlock(block: StatBlockConfig, order: number): UnifiedStatBlockConfig {
+  return {
+    id: block.id,
+    name: block.name,
+    icon: block.icon,
+    color: block.color as StatBlockColor,
+    visible: block.visible,
+    order,
+    // Use callback value source - actual value comes from getStatValue
+    valueSource: { type: 'hook', hookName: 'getStatValue', field: block.id },
+  }
+}
+
+/**
+ * Convert legacy stat blocks array to unified config
+ */
+function createConfig(
+  type: string,
+  title: string,
+  blocks: StatBlockConfig[],
+  options?: Partial<UnifiedStatsSectionConfig>
+): UnifiedStatsSectionConfig {
+  return {
+    type,
+    title,
+    blocks: blocks.map((b, i) => convertBlock(b, i)),
+    collapsible: true,
+    showConfigButton: true,
+    storageKey: `kubestellar-${type}-stats-collapsed`,
+    ...options,
+  }
+}
+
+// ============================================================================
+// Dashboard-specific configs
+// ============================================================================
+
+export const CLUSTERS_STATS_CONFIG = createConfig(
+  'clusters',
+  'Stats Overview',
+  CLUSTERS_STAT_BLOCKS
+)
+
+export const WORKLOADS_STATS_CONFIG = createConfig(
+  'workloads',
+  'Stats Overview',
+  WORKLOADS_STAT_BLOCKS
+)
+
+export const PODS_STATS_CONFIG = createConfig(
+  'pods',
+  'Stats Overview',
+  PODS_STAT_BLOCKS
+)
+
+export const GITOPS_STATS_CONFIG = createConfig(
+  'gitops',
+  'Stats Overview',
+  GITOPS_STAT_BLOCKS
+)
+
+export const STORAGE_STATS_CONFIG = createConfig(
+  'storage',
+  'Stats Overview',
+  STORAGE_STAT_BLOCKS
+)
+
+export const NETWORK_STATS_CONFIG = createConfig(
+  'network',
+  'Stats Overview',
+  NETWORK_STAT_BLOCKS
+)
+
+export const SECURITY_STATS_CONFIG = createConfig(
+  'security',
+  'Stats Overview',
+  SECURITY_STAT_BLOCKS
+)
+
+export const COMPLIANCE_STATS_CONFIG = createConfig(
+  'compliance',
+  'Stats Overview',
+  COMPLIANCE_STAT_BLOCKS
+)
+
+export const DATA_COMPLIANCE_STATS_CONFIG = createConfig(
+  'data-compliance',
+  'Stats Overview',
+  DATA_COMPLIANCE_STAT_BLOCKS
+)
+
+export const COMPUTE_STATS_CONFIG = createConfig(
+  'compute',
+  'Stats Overview',
+  COMPUTE_STAT_BLOCKS
+)
+
+export const EVENTS_STATS_CONFIG = createConfig(
+  'events',
+  'Stats Overview',
+  EVENTS_STAT_BLOCKS
+)
+
+export const COST_STATS_CONFIG = createConfig(
+  'cost',
+  'Stats Overview',
+  COST_STAT_BLOCKS
+)
+
+export const ALERTS_STATS_CONFIG = createConfig(
+  'alerts',
+  'Stats Overview',
+  ALERTS_STAT_BLOCKS
+)
+
+export const DASHBOARD_STATS_CONFIG = createConfig(
+  'dashboard',
+  'Stats Overview',
+  DASHBOARD_STAT_BLOCKS
+)
+
+export const OPERATORS_STATS_CONFIG = createConfig(
+  'operators',
+  'Stats Overview',
+  OPERATORS_STAT_BLOCKS
+)
+
+export const DEPLOY_STATS_CONFIG = createConfig(
+  'deploy',
+  'Stats Overview',
+  DEPLOY_STAT_BLOCKS
+)
+
+// ============================================================================
+// Config lookup
+// ============================================================================
+
+export type StatsConfigType =
+  | 'clusters'
+  | 'workloads'
+  | 'pods'
+  | 'gitops'
+  | 'storage'
+  | 'network'
+  | 'security'
+  | 'compliance'
+  | 'data-compliance'
+  | 'compute'
+  | 'events'
+  | 'cost'
+  | 'alerts'
+  | 'dashboard'
+  | 'operators'
+  | 'deploy'
+
+const CONFIGS: Record<StatsConfigType, UnifiedStatsSectionConfig> = {
+  clusters: CLUSTERS_STATS_CONFIG,
+  workloads: WORKLOADS_STATS_CONFIG,
+  pods: PODS_STATS_CONFIG,
+  gitops: GITOPS_STATS_CONFIG,
+  storage: STORAGE_STATS_CONFIG,
+  network: NETWORK_STATS_CONFIG,
+  security: SECURITY_STATS_CONFIG,
+  compliance: COMPLIANCE_STATS_CONFIG,
+  'data-compliance': DATA_COMPLIANCE_STATS_CONFIG,
+  compute: COMPUTE_STATS_CONFIG,
+  events: EVENTS_STATS_CONFIG,
+  cost: COST_STATS_CONFIG,
+  alerts: ALERTS_STATS_CONFIG,
+  dashboard: DASHBOARD_STATS_CONFIG,
+  operators: OPERATORS_STATS_CONFIG,
+  deploy: DEPLOY_STATS_CONFIG,
+}
+
+/**
+ * Get unified stats config for a dashboard type
+ */
+export function getUnifiedStatsConfig(type: StatsConfigType): UnifiedStatsSectionConfig {
+  return CONFIGS[type]
+}

--- a/web/src/lib/unified/stats/index.ts
+++ b/web/src/lib/unified/stats/index.ts
@@ -1,0 +1,43 @@
+/**
+ * Unified Stats Components
+ */
+
+export { UnifiedStatBlock } from './UnifiedStatBlock'
+export { UnifiedStatsSection } from './UnifiedStatsSection'
+
+export {
+  resolveStatValue,
+  resolveFieldPath,
+  resolveComputedExpression,
+  resolveAggregate,
+  formatValue,
+  formatNumber,
+  formatBytes,
+  formatCurrency,
+  formatDuration,
+} from './valueResolvers'
+
+export type { ResolvedStatValue } from './valueResolvers'
+
+// Stats configs
+export {
+  getUnifiedStatsConfig,
+  CLUSTERS_STATS_CONFIG,
+  WORKLOADS_STATS_CONFIG,
+  PODS_STATS_CONFIG,
+  GITOPS_STATS_CONFIG,
+  STORAGE_STATS_CONFIG,
+  NETWORK_STATS_CONFIG,
+  SECURITY_STATS_CONFIG,
+  COMPLIANCE_STATS_CONFIG,
+  DATA_COMPLIANCE_STATS_CONFIG,
+  COMPUTE_STATS_CONFIG,
+  EVENTS_STATS_CONFIG,
+  COST_STATS_CONFIG,
+  ALERTS_STATS_CONFIG,
+  DASHBOARD_STATS_CONFIG,
+  OPERATORS_STATS_CONFIG,
+  DEPLOY_STATS_CONFIG,
+} from './configs'
+
+export type { StatsConfigType } from './configs'

--- a/web/src/lib/unified/stats/valueResolvers.ts
+++ b/web/src/lib/unified/stats/valueResolvers.ts
@@ -1,0 +1,379 @@
+/**
+ * Value Resolvers for UnifiedStatBlock
+ *
+ * Resolves stat values from various sources (field path, computed expression,
+ * hook result, or aggregation).
+ */
+
+import type {
+  StatValueSource,
+  StatValueFormat,
+} from '../types'
+
+/**
+ * Resolved stat value with metadata
+ */
+export interface ResolvedStatValue {
+  value: string | number
+  sublabel?: string
+  isDemo?: boolean
+}
+
+/**
+ * Resolve a stat value from data using the configured source
+ */
+export function resolveStatValue(
+  source: StatValueSource,
+  data: unknown,
+  format?: StatValueFormat
+): ResolvedStatValue {
+  let rawValue: unknown
+
+  switch (source.type) {
+    case 'field':
+      rawValue = resolveFieldPath(data, source.path)
+      break
+
+    case 'computed':
+      rawValue = resolveComputedExpression(data, source.expression)
+      break
+
+    case 'hook':
+      // Hook values should be provided via separate mechanism
+      // This is a placeholder - hooks are resolved by the component
+      rawValue = undefined
+      break
+
+    case 'aggregate':
+      rawValue = resolveAggregate(data, source.aggregation, source.field, source.filter)
+      break
+
+    default:
+      rawValue = undefined
+  }
+
+  // Format the value
+  const formattedValue = formatValue(rawValue, format)
+
+  return {
+    value: formattedValue,
+    isDemo: false,
+  }
+}
+
+/**
+ * Resolve a dot-notation field path from data
+ * Example: 'summary.healthyCount' -> data.summary.healthyCount
+ */
+export function resolveFieldPath(data: unknown, path: string): unknown {
+  if (data === null || data === undefined) return undefined
+  if (!path) return data
+
+  const parts = path.split('.')
+  let current: unknown = data
+
+  for (const part of parts) {
+    if (current === null || current === undefined) return undefined
+
+    // Handle array access like 'items[0]'
+    const arrayMatch = part.match(/^(\w+)\[(\d+)\]$/)
+    if (arrayMatch) {
+      const [, key, index] = arrayMatch
+      current = (current as Record<string, unknown>)[key]
+      if (Array.isArray(current)) {
+        current = current[parseInt(index, 10)]
+      } else {
+        return undefined
+      }
+    } else {
+      current = (current as Record<string, unknown>)[part]
+    }
+  }
+
+  return current
+}
+
+/**
+ * Resolve a computed expression
+ *
+ * Supported expressions:
+ * - 'count' - Count array items
+ * - 'sum:field' - Sum a field across array items
+ * - 'avg:field' - Average a field
+ * - 'min:field' - Minimum value
+ * - 'max:field' - Maximum value
+ * - 'filter:condition|count' - Filter then count
+ * - 'filter:condition|sum:field' - Filter then sum
+ * - 'latest:field' - Get last item's field value
+ * - 'first:field' - Get first item's field value
+ */
+export function resolveComputedExpression(data: unknown, expression: string): unknown {
+  if (!Array.isArray(data)) {
+    // If data is an object, try to extract an array field
+    if (typeof data === 'object' && data !== null) {
+      // Look for common array field names
+      const obj = data as Record<string, unknown>
+      const arrayField = obj.items || obj.data || obj.results || obj.list
+      if (Array.isArray(arrayField)) {
+        data = arrayField
+      } else {
+        return undefined
+      }
+    } else {
+      return undefined
+    }
+  }
+
+  const items = data as Record<string, unknown>[]
+
+  // Parse expression
+  const parts = expression.split('|')
+  let currentItems = items
+
+  for (const part of parts) {
+    const [op, arg] = part.split(':')
+
+    switch (op) {
+      case 'count':
+        return currentItems.length
+
+      case 'sum':
+        return currentItems.reduce((acc, item) => {
+          const val = resolveFieldPath(item, arg)
+          return acc + (typeof val === 'number' ? val : 0)
+        }, 0)
+
+      case 'avg': {
+        if (currentItems.length === 0) return 0
+        const sum = currentItems.reduce((acc, item) => {
+          const val = resolveFieldPath(item, arg)
+          return acc + (typeof val === 'number' ? val : 0)
+        }, 0)
+        return sum / currentItems.length
+      }
+
+      case 'min': {
+        if (currentItems.length === 0) return 0
+        return Math.min(
+          ...currentItems.map((item) => {
+            const val = resolveFieldPath(item, arg)
+            return typeof val === 'number' ? val : Infinity
+          })
+        )
+      }
+
+      case 'max': {
+        if (currentItems.length === 0) return 0
+        return Math.max(
+          ...currentItems.map((item) => {
+            const val = resolveFieldPath(item, arg)
+            return typeof val === 'number' ? val : -Infinity
+          })
+        )
+      }
+
+      case 'latest': {
+        if (currentItems.length === 0) return undefined
+        return resolveFieldPath(currentItems[currentItems.length - 1], arg)
+      }
+
+      case 'first': {
+        if (currentItems.length === 0) return undefined
+        return resolveFieldPath(currentItems[0], arg)
+      }
+
+      case 'filter': {
+        // Filter format: 'filter:field=value' or 'filter:field!=value'
+        // or 'filter:field' (truthy check)
+        if (arg.includes('=')) {
+          const [field, expectedValue] = arg.includes('!=')
+            ? arg.split('!=').map((s) => s.trim())
+            : arg.split('=').map((s) => s.trim())
+          const isNegation = arg.includes('!=')
+
+          currentItems = currentItems.filter((item) => {
+            const val = resolveFieldPath(item, field)
+            const matches = String(val) === expectedValue
+            return isNegation ? !matches : matches
+          })
+        } else {
+          // Truthy check
+          currentItems = currentItems.filter((item) => {
+            const val = resolveFieldPath(item, arg)
+            return Boolean(val)
+          })
+        }
+        break
+      }
+
+      default:
+        // Unknown operation
+        break
+    }
+  }
+
+  // If we get here without returning, return the count of remaining items
+  return currentItems.length
+}
+
+/**
+ * Resolve an aggregate operation
+ */
+export function resolveAggregate(
+  data: unknown,
+  aggregation: 'sum' | 'count' | 'avg' | 'min' | 'max',
+  field: string,
+  filter?: string
+): number {
+  if (!Array.isArray(data)) return 0
+
+  let items = data as Record<string, unknown>[]
+
+  // Apply filter if specified
+  if (filter) {
+    const [filterField, filterValue] = filter.split('=')
+    items = items.filter((item) => {
+      const val = resolveFieldPath(item, filterField.trim())
+      return String(val) === filterValue?.trim()
+    })
+  }
+
+  switch (aggregation) {
+    case 'count':
+      return items.length
+
+    case 'sum':
+      return items.reduce((acc, item) => {
+        const val = resolveFieldPath(item, field)
+        return acc + (typeof val === 'number' ? val : 0)
+      }, 0)
+
+    case 'avg': {
+      if (items.length === 0) return 0
+      const sum = items.reduce((acc, item) => {
+        const val = resolveFieldPath(item, field)
+        return acc + (typeof val === 'number' ? val : 0)
+      }, 0)
+      return sum / items.length
+    }
+
+    case 'min': {
+      if (items.length === 0) return 0
+      return Math.min(
+        ...items.map((item) => {
+          const val = resolveFieldPath(item, field)
+          return typeof val === 'number' ? val : Infinity
+        })
+      )
+    }
+
+    case 'max': {
+      if (items.length === 0) return 0
+      return Math.max(
+        ...items.map((item) => {
+          const val = resolveFieldPath(item, field)
+          return typeof val === 'number' ? val : -Infinity
+        })
+      )
+    }
+
+    default:
+      return 0
+  }
+}
+
+/**
+ * Format a value according to the specified format
+ */
+export function formatValue(value: unknown, format?: StatValueFormat): string | number {
+  if (value === null || value === undefined) return '-'
+
+  const numValue = typeof value === 'number' ? value : parseFloat(String(value))
+
+  if (isNaN(numValue)) {
+    // Return as string if not a number
+    return String(value)
+  }
+
+  switch (format) {
+    case 'number':
+      return formatNumber(numValue)
+
+    case 'percentage':
+      return `${Math.round(numValue)}%`
+
+    case 'bytes':
+      return formatBytes(numValue)
+
+    case 'currency':
+      return formatCurrency(numValue)
+
+    case 'duration':
+      return formatDuration(numValue)
+
+    default:
+      // Default: format large numbers nicely
+      if (Number.isInteger(numValue)) {
+        return formatNumber(numValue)
+      }
+      return numValue
+  }
+}
+
+/**
+ * Format a number with K/M/B suffixes
+ */
+export function formatNumber(value: number): string | number {
+  if (Math.abs(value) >= 1_000_000_000) {
+    return `${(value / 1_000_000_000).toFixed(1)}B`
+  }
+  if (Math.abs(value) >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(1)}M`
+  }
+  if (Math.abs(value) >= 1_000) {
+    return `${(value / 1_000).toFixed(1)}K`
+  }
+  return value
+}
+
+/**
+ * Format bytes to human-readable
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B'
+
+  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
+  const exp = Math.floor(Math.log(bytes) / Math.log(1024))
+  const size = bytes / Math.pow(1024, exp)
+
+  return `${size.toFixed(1)} ${units[exp]}`
+}
+
+/**
+ * Format currency
+ */
+export function formatCurrency(value: number): string {
+  if (value >= 1_000_000) {
+    return `$${(value / 1_000_000).toFixed(1)}M`
+  }
+  if (value >= 1_000) {
+    return `$${(value / 1_000).toFixed(1)}K`
+  }
+  return `$${value.toFixed(2)}`
+}
+
+/**
+ * Format duration in seconds to human-readable
+ */
+export function formatDuration(seconds: number): string {
+  if (seconds < 60) {
+    return `${Math.round(seconds)}s`
+  }
+  if (seconds < 3600) {
+    return `${Math.round(seconds / 60)}m`
+  }
+  if (seconds < 86400) {
+    return `${(seconds / 3600).toFixed(1)}h`
+  }
+  return `${(seconds / 86400).toFixed(1)}d`
+}

--- a/web/src/lib/unified/types.ts
+++ b/web/src/lib/unified/types.ts
@@ -1,0 +1,803 @@
+/**
+ * Unified Component Types
+ *
+ * This module provides type definitions for the unified component architecture:
+ * - UnifiedCard: Single component that renders any card type from config
+ * - UnifiedStatBlock: Single component that renders any stat block from config
+ * - UnifiedDashboard: Single component that renders any dashboard from config
+ *
+ * All variations come from configuration, not code branches.
+ */
+
+// Re-export existing types that we're extending
+export type {
+  CardCategory,
+  CardVisualization,
+  CardPlacement,
+  CardStatus,
+} from '../cards/types'
+
+export type {
+  StatBlockColor,
+  StatBlockValue,
+  StatBlockConfig,
+} from '../stats/types'
+
+// ============================================================================
+// UnifiedCard Types
+// ============================================================================
+
+/**
+ * Complete card configuration - drives all card rendering
+ */
+export interface UnifiedCardConfig {
+  /** Unique card type identifier */
+  type: string
+  /** Display title */
+  title: string
+  /** Card category for organization */
+  category: CardCategory
+  /** Description shown in info tooltip */
+  description?: string
+
+  // Appearance
+  /** Icon name from lucide-react */
+  icon?: string
+  /** Icon color class (e.g., 'text-green-400') */
+  iconColor?: string
+  /** Default grid width (3-12 columns) */
+  defaultWidth?: CardWidth
+  /** Default grid height (in rows) */
+  defaultHeight?: number
+
+  // Data
+  /** Data source configuration */
+  dataSource: CardDataSource
+  /** Data transformation after fetching */
+  transform?: CardDataTransform
+
+  // Layout sections
+  /** Inline stats shown at top of card */
+  stats?: CardStatConfig[]
+  /** Filter controls */
+  filters?: CardFilterConfig[]
+  /** Main content area */
+  content: CardContent
+  /** Footer configuration */
+  footer?: CardFooterConfig
+
+  // Interaction
+  /** Drill-down configuration */
+  drillDown?: CardDrillDownConfig
+  /** Empty state configuration */
+  emptyState?: CardEmptyStateConfig
+  /** Loading state configuration */
+  loadingState?: CardLoadingStateConfig
+
+  // Metadata
+  /** Whether card uses demo/mock data */
+  isDemoData?: boolean
+  /** Whether card has live/real-time data */
+  isLive?: boolean
+}
+
+export type CardWidth = 3 | 4 | 5 | 6 | 8 | 12
+
+// ============================================================================
+// Data Source Types (discriminated union)
+// ============================================================================
+
+export type CardDataSource =
+  | CardDataSourceHook
+  | CardDataSourceApi
+  | CardDataSourceStatic
+  | CardDataSourceContext
+
+export interface CardDataSourceHook {
+  type: 'hook'
+  /** Hook name from the hook registry */
+  hook: string
+  /** Parameters to pass to the hook */
+  params?: Record<string, unknown>
+}
+
+export interface CardDataSourceApi {
+  type: 'api'
+  /** API endpoint path */
+  endpoint: string
+  /** HTTP method */
+  method?: 'GET' | 'POST'
+  /** Query parameters */
+  params?: Record<string, unknown>
+  /** Polling interval in ms (0 = no polling) */
+  pollInterval?: number
+}
+
+export interface CardDataSourceStatic {
+  type: 'static'
+  /** Static data array (optional for custom components that don't need data) */
+  data?: unknown[]
+}
+
+export interface CardDataSourceContext {
+  type: 'context'
+  /** Key in React context to read data from */
+  contextKey: string
+}
+
+export interface CardDataTransform {
+  /** Transform function name from registry */
+  fn: string
+  /** Additional parameters */
+  params?: Record<string, unknown>
+}
+
+// ============================================================================
+// Content Types (discriminated union)
+// ============================================================================
+
+export type CardContent =
+  | CardContentList
+  | CardContentTable
+  | CardContentChart
+  | CardContentStatusGrid
+  | CardContentStatsGrid
+  | CardContentCustom
+
+export interface CardContentList {
+  type: 'list'
+  /** Column definitions */
+  columns: CardColumnConfig[]
+  /** Item click behavior */
+  itemClick?: 'drill' | 'expand' | 'select' | 'none'
+  /** Max items per page (enables pagination) */
+  pageSize?: number
+  /** Show row numbers */
+  showRowNumbers?: boolean
+  /** AI actions configuration for list items */
+  aiActions?: CardAIActionsConfig
+  /** Enable sorting controls */
+  sortable?: boolean
+  /** Default sort field (column field name) */
+  defaultSort?: string
+  /** Default sort direction */
+  defaultDirection?: 'asc' | 'desc'
+  /** Sort options to show in dropdown (defaults to all sortable columns) */
+  sortOptions?: Array<{ field: string; label: string }>
+}
+
+/**
+ * Configuration for AI actions (Diagnose/Repair) on list items
+ */
+export interface CardAIActionsConfig {
+  /** Field mappings to construct the resource context */
+  resourceMapping: {
+    /** Resource kind (e.g., 'Pod', 'Deployment') - can be field name or static value */
+    kind: string
+    /** Field for resource name */
+    nameField: string
+    /** Field for namespace (optional) */
+    namespaceField?: string
+    /** Field for cluster (optional) */
+    clusterField?: string
+    /** Field for status (optional) */
+    statusField?: string
+  }
+  /** Field that contains issues array (optional) - each issue should have name/message */
+  issuesField?: string
+  /** Additional context fields to include */
+  contextFields?: string[]
+  /** Whether to show the repair button (default: true) */
+  showRepair?: boolean
+}
+
+export interface CardContentTable {
+  type: 'table'
+  /** Column definitions */
+  columns: CardColumnConfig[]
+  /** Enable column sorting */
+  sortable?: boolean
+  /** Default sort field */
+  defaultSort?: string
+  /** Default sort direction */
+  defaultDirection?: 'asc' | 'desc'
+  /** Max items per page */
+  pageSize?: number
+}
+
+export interface CardContentChart {
+  type: 'chart'
+  /** Chart type */
+  chartType: 'line' | 'bar' | 'donut' | 'gauge' | 'sparkline' | 'area'
+  /** Data series configuration (optional - can derive from yAxis) */
+  series?: CardChartSeries[]
+  /** X-axis configuration (string field name or full config) */
+  xAxis?: CardAxisConfig | string
+  /** Y-axis configuration (string field name, array of fields, or full config) */
+  yAxis?: CardAxisConfig | string | string[]
+  /** Show legend */
+  showLegend?: boolean
+  /** Chart height in pixels */
+  height?: number
+  /** Data key field (for donut/pie charts) */
+  dataKey?: string
+  /** Value key field (alias for dataKey) */
+  valueKey?: string
+  /** Label key field (for donut/pie charts) */
+  labelKey?: string
+  /** Color palette for chart series */
+  colors?: string[]
+}
+
+export interface CardContentStatusGrid {
+  type: 'status-grid'
+  /** Status items to display */
+  items: CardStatusItem[]
+  /** Grid columns */
+  columns?: number
+  /** Show counts */
+  showCounts?: boolean
+}
+
+export interface CardContentCustom {
+  type: 'custom'
+  /** Component name from registry */
+  componentName?: string
+  /** Component name (alias for componentName) */
+  component?: string
+  /** Props to pass to component */
+  props?: Record<string, unknown>
+}
+
+export interface CardContentStatsGrid {
+  type: 'stats-grid'
+  /** Stat items to display */
+  stats: CardStatsGridItem[]
+  /** Grid columns */
+  columns?: number
+}
+
+export interface CardStatsGridItem {
+  /** Field name from data */
+  field: string
+  /** Label to display */
+  label: string
+  /** Color for the stat */
+  color?: string
+  /** Icon name */
+  icon?: string
+  /** Value format */
+  format?: 'number' | 'percentage' | 'bytes' | 'currency'
+}
+
+// ============================================================================
+// Column & Renderer Types
+// ============================================================================
+
+export interface CardColumnConfig {
+  /** Field name from data item */
+  field: string
+  /** Column header text */
+  header?: string
+  /** Column width (px, %, or 'auto') */
+  width?: number | string
+  /** Text alignment */
+  align?: 'left' | 'center' | 'right'
+  /** Renderer name from registry, or built-in type */
+  render?: CardRenderer
+  /** Whether this is the primary field (bold, clickable) */
+  primary?: boolean
+  /** Whether column is sortable */
+  sortable?: boolean
+  /** Whether column is hidden by default */
+  hidden?: boolean
+  /** Suffix to append to value */
+  suffix?: string
+  /** Prefix to prepend to value */
+  prefix?: string
+}
+
+export type CardRenderer =
+  | 'text'
+  | 'number'
+  | 'percentage'
+  | 'bytes'
+  | 'duration'
+  | 'date'
+  | 'datetime'
+  | 'relative-time'
+  | 'status-badge'
+  | 'cluster-badge'
+  | 'namespace-badge'
+  | 'progress-bar'
+  | 'icon'
+  | 'boolean'
+  | 'json'
+  | 'truncate'
+  | 'link'
+  | string // Custom renderer name
+
+// ============================================================================
+// Chart Types
+// ============================================================================
+
+export interface CardChartSeries {
+  /** Field name for values */
+  field: string
+  /** Series label */
+  label?: string
+  /** Series color */
+  color?: string
+  /** Line/bar style */
+  style?: 'solid' | 'dashed' | 'dotted'
+  /** For donut: whether this is the main value */
+  primary?: boolean
+}
+
+export interface CardAxisConfig {
+  /** Field for axis values */
+  field?: string
+  /** Axis label */
+  label?: string
+  /** Axis type */
+  type?: 'linear' | 'time' | 'category'
+  /** Value format */
+  format?: 'number' | 'percentage' | 'bytes' | 'currency' | 'time'
+  /** Min value */
+  min?: number
+  /** Max value */
+  max?: number
+}
+
+// ============================================================================
+// Status Grid Types
+// ============================================================================
+
+export interface CardStatusItem {
+  /** Item ID */
+  id: string
+  /** Item label */
+  label: string
+  /** Icon name */
+  icon: string
+  /** Icon color */
+  color: string
+  /** Background color */
+  bgColor?: string
+  /** Value source configuration */
+  valueSource: CardValueSource
+}
+
+export type CardValueSource =
+  | { type: 'field'; path: string }
+  | { type: 'computed'; expression: string }
+  | { type: 'count'; filter?: string }
+
+// ============================================================================
+// Filter Types
+// ============================================================================
+
+export interface CardFilterConfig {
+  /** Field to filter on */
+  field: string
+  /** Filter type */
+  type: 'text' | 'select' | 'multi-select' | 'cluster-select' | 'chips' | 'toggle'
+  /** Filter label */
+  label?: string
+  /** Placeholder text */
+  placeholder?: string
+  /** For text: fields to search across */
+  searchFields?: string[]
+  /** For select/chips: static options */
+  options?: CardFilterOption[]
+  /** For select/chips: data source for options */
+  optionsSource?: string
+  /** Storage key for persistence */
+  storageKey?: string
+}
+
+export interface CardFilterOption {
+  value: string
+  label: string
+  icon?: string
+  color?: string
+}
+
+// ============================================================================
+// Inline Stats Types
+// ============================================================================
+
+export interface CardStatConfig {
+  /** Stat ID */
+  id: string
+  /** Icon name */
+  icon: string
+  /** Icon color class */
+  color: string
+  /** Background color class */
+  bgColor?: string
+  /** Stat label */
+  label: string
+  /** Value source */
+  valueSource: CardValueSource
+  /** Click action */
+  onClick?: CardStatAction
+}
+
+export interface CardStatAction {
+  type: 'filter' | 'drill' | 'navigate'
+  target: string
+  params?: Record<string, string>
+}
+
+// ============================================================================
+// Footer Types
+// ============================================================================
+
+export interface CardFooterConfig {
+  /** Show pagination */
+  pagination?: boolean
+  /** Show total count */
+  showTotal?: boolean
+  /** Custom footer text */
+  text?: string
+}
+
+// ============================================================================
+// Drill-Down Types
+// ============================================================================
+
+export interface CardDrillDownConfig {
+  /** Action name from useDrillDownActions */
+  action: string
+  /** Fields from data item to pass as params */
+  params: string[]
+  /** Additional context to include */
+  context?: Record<string, string>
+}
+
+// ============================================================================
+// Empty & Loading States
+// ============================================================================
+
+export interface CardEmptyStateConfig {
+  /** Icon name */
+  icon: string
+  /** Main message */
+  title: string
+  /** Secondary message */
+  message?: string
+  /** Variant for styling */
+  variant: 'success' | 'info' | 'warning' | 'neutral'
+}
+
+export interface CardLoadingStateConfig {
+  /** Number of skeleton rows */
+  rows?: number
+  /** Skeleton type */
+  type?: 'table' | 'list' | 'chart' | 'status' | 'stats' | 'custom'
+  /** Show header skeleton */
+  showHeader?: boolean
+  /** Show search skeleton */
+  showSearch?: boolean
+  /** Number of items for stats type */
+  count?: number
+}
+
+// ============================================================================
+// UnifiedStatBlock Types
+// ============================================================================
+
+/**
+ * Complete stat block configuration
+ */
+export interface UnifiedStatBlockConfig {
+  /** Unique block ID */
+  id: string
+  /** Display name */
+  name: string
+  /** Icon name from lucide-react */
+  icon: string
+  /** Color variant */
+  color: StatBlockColor
+  /** Whether visible by default */
+  visible?: boolean
+  /** Display order */
+  order?: number
+
+  // Value resolution
+  /** How to get the value */
+  valueSource: StatValueSource
+  /** Value format */
+  format?: StatValueFormat
+  /** Sublabel field */
+  sublabelField?: string
+
+  // Interaction
+  /** Click action */
+  onClick?: StatBlockAction
+  /** Tooltip text */
+  tooltip?: string
+}
+
+export type StatValueSource =
+  | StatValueSourceField
+  | StatValueSourceComputed
+  | StatValueSourceHook
+  | StatValueSourceAggregate
+
+export interface StatValueSourceField {
+  type: 'field'
+  /** Dot-notation path to value (e.g., 'summary.healthyCount') */
+  path: string
+}
+
+export interface StatValueSourceComputed {
+  type: 'computed'
+  /** Expression (e.g., 'filter:healthy|count', 'sum:pods') */
+  expression: string
+}
+
+export interface StatValueSourceHook {
+  type: 'hook'
+  /** Hook name */
+  hookName: string
+  /** Field from hook result */
+  field: string
+}
+
+export interface StatValueSourceAggregate {
+  type: 'aggregate'
+  /** Aggregation type */
+  aggregation: 'sum' | 'count' | 'avg' | 'min' | 'max'
+  /** Field to aggregate */
+  field: string
+  /** Filter before aggregating */
+  filter?: string
+}
+
+export type StatValueFormat = 'number' | 'percentage' | 'bytes' | 'currency' | 'duration'
+
+export interface StatBlockAction {
+  /** Action type */
+  type: 'drill' | 'filter' | 'navigate' | 'callback'
+  /** Target (action name, filter field, or route) */
+  target: string
+  /** Parameters */
+  params?: Record<string, string>
+}
+
+// ============================================================================
+// UnifiedStatsSection Types
+// ============================================================================
+
+/**
+ * Complete stats section configuration
+ */
+export interface UnifiedStatsSectionConfig {
+  /** Section type identifier */
+  type: string
+  /** Section title */
+  title?: string
+  /** Stat blocks */
+  blocks: UnifiedStatBlockConfig[]
+  /** Default collapsed state */
+  defaultCollapsed?: boolean
+  /** Collapsible */
+  collapsible?: boolean
+  /** Storage key for collapsed state */
+  storageKey?: string
+  /** Show configure button */
+  showConfigButton?: boolean
+  /** Grid configuration */
+  grid?: {
+    columns?: number
+    responsive?: {
+      sm?: number
+      md?: number
+      lg?: number
+    }
+  }
+}
+
+// ============================================================================
+// UnifiedDashboard Types
+// ============================================================================
+
+/**
+ * Complete dashboard configuration
+ */
+export interface UnifiedDashboardConfig {
+  /** Unique dashboard ID */
+  id: string
+  /** Display name */
+  name: string
+  /** Subtitle/description */
+  subtitle?: string
+  /** Route path */
+  route?: string
+
+  // Stats configuration
+  /** Stats section type */
+  statsType?: string
+  /** Custom stats config */
+  stats?: UnifiedStatsSectionConfig
+  /** Custom value resolver function name */
+  statsValueResolver?: string
+
+  // Cards configuration
+  /** Default cards for this dashboard */
+  cards: DashboardCardPlacement[]
+  /** Available card types for add menu */
+  availableCardTypes?: string[]
+
+  // Features
+  features?: DashboardFeatures
+
+  // Persistence
+  /** Storage key for card positions */
+  storageKey?: string
+}
+
+export interface DashboardCardPlacement {
+  /** Unique placement ID */
+  id: string
+  /** Card type (references UnifiedCardConfig.type) */
+  cardType: string
+  /** Instance-specific config overrides */
+  config?: Record<string, unknown>
+  /** Title override */
+  title?: string
+  /** Grid position */
+  position: {
+    /** Width in grid columns (3-12) */
+    w: number
+    /** Height in grid rows */
+    h: number
+    /** X position (optional, for absolute positioning) */
+    x?: number
+    /** Y position (optional, for absolute positioning) */
+    y?: number
+  }
+}
+
+export interface DashboardFeatures {
+  /** Enable drag-and-drop */
+  dragDrop?: boolean
+  /** Enable auto-refresh */
+  autoRefresh?: boolean
+  /** Auto-refresh interval in ms */
+  autoRefreshInterval?: number
+  /** Show add card button */
+  addCard?: boolean
+  /** Show templates button */
+  templates?: boolean
+  /** Show recommendations */
+  recommendations?: boolean
+  /** Show AI mission suggestions */
+  missionSuggestions?: boolean
+  /** Show floating action buttons */
+  floatingActions?: boolean
+  /** Enable card sections */
+  cardSections?: boolean
+}
+
+// ============================================================================
+// Registry Types
+// ============================================================================
+
+/**
+ * Card configuration registry
+ */
+export type CardConfigRegistry = Record<string, UnifiedCardConfig>
+
+/**
+ * Stats configuration registry
+ */
+export type StatsConfigRegistry = Record<string, UnifiedStatsSectionConfig>
+
+/**
+ * Dashboard configuration registry
+ */
+export type DashboardConfigRegistry = Record<string, UnifiedDashboardConfig>
+
+/**
+ * Renderer function type
+ */
+export type RendererFunction<T = unknown> = (
+  value: T,
+  item: Record<string, unknown>,
+  column: CardColumnConfig
+) => React.ReactNode
+
+/**
+ * Renderer registry
+ */
+export type RendererRegistry = Record<string, RendererFunction>
+
+/**
+ * Data hook type
+ */
+export type DataHookFunction = (
+  params?: Record<string, unknown>
+) => {
+  data: unknown[] | undefined
+  isLoading: boolean
+  error: Error | null
+  refetch?: () => void
+}
+
+/**
+ * Data hook registry
+ */
+export type DataHookRegistry = Record<string, DataHookFunction>
+
+// ============================================================================
+// Component Props Types
+// ============================================================================
+
+/**
+ * Props for UnifiedCard component
+ */
+export interface UnifiedCardProps {
+  /** Card configuration */
+  config: UnifiedCardConfig
+  /** Instance-specific config overrides */
+  instanceConfig?: Record<string, unknown>
+  /** Title override */
+  title?: string
+  /** Additional className */
+  className?: string
+  /** Override data for demo/testing purposes (bypasses data source) */
+  overrideData?: unknown[]
+}
+
+/**
+ * Props for UnifiedStatBlock component
+ */
+export interface UnifiedStatBlockProps {
+  /** Stat block configuration */
+  config: UnifiedStatBlockConfig
+  /** Data object to resolve values from */
+  data?: unknown
+  /** Override value getter */
+  getValue?: () => StatBlockValue
+  /** Loading state */
+  isLoading?: boolean
+}
+
+/**
+ * Props for UnifiedStatsSection component
+ */
+export interface UnifiedStatsSectionProps {
+  /** Stats section configuration */
+  config: UnifiedStatsSectionConfig
+  /** Data to resolve values from */
+  data?: unknown
+  /** Custom value getter by block ID */
+  getStatValue?: (blockId: string) => StatBlockValue
+  /** Whether data is loaded */
+  hasData?: boolean
+  /** Loading state */
+  isLoading?: boolean
+  /** Last updated timestamp */
+  lastUpdated?: Date | null
+  /** Additional className */
+  className?: string
+}
+
+/**
+ * Props for UnifiedDashboard component
+ */
+export interface UnifiedDashboardProps {
+  /** Dashboard configuration */
+  config: UnifiedDashboardConfig
+  /** Stats data */
+  statsData?: unknown
+  /** Additional className */
+  className?: string
+}
+
+// Import CardCategory for the type alias
+import type { CardCategory } from '../cards/types'
+import type { StatBlockColor, StatBlockValue } from '../stats/types'

--- a/web/src/pages/UnifiedDashboardTest.tsx
+++ b/web/src/pages/UnifiedDashboardTest.tsx
@@ -1,0 +1,163 @@
+/**
+ * UnifiedDashboard Test Page
+ *
+ * Tests the UnifiedDashboard component with the arcade dashboard config.
+ * Also tests UnifiedCard and UnifiedCardAdapter for migration.
+ */
+
+import { useState } from 'react'
+import { UnifiedDashboard } from '../lib/unified/dashboard/UnifiedDashboard'
+import { arcadeDashboardConfig } from '../config/dashboards/arcade'
+import { UnifiedCard } from '../lib/unified/card/UnifiedCard'
+import {
+  UnifiedCardAdapter,
+  UNIFIED_READY_CARDS,
+  UNIFIED_EXCLUDED_CARDS,
+  hasValidUnifiedConfig,
+  getCardMigrationStatus,
+} from '../lib/unified/card/UnifiedCardAdapter'
+import { getCardConfig, CARD_CONFIGS } from '../config/cards'
+import { CardWrapper } from '../components/cards/CardWrapper'
+
+export function UnifiedDashboardTest() {
+  const [selectedCard, setSelectedCard] = useState('pod_issues')
+
+  // Get migration stats
+  const allCardTypes = Object.keys(CARD_CONFIGS)
+  const readyCount = allCardTypes.filter(c => hasValidUnifiedConfig(c)).length
+  const unifiedCount = UNIFIED_READY_CARDS.size
+  const excludedCount = UNIFIED_EXCLUDED_CARDS.size
+
+  const selectedConfig = getCardConfig(selectedCard)
+  const migrationStatus = getCardMigrationStatus(selectedCard)
+
+  return (
+    <div className="p-6 pt-20 space-y-8">
+      <h1 className="text-2xl font-bold">Unified Framework Test</h1>
+
+      {/* Migration Stats */}
+      <div className="grid grid-cols-4 gap-4">
+        <div className="p-4 bg-card rounded-lg border">
+          <div className="text-2xl font-bold text-blue-400">{allCardTypes.length}</div>
+          <div className="text-sm text-muted-foreground">Total Cards</div>
+        </div>
+        <div className="p-4 bg-card rounded-lg border">
+          <div className="text-2xl font-bold text-green-400">{readyCount}</div>
+          <div className="text-sm text-muted-foreground">Config Ready</div>
+        </div>
+        <div className="p-4 bg-card rounded-lg border">
+          <div className="text-2xl font-bold text-purple-400">{unifiedCount}</div>
+          <div className="text-sm text-muted-foreground">Using UnifiedCard</div>
+        </div>
+        <div className="p-4 bg-card rounded-lg border">
+          <div className="text-2xl font-bold text-orange-400">{excludedCount}</div>
+          <div className="text-sm text-muted-foreground">Excluded</div>
+        </div>
+      </div>
+
+      {/* Card Comparison Test */}
+      <div className="border rounded-lg p-4 bg-card">
+        <h2 className="text-lg font-semibold mb-4">UnifiedCard Comparison Test</h2>
+
+        {/* Card selector */}
+        <div className="mb-4">
+          <label className="text-sm text-muted-foreground mr-2">Select card:</label>
+          <select
+            value={selectedCard}
+            onChange={(e) => setSelectedCard(e.target.value)}
+            className="bg-background border rounded px-3 py-1.5 text-sm"
+          >
+            {allCardTypes.slice(0, 30).map((cardType) => (
+              <option key={cardType} value={cardType}>
+                {cardType} ({getCardMigrationStatus(cardType).status})
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Status badge */}
+        <div className="mb-4 p-3 rounded bg-secondary/50">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium">{selectedCard}</span>
+            <span className={`px-2 py-0.5 rounded text-xs ${
+              migrationStatus.status === 'unified' ? 'bg-green-500/20 text-green-400' :
+              migrationStatus.status === 'ready' ? 'bg-blue-500/20 text-blue-400' :
+              migrationStatus.status === 'excluded' ? 'bg-orange-500/20 text-orange-400' :
+              'bg-gray-500/20 text-gray-400'
+            }`}>
+              {migrationStatus.status}
+            </span>
+          </div>
+          <div className="text-xs text-muted-foreground mt-1">{migrationStatus.reason}</div>
+        </div>
+
+        {/* Side by side comparison */}
+        {selectedConfig && hasValidUnifiedConfig(selectedCard) && (
+          <div className="grid grid-cols-2 gap-4">
+            {/* UnifiedCard rendering */}
+            <div>
+              <h3 className="text-sm font-medium mb-2 text-green-400">UnifiedCard (from config)</h3>
+              <div className="border border-green-500/30 rounded-lg h-[300px] overflow-hidden">
+                <CardWrapper
+                  cardId={`unified-${selectedCard}`}
+                  title={selectedConfig.title}
+                  cardType={selectedCard}
+                >
+                  <UnifiedCard config={selectedConfig} />
+                </CardWrapper>
+              </div>
+            </div>
+
+            {/* Adapter rendering */}
+            <div>
+              <h3 className="text-sm font-medium mb-2 text-purple-400">UnifiedCardAdapter</h3>
+              <div className="border border-purple-500/30 rounded-lg h-[300px] overflow-hidden">
+                <CardWrapper
+                  cardId={`adapter-${selectedCard}`}
+                  title={selectedConfig.title}
+                  cardType={selectedCard}
+                >
+                  <UnifiedCardAdapter
+                    cardType={selectedCard}
+                    cardId={`adapter-${selectedCard}`}
+                    renderLegacy={() => (
+                      <div className="text-sm text-muted-foreground p-4 text-center">
+                        Falls back to legacy component
+                      </div>
+                    )}
+                  />
+                </CardWrapper>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* UnifiedDashboard Test */}
+      <div>
+        <h2 className="text-lg font-semibold mb-3 text-purple-400">
+          UnifiedDashboard (arcade config - {arcadeDashboardConfig.cards.length} cards)
+        </h2>
+        <div className="border border-purple-500/30 rounded-lg bg-card">
+          <UnifiedDashboard config={arcadeDashboardConfig} />
+        </div>
+      </div>
+
+      {/* Feature checklist */}
+      <div className="p-4 bg-secondary/50 rounded-lg">
+        <h3 className="font-semibold mb-3">Framework Status</h3>
+        <ul className="list-disc list-inside text-sm text-muted-foreground space-y-1">
+          <li>✅ <strong>UnifiedCard</strong> - Renders from config (list, table, chart, status-grid)</li>
+          <li>✅ <strong>UnifiedCardAdapter</strong> - Bridge for gradual migration</li>
+          <li>✅ <strong>UnifiedDashboard</strong> - Config-driven dashboard layout</li>
+          <li>✅ <strong>Modals</strong> - AddCardModal, ConfigureCardModal integrated</li>
+          <li>✅ <strong>Migration utilities</strong> - Analyzer, validator, reporter</li>
+          <li>⏳ <strong>Data hooks</strong> - Some hooks need registration</li>
+          <li>⏳ <strong>Card validation</strong> - Verify each card works correctly</li>
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+export default UnifiedDashboardTest


### PR DESCRIPTION
## Summary

Implements the UnifiedCard framework that enables config-driven card rendering:

- **UnifiedCard**: Renders any card type from configuration (list, table, chart, status-grid)
- **UnifiedCardAdapter**: Bridge component for gradual migration from legacy cards
- **89 cards** migrated to use UnifiedCard rendering
- **59 complex cards** (games, embeds, custom viz) excluded by design
- Loading state integration with CardWrapper (skeleton + refresh icon)
- Data hooks registered for all migrated cards
- UnifiedDashboard for config-driven dashboard layouts
- Test page at `/test/unified-dashboard` for validation

## Migration Statistics

| Metric | Count |
|--------|-------|
| Total Cards | 144 |
| Config Ready | 82 |
| Using UnifiedCard | 89 |
| Excluded | 59 |

## Test plan

- [x] Verify UnifiedCard renders pod_issues identically to legacy
- [x] Verify loading state integration (skeleton + refresh icon spinning)
- [x] Verify UnifiedDashboard renders arcade dashboard with 22 cards
- [x] Verify main dashboard cards render correctly (Cluster Health, Metrics, Events)
- [ ] Build passes
- [ ] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)