### PR TITLE
🐛 fix(ui): prevent trailing dash clipping in cluster names on hover

### DIFF
--- a/frontend/src/components/wds_topology/NodeLabel.tsx
+++ b/frontend/src/components/wds_topology/NodeLabel.tsx
@@ -214,7 +214,7 @@ export const NodeLabel = memo<NodeLabelProps>(
           !prefersReducedMotion && (isHovered || (statusStyle.pulse && status === 'Running'))
             ? 'transform'
             : 'auto',
-        overflow: 'hidden', // Prevent any content from escaping
+        overflow: isHovered ? 'visible' : 'hidden', // Visible on hover to prevent clipping during scale transform
         overflowWrap: 'break-word' as const, // Handle any edge cases
       }),
       [theme, hasHighlightedLabel, hasLabels, statusStyle, isHovered, status, prefersReducedMotion]
@@ -264,8 +264,8 @@ export const NodeLabel = memo<NodeLabelProps>(
                 height: '24px',
                 background:
                   highlightedLabels &&
-                  highlightedLabels.key === key &&
-                  highlightedLabels.value === value
+                    highlightedLabels.key === key &&
+                    highlightedLabels.value === value
                     ? 'linear-gradient(135deg, #3b82f6, #6366f1)'
                     : theme === 'dark'
                       ? 'linear-gradient(135deg, #475569, #64748b)'


### PR DESCRIPTION
## Root Cause

The `NodeLabel` component's card style has:
- `overflow: 'hidden'` - which clips content
- `transform: scale(1.02)` on hover - which scales the content up

When combined, the 2% scale increase caused text at the edges (especially trailing characters like `-`) to be clipped by the hidden overflow.

Fixes #2300

<img width="930" height="640" alt="Screenshot From 2026-02-07 21-17-26" src="https://github.com/user-attachments/assets/05bceef8-192e-41a3-92f0-b5ceee70a3f8" />


## Solution

Changed the `overflow` property to be dynamic based on hover state:
```javascript
overflow: isHovered ? 'visible' : 'hidden'