### PR TITLE
fix: ensure tree view edges are always visible

### DIFF
--- a/frontend/src/components/WecsTopology.tsx
+++ b/frontend/src/components/WecsTopology.tsx
@@ -831,7 +831,7 @@ const WecsTreeview = () => {
       if (!cachedNode) nodeCache.current.set(id, node);
       newNodes.push(node);
 
-      if (parent && stateRef.current.isExpanded) {
+      if (parent) {
         const uniqueSuffix = resourceData?.metadata?.uid || edgeIdCounter.current++;
         const edgeId = `edge-${parent}-${id}-${uniqueSuffix}`;
         const edge = {
@@ -841,7 +841,7 @@ const WecsTreeview = () => {
           type: edgeType,
           animated: true,
           style: {
-            stroke: theme === 'dark' ? 'url(#edge-gradient-dark)' : 'url(#edge-gradient-light)',
+            stroke: theme === 'dark' ? '#94a3b8' : '#64748b',
             strokeWidth: 2,
             opacity: 0.8,
             transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',

--- a/frontend/src/components/treeView/TreeViewNodes.tsx
+++ b/frontend/src/components/treeView/TreeViewNodes.tsx
@@ -45,7 +45,6 @@ interface TreeViewNodesProps {
     groupItems?: ResourceItem[];
   }) => void;
   onMenuOpen: (event: React.MouseEvent, nodeId: string) => void;
-  isExpanded: boolean;
 }
 
 // TreeView node dimensions
@@ -259,7 +258,7 @@ const getTimeAgo = (timestamp: string | undefined, t: (key: string) => string): 
       );
 };
 
-export const useTreeViewNodes = ({ onNodeSelect, onMenuOpen, isExpanded }: TreeViewNodesProps) => {
+export const useTreeViewNodes = ({ onNodeSelect, onMenuOpen }: TreeViewNodesProps) => {
   const theme = useTheme(state => state.theme);
   const highlightedLabels = useLabelHighlightStore(state => state.highlightedLabels);
   const nodeCache = useRef<Map<string, CustomNode>>(new Map());
@@ -421,7 +420,7 @@ export const useTreeViewNodes = ({ onNodeSelect, onMenuOpen, isExpanded }: TreeV
       newNodes.push(node);
 
       // Add direct edge from parent to node if it's a parent-child relationship
-      if (parent && isExpanded) {
+      if (parent) {
         const uniqueSuffix = resourceData?.metadata?.uid || edgeIdCounter.current++;
         const edgeId = `edge-${parent}-${id}-${uniqueSuffix}`;
         const edge = {
@@ -431,7 +430,7 @@ export const useTreeViewNodes = ({ onNodeSelect, onMenuOpen, isExpanded }: TreeV
           type: edgeType,
           animated: true,
           style: {
-            stroke: theme === 'dark' ? 'url(#edge-gradient-dark)' : 'url(#edge-gradient-light)',
+            stroke: theme === 'dark' ? '#94a3b8' : '#64748b',
             strokeWidth: 2,
             opacity: 0.8,
             transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
@@ -456,7 +455,7 @@ export const useTreeViewNodes = ({ onNodeSelect, onMenuOpen, isExpanded }: TreeV
         newEdges.push(edge);
       }
     },
-    [theme, isExpanded, highlightedLabels, onNodeSelect, onMenuOpen, edgeType]
+    [theme, highlightedLabels, onNodeSelect, onMenuOpen, edgeType]
   );
 
   const clearNodeCache = useCallback(() => {

--- a/frontend/src/components/treeView/hooks/useTreeViewData.ts
+++ b/frontend/src/components/treeView/hooks/useTreeViewData.ts
@@ -73,7 +73,6 @@ export const useTreeViewData = ({
   const { createNode, clearNodeCache, updateNodeStyles } = useTreeViewNodes({
     onNodeSelect,
     onMenuOpen,
-    isExpanded,
   });
 
   const theme = useTheme(state => state.theme);


### PR DESCRIPTION
### Fix: Tree View Connecting Lines Not Visible

Fixes an issue where connecting lines (edges) between parent and child nodes were not rendered in the tree view on both **Staged Workloads** and **Deployed Workloads** pages.

---

### Description

Connecting lines between tree nodes were not visible due to edge creation being conditionally gated by the `isExpanded` state. This caused edges to not be created when the tree was in its default or collapsed state, even though the nodes themselves were visible.

This PR removes the unnecessary conditional logic and ensures edges are always created between visible parent and child nodes. It also improves edge visibility by switching from low-opacity gradient strokes to solid colors and cleans up unused parameters.

---

### Related Issue

Fixes #2279 

---

### Changes Made

- Remove `isExpanded` conditional from edge creation in `TreeViewNodes.tsx` and `WecsTopology.tsx`
- Ensure edges render correctly in both collapsed and expanded view modes
- Change edge stroke styles from gradients to solid colors for better visibility
- Remove unused `isExpanded` parameter from `useTreeViewNodes` hook
- Clean up related logic for improved readability and maintainability

---

### Checklist

- [x] I have reviewed the project's contribution guidelines.
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.
- [ ] I have written unit tests for the changes (not applicable for UI-only changes).
- [ ] I have updated the documentation (not applicable).

---

### Screenshots or Logs (if applicable)

**Before**  
_No connecting lines visible between parent and child nodes_
<img width="1913" height="1086" alt="Screenshot From 2026-02-07 10-58-49" src="https://github.com/user-attachments/assets/49a012da-7737-4ebc-8647-1469e069bcdd" />


**After**  
_Connecting lines are clearly visible and correctly rendered between context → namespaces → resources_
<img width="1917" height="1082" alt="Screenshot From 2026-02-07 17-51-56" src="https://github.com/user-attachments/assets/8cb8b868-30ee-4cd9-8f45-adce8417675a" />

