### PR TITLE
🐛 fix(ui): remove static dash from cluster name display

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -201,17 +201,6 @@ body {
   margin-right: -3px;
 }
 
-/* Add a single dash exactly in the middle for non-terminal nodes only */
-.react-flow__node:not(.terminal-node)::after {
-  content: '-'; /* Single dash */
-  position: absolute;
-  top: 50%;
-  left: calc(100% + 2px); /* Slightly outside the right edge */
-  transform: translateY(-50%);
-  font-size: 10px; /* Adjust size */
-  color: black; /* Adjust color */
-}
-
 @font-face {
   font-family: 'Got Milk Sans Serif';
   src: url('./assets/Gotmilk-Font.ttf') format('truetype');


### PR DESCRIPTION
Remove CSS ::after pseudo-element that was adding an unwanted dash character to all react-flow nodes in the tree view. The rule was adding 'content: "-"' which appeared as a trailing dash after cluster names.

Fixes #2300

### Description

Remove a CSS ``::after pseudo-element`` that was adding an unwanted dash (-) to all React Flow nodes in the tree view. This resulted in a trailing dash being displayed after cluster names in both Staged Workloads and Deployed Workloads views.

This change ensures cluster names render cleanly without any unintended characters.

### Related Issue

Fixes #2300

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

before
<img width="413" height="508" alt="Screenshot From 2026-02-07 18-37-01" src="https://github.com/user-attachments/assets/692c302a-42a5-47a4-8ef0-b4607af4074a" />

after
<img width="523" height="623" alt="Screenshot From 2026-02-07 19-47-30" src="https://github.com/user-attachments/assets/3a9cf41a-1df1-4a0e-9034-1bc1819ca9ef" />


### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
