### PR TITLE
Fix: account dropdown not closing when opening change password modal

### DIFF
--- a/frontend/src/components/ProfileSection.tsx
+++ b/frontend/src/components/ProfileSection.tsx
@@ -670,7 +670,10 @@ const ProfileSection = () => {
                   >
                     <div className="grid grid-cols-1 gap-1">
                       <button
-                        onClick={() => setShowChangePasswordModal(true)}
+                        onClick={() => {
+                          setShowChangePasswordModal(true);
+                          setShowUserMenu(false);
+                        }}
                         className="py-3\ group flex w-full items-center rounded-lg px-4 text-sm font-medium transition-colors duration-150"
                         style={{
                           color: styles.helpButton.color,


### PR DESCRIPTION
### Description

Fixes a UI issue where the account dropdown menu remained open and overlapped with the Change Password modal dialog when users clicked "Change Password".


### Related Issue

Fixes #2420 

### Changes Made

- Modified `ProfileSection.tsx` - "Change Password" button onClick handler
- Now properly manages state for both dropdown and modal visibility
- Prevents UI overlap by closing dropdown before modal appears

- [ ] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

## BEFORE:

https://github.com/user-attachments/assets/29115dcb-9b92-45d3-a49d-43ece81fd01c

## AFTER:


https://github.com/user-attachments/assets/0c152ca5-7847-42d8-884d-7e27491faba1

